### PR TITLE
EID-257: Remove blanket catch of exception

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
@@ -69,18 +69,13 @@ public class AuthnResponseFromCountryService {
         String matchingServiceEntityId = stateController.getMatchingServiceEntityId();
         stateController.validateCountryIsIn(countriesService.getCountries(sessionId));
 
-        // TODO: Bug in CEF Reference 1.1. Remove this try..catch when EID-177 CEF Reference 1.3 is deployed.
-        try {
-            SamlAuthnResponseTranslatorDto responseToTranslate = samlAuthnResponseTranslatorDtoFactory.fromSamlAuthnResponseContainerDto(responseFromCountry, matchingServiceEntityId);
-            InboundResponseFromCountry translatedResponse = samlEngineProxy.translateAuthnResponseFromCountry(responseToTranslate);
-            validateTranslatedResponse(stateController, translatedResponse);
-            EidasAttributeQueryRequestDto eidasAttributeQueryRequestDto = getEidasAttributeQueryRequestDto(stateController, translatedResponse);
-            stateController.transitionToEidasCycle0And1MatchRequestSentState(eidasAttributeQueryRequestDto, responseFromCountry.getPrincipalIPAddressAsSeenByHub(), translatedResponse.getIssuer());
-            AttributeQueryContainerDto aqr = samlEngineProxy.generateEidasAttributeQuery(eidasAttributeQueryRequestDto);
-            samlSoapProxyProxy.sendHubMatchingServiceRequest(sessionId, getAttributeQueryRequest(aqr));
-        } catch (RuntimeException e) {
-            LOG.info("Exception when translating country response", e);
-        }
+        SamlAuthnResponseTranslatorDto responseToTranslate = samlAuthnResponseTranslatorDtoFactory.fromSamlAuthnResponseContainerDto(responseFromCountry, matchingServiceEntityId);
+        InboundResponseFromCountry translatedResponse = samlEngineProxy.translateAuthnResponseFromCountry(responseToTranslate);
+        validateTranslatedResponse(stateController, translatedResponse);
+        EidasAttributeQueryRequestDto eidasAttributeQueryRequestDto = getEidasAttributeQueryRequestDto(stateController, translatedResponse);
+        stateController.transitionToEidasCycle0And1MatchRequestSentState(eidasAttributeQueryRequestDto, responseFromCountry.getPrincipalIPAddressAsSeenByHub(), translatedResponse.getIssuer());
+        AttributeQueryContainerDto aqr = samlEngineProxy.generateEidasAttributeQuery(eidasAttributeQueryRequestDto);
+        samlSoapProxyProxy.sendHubMatchingServiceRequest(sessionId, getAttributeQueryRequest(aqr));
 
         return ResponseAction.success(sessionId, false, LevelOfAssurance.LEVEL_2);
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryServiceTest.java
@@ -7,7 +7,6 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -211,8 +210,6 @@ public class AuthnResponseFromCountryServiceTest {
         service.receiveAuthnResponseFromCountry(SESSION_ID, SAML_AUTHN_RESPONSE_CONTAINER_DTO);
     }
 
-    // TODO: Bug in CEF Reference 1.1. Re-enable the test when EID-177 CEF Reference 1.3 is deployed.
-    @Ignore
     @Test
     public void shouldThrowIfLevelOfAssuranceNotWhatExpected() {
         exception.expect(StateProcessingValidationException.class);
@@ -223,8 +220,6 @@ public class AuthnResponseFromCountryServiceTest {
         service.receiveAuthnResponseFromCountry(SESSION_ID, SAML_AUTHN_RESPONSE_CONTAINER_DTO);
     }
 
-    // TODO: Bug in CEF Reference 1.1. Re-enable the test when EID-177 CEF Reference 1.3 is deployed.
-    @Ignore
     @Test
     public void shouldThrowIfTranslationResponseFromSamlEngineNotSuccess() {
         exception.expect(StateProcessingValidationException.class);
@@ -235,8 +230,6 @@ public class AuthnResponseFromCountryServiceTest {
         service.receiveAuthnResponseFromCountry(SESSION_ID, SAML_AUTHN_RESPONSE_CONTAINER_DTO);
     }
 
-    // TODO: Bug in CEF Reference 1.1. Re-enable the test when EID-177 CEF Reference 1.3 is deployed.
-    @Ignore
     @Test
     public void shouldThrowIfPidNotPresentInTranslatedResponse() {
         exception.expect(StateProcessingValidationException.class);
@@ -247,8 +240,6 @@ public class AuthnResponseFromCountryServiceTest {
         service.receiveAuthnResponseFromCountry(SESSION_ID, SAML_AUTHN_RESPONSE_CONTAINER_DTO);
     }
 
-    // TODO: Bug in CEF Reference 1.1. Re-enable the test when EID-177 CEF Reference 1.3 is deployed.
-    @Ignore
     @Test
     public void shouldThrowIfIdentityBlobNotPresentInTranslatedResponse() {
         exception.expect(StateProcessingValidationException.class);
@@ -259,8 +250,6 @@ public class AuthnResponseFromCountryServiceTest {
         service.receiveAuthnResponseFromCountry(SESSION_ID, SAML_AUTHN_RESPONSE_CONTAINER_DTO);
     }
 
-    // TODO: Bug in CEF Reference 1.1. Re-enable the test when EID-177 CEF Reference 1.3 is deployed.
-    @Ignore
     @Test
     public void shouldThrowIfLOANotPresentInTranslatedResponse() {
         exception.expect(StateProcessingValidationException.class);


### PR DESCRIPTION
SAML engine was updated to use correct name id policy (persistent instead of unspecified) for eIDAS Authn Request. eIDAS Authn Request and Verify Authn Request now have same name id format. As a result of this change, eIDAS Authn Response now contains correct name id format (persistent). It will pass name id format validation without errors. This means that the blanket catch of exception in policy is no longer needed.

Authors: @adityapahuja