### PR TITLE
TT-1603: Allow hub-config to return IDPs relevant to a particular RP …

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.collections.ListUtils;
-import org.apache.commons.io.FileUtils;
 import uk.gov.ida.hub.config.ConfigEntityData;
 
 import javax.validation.Valid;
@@ -66,6 +65,11 @@ public class IdentityProviderConfigEntityData implements ConfigEntityData {
         return entityId;
     }
 
+    @Override
+    public String toString() {
+        return String.format("%s | %s", this.getEntityId(), this.getSimpleId());
+    }
+
     public List<LevelOfAssurance> getSupportedLevelsOfAssurance() {
         return supportedLevelsOfAssurance;
     }
@@ -86,11 +90,15 @@ public class IdentityProviderConfigEntityData implements ConfigEntityData {
         return ListUtils.union(onboardingTransactionEntityIdsTemp, onboardingTransactionEntityIds);
     }
 
-    public boolean isOnboardingAtAllLevels() {
-        return supportedLevelsOfAssurance.stream().allMatch(loa -> isOnboarding(loa));
+    public boolean isOnboardingForTransactionEntity(String transactionEntity) {
+        return this.getOnboardingTransactionEntityIdsTemp().contains(transactionEntity);
     }
 
-    public boolean isOnboarding(LevelOfAssurance levelOfAssurance) {
+    public boolean isOnboardingAtAllLevels() {
+        return supportedLevelsOfAssurance.stream().allMatch(this::isOnboardingAtLoa);
+    }
+
+    public boolean isOnboardingAtLoa(LevelOfAssurance levelOfAssurance) {
         return onboardingLevelsOfAssurance.contains(levelOfAssurance);
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactory.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactory.java
@@ -27,12 +27,13 @@ public class IdpPredicateFactory {
         return predicates;
     }
 
-    public Set<Predicate<IdentityProviderConfigEntityData>> createPredicatesForTransactionEntity(String transactionEntity,
-                                                                                                 LevelOfAssurance levelOfAssurance) {
-        return Sets.newHashSet(new EnabledIdpPredicate(), new OnboardingIdpPredicate(transactionEntity, levelOfAssurance));
+    public Set<Predicate<IdentityProviderConfigEntityData>> createPredicatesForTransactionEntityAndLoa(String transactionEntity,
+                                                                                                       LevelOfAssurance levelOfAssurance) {
+        return Sets.newHashSet(new EnabledIdpPredicate(), new OnboardingIdpPredicate(transactionEntity, levelOfAssurance),
+                new SupportedLoaIdpPredicate(levelOfAssurance));
     }
 
     public Set<Predicate<IdentityProviderConfigEntityData>> createPredicatesForSignIn(String transactionEntityId) {
-        return createPredicatesForTransactionEntity(transactionEntityId, null);
+        return Sets.newHashSet(new EnabledIdpPredicate(), new OnboardingIdpPredicate(transactionEntityId, null));
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicate.java
@@ -16,9 +16,10 @@ public class OnboardingIdpPredicate implements Predicate<IdentityProviderConfigE
     @Override
     public boolean apply(IdentityProviderConfigEntityData identityProviderConfigEntityData) {
         boolean isOnboarding = levelOfAssurance != null ?
-                identityProviderConfigEntityData.isOnboarding(levelOfAssurance) :
+                identityProviderConfigEntityData.isOnboardingAtLoa(levelOfAssurance) :
                 identityProviderConfigEntityData.isOnboardingAtAllLevels();
 
         return !isOnboarding || identityProviderConfigEntityData.getOnboardingTransactionEntityIdsTemp().contains(transactionEntity);
     }
+
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicate.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.hub.config.domain.filters;
+
+import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
+import uk.gov.ida.hub.config.domain.LevelOfAssurance;
+
+public class SupportedLoaIdpPredicate implements com.google.common.base.Predicate<IdentityProviderConfigEntityData> {
+    private LevelOfAssurance levelOfAssurance;
+
+    public SupportedLoaIdpPredicate(LevelOfAssurance levelOfAssurance) {
+        this.levelOfAssurance = levelOfAssurance;
+    }
+
+    @Override
+    public boolean apply(IdentityProviderConfigEntityData identityProviderConfigEntityData) {
+        return identityProviderConfigEntityData.getSupportedLevelsOfAssurance().contains(levelOfAssurance);
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
@@ -162,7 +162,7 @@ public class IdentityProviderResource {
     private Set<IdentityProviderConfigEntityData> getIdentityProviderConfigEntityData(String transactionEntityId,
                                                                                       LevelOfAssurance levelOfAssurance) {
         Set<Predicate<IdentityProviderConfigEntityData>> predicatesForTransactionEntity =
-                idpPredicateFactory.createPredicatesForTransactionEntity(transactionEntityId, levelOfAssurance);
+                idpPredicateFactory.createPredicatesForTransactionEntityAndLoa(transactionEntityId, levelOfAssurance);
         return idpsFilteredBy(predicatesForTransactionEntity);
     }
 

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityDataTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityDataTest.java
@@ -3,6 +3,10 @@ package uk.gov.ida.hub.config.domain;
 import org.junit.Test;
 import uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
 
@@ -11,10 +15,72 @@ public class IdentityProviderConfigEntityDataTest {
     private final IdentityProviderConfigDataBuilder dataBuilder = anIdentityProviderConfigData();
 
     @Test
-    public void should_defaultSupportedLevelsOfAssuranceToOnlyIncludeLOA2() throws Exception {
+    public void should_defaultSupportedLevelsOfAssuranceToOnlyIncludeLOA2() {
         IdentityProviderConfigEntityData data = dataBuilder.build();
 
         assertThat(data.getSupportedLevelsOfAssurance()).containsExactly(LevelOfAssurance.LEVEL_2);
+    }
+
+    @Test
+    public void shouldReturnAllOnboardingEntityIds() {
+        IdentityProviderConfigEntityData data = dataBuilder
+                .withOnboarding(Arrays.asList("EID1", "EID2"))
+                .withOnboardingTemp(Arrays.asList("EID_OT1", "EID_OT2"))
+                .build();
+
+        final List<String> onboardingEntityIds = data.getOnboardingTransactionEntityIds();
+        assertThat(onboardingEntityIds.size()).isEqualTo(2);
+        assertThat(onboardingEntityIds).contains("EID1");
+        assertThat(onboardingEntityIds).contains("EID2");
+
+        final List<String> onboardingEntityIdsTemp = data.getOnboardingTransactionEntityIdsTemp();
+        assertThat(onboardingEntityIdsTemp.size()).isEqualTo(4);
+        assertThat(onboardingEntityIdsTemp).contains("EID1");
+        assertThat(onboardingEntityIdsTemp).contains("EID2");
+        assertThat(onboardingEntityIdsTemp).contains("EID_OT1");
+        assertThat(onboardingEntityIdsTemp).contains("EID_OT2");
+    }
+
+    @Test
+    public void shouldCheckThatIsOnboardingForTransactionEntity() {
+        final IdentityProviderConfigEntityData dataWithoutOnboarding = dataBuilder.withEntityId("EID").build();
+        assertThat(dataWithoutOnboarding.isOnboardingForTransactionEntity("EID")).isFalse();
+
+        final IdentityProviderConfigEntityData data = dataBuilder
+                .withOnboarding(Collections.singletonList("EID_O"))
+                .withOnboardingTemp(Collections.singletonList("EID_OT"))
+                .build();
+
+        assertThat(data.isOnboardingForTransactionEntity("EID_O")).isTrue();
+        assertThat(data.isOnboardingForTransactionEntity("EID_OT")).isTrue();
+    }
+
+    @Test
+    public void shouldCheckThatIsOnboardingAtAllLevels() {
+        final IdentityProviderConfigEntityData dataOnboardingAtAllLevels = dataBuilder
+                .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+                .withOnboardingLevels(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+                .build();
+
+        assertThat(dataOnboardingAtAllLevels.isOnboardingAtAllLevels()).isTrue();
+
+        final IdentityProviderConfigEntityData dataOnboardingAtOneLevelOnly = dataBuilder
+                .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+                .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_1))
+                .build();
+
+        assertThat(dataOnboardingAtOneLevelOnly.isOnboardingAtAllLevels()).isFalse();
+    }
+
+    @Test
+    public void shouldCheckThatIsOnboardingAtLoa() {
+        final IdentityProviderConfigEntityData data = dataBuilder
+                .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+                .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_1))
+                .build();
+
+        assertThat(data.isOnboardingAtLoa(LevelOfAssurance.LEVEL_1)).isTrue();
+        assertThat(data.isOnboardingAtLoa(LevelOfAssurance.LEVEL_2)).isFalse();
     }
 
 }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryPredicatesTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryPredicatesTest.java
@@ -1,0 +1,76 @@
+package uk.gov.ida.hub.config.domain.filters;
+
+import com.google.common.base.Predicate;
+import org.junit.Test;
+import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
+import uk.gov.ida.hub.config.domain.LevelOfAssurance;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.hub.config.domain.filters.PredicateTestHelper.*;
+
+public class IdpPredicateFactoryPredicatesTest {
+
+    private final IdpPredicateFactory idpPredicateFactory = new IdpPredicateFactory();
+
+    @Test
+    public void shouldReturnIdpsForLoaForNonOnboardingTransactionEntity() {
+        final Set<Predicate<IdentityProviderConfigEntityData>> loa1Predicate = idpPredicateFactory
+                .createPredicatesForTransactionEntityAndLoa(transactionEntityNonOnboarding, LevelOfAssurance.LEVEL_1);
+
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, loa1Predicate);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingAllLevelsIdp,
+                onboardingLoa2Idp, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+    @Test
+    public void shouldReturnIdpsForLoaForOnboardingTransactionEntity() {
+        final Set<Predicate<IdentityProviderConfigEntityData>> loa1PredicateOnboarding = idpPredicateFactory
+                .createPredicatesForTransactionEntityAndLoa(transactionEntityOnboarding, LevelOfAssurance.LEVEL_1);
+
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, loa1PredicateOnboarding);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingAllLevelsIdp,
+                onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+    @Test
+    public void shouldReturnIdpsForSignInForNonOnboardingTransactionEntity() {
+        final Set<Predicate<IdentityProviderConfigEntityData>> signInPredicateNonOnboarding= idpPredicateFactory
+                .createPredicatesForSignIn(transactionEntityNonOnboarding);
+
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, signInPredicateNonOnboarding);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp,
+                nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp,
+                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+    @Test
+    public void shouldReturnIdpsForSignInForOnboardingTransactionEntity()
+    {
+        final Set<Predicate<IdentityProviderConfigEntityData>> signInPredicateOnboarding = idpPredicateFactory
+                .createPredicatesForSignIn(transactionEntityOnboarding);
+
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, signInPredicateOnboarding);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp,
+                nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
+                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+}

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryPredicatesTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryPredicatesTest.java
@@ -24,7 +24,6 @@ public class IdpPredicateFactoryPredicatesTest {
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingAllLevelsIdp,
                 onboardingLoa2Idp, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 
@@ -38,7 +37,6 @@ public class IdpPredicateFactoryPredicatesTest {
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingAllLevelsIdp,
                 onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 
@@ -53,7 +51,6 @@ public class IdpPredicateFactoryPredicatesTest {
                 nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp,
                 onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 
@@ -69,7 +66,6 @@ public class IdpPredicateFactoryPredicatesTest {
                 nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
                 onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryTest.java
@@ -25,14 +25,16 @@ public class IdpPredicateFactoryTest {
 
     @Test
     public void createPredicatesForTransactionEntityAndLoA_shouldNotIncludeExtraPredicate() throws Exception {
-        Set<Predicate<IdentityProviderConfigEntityData>> predicates = idpPredicateFactory.createPredicatesForTransactionEntity(TRANSACTION_ENTITY, LEVEL_OF_ASSURANCE);
+        Set<Predicate<IdentityProviderConfigEntityData>> predicates = idpPredicateFactory.createPredicatesForTransactionEntityAndLoa(TRANSACTION_ENTITY, LEVEL_OF_ASSURANCE);
 
         Predicate<Predicate> findEnabled = input -> input instanceof EnabledIdpPredicate;
         Predicate<Predicate> findOnboarding = input -> input instanceof OnboardingIdpPredicate;
+        Predicate<Predicate> supportedLoa = input -> input instanceof SupportedLoaIdpPredicate;
 
-        assertThat(predicates).hasSize(2);
+        assertThat(predicates).hasSize(3);
         assertThat(Collections2.filter(predicates, findEnabled)).hasSize(1);
         assertThat(Collections2.filter(predicates, findOnboarding)).hasSize(1);
+        assertThat(Collections2.filter(predicates, supportedLoa)).hasSize(1);
     }
 
     @Test

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingForTransactionEntityPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingForTransactionEntityPredicateTest.java
@@ -13,7 +13,7 @@ import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBu
 public class OnboardingForTransactionEntityPredicateTest {
 
     @Test
-    public void shouldBeTrueForNonOnboarding() throws Exception {
+    public void shouldBeTrueForNonOnboarding() {
         String transactionEntity = "transactionEntity";
         Predicate<IdentityProviderConfigEntityData> onboardingPredicate = new OnboardingForTransactionEntityPredicate(transactionEntity);
 
@@ -24,7 +24,7 @@ public class OnboardingForTransactionEntityPredicateTest {
     }
 
     @Test
-    public void shouldBeTrueForOnboardingForSameTransactionEntity() throws Exception {
+    public void shouldBeTrueForOnboardingForSameTransactionEntity() {
         String transactionEntity = "transactionEntity";
         Predicate<IdentityProviderConfigEntityData> onboardingPredicate = new OnboardingForTransactionEntityPredicate(transactionEntity);
 
@@ -36,7 +36,7 @@ public class OnboardingForTransactionEntityPredicateTest {
     }
 
     @Test
-    public void shouldBeFalseForOnboardingDifferentTransactionEntity() throws Exception {
+    public void shouldBeFalseForOnboardingDifferentTransactionEntity() {
         String transactionEntity = "transactionEntity";
         List<String>  differentTransactionEntity = ImmutableList.of("differentTransactionEntity");
         Predicate<IdentityProviderConfigEntityData> onboardingPredicate = new OnboardingForTransactionEntityPredicate(transactionEntity);

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicateTest.java
@@ -1,0 +1,65 @@
+package uk.gov.ida.hub.config.domain.filters;
+
+import org.junit.Test;
+import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
+import uk.gov.ida.hub.config.domain.LevelOfAssurance;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.hub.config.domain.filters.PredicateTestHelper.*;
+
+public class OnboardingIdpPredicateTest {
+
+    @Test
+    public void shouldReturnIdpForLoaForNonOnboardingTransactionEntity() {
+        final OnboardingIdpPredicate loa1Predicate = new OnboardingIdpPredicate(transactionEntityNonOnboarding, LevelOfAssurance.LEVEL_1);
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, loa1Predicate);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp,
+                nonOnboardingAllLevelsIdp, onboardingLoa2Idp, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+    @Test
+    public void shouldReturnIdpForLoaForOnboardingTransactionEntity() {
+        final OnboardingIdpPredicate loa1PredicateOnboarding = new OnboardingIdpPredicate(transactionEntityOnboarding, LevelOfAssurance.LEVEL_1);
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, loa1PredicateOnboarding);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp,
+                onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+    @Test
+    public void shouldReturnIdpsWithoutLoaForNonOnboardingTransactionEntity()
+    {
+        final OnboardingIdpPredicate signInPredicateNonOnboarding = new OnboardingIdpPredicate(transactionEntityNonOnboarding, null);
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, signInPredicateNonOnboarding);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp,
+                onboardingLoa1Idp, onboardingLoa2Idp, onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+    @Test
+    public void shouldReturnIdpsWithoutLoaForOnboardingTransactionEntity()
+    {
+        final OnboardingIdpPredicate signInPredicateOnboarding = new OnboardingIdpPredicate(transactionEntityOnboarding, null);
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, signInPredicateOnboarding);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp,
+                nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
+                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+
+}

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicateTest.java
@@ -19,7 +19,6 @@ public class OnboardingIdpPredicateTest {
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp,
                 nonOnboardingAllLevelsIdp, onboardingLoa2Idp, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 
@@ -31,7 +30,6 @@ public class OnboardingIdpPredicateTest {
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp,
                 onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 
@@ -44,7 +42,6 @@ public class OnboardingIdpPredicateTest {
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp,
                 onboardingLoa1Idp, onboardingLoa2Idp, onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 
@@ -58,7 +55,6 @@ public class OnboardingIdpPredicateTest {
                 nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
                 onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/PredicateTestHelper.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/PredicateTestHelper.java
@@ -1,0 +1,100 @@
+package uk.gov.ida.hub.config.domain.filters;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Sets;
+import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
+import uk.gov.ida.hub.config.domain.LevelOfAssurance;
+import uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
+
+final class PredicateTestHelper {
+
+    private PredicateTestHelper() { }
+
+    private static final IdentityProviderConfigDataBuilder builder = anIdentityProviderConfigData();
+
+    static final String transactionEntityNonOnboarding = "transactionEntityNonOnboarding";
+    static final String transactionEntityOnboarding = "transactionEntityOnboarding";
+    static final String transactionEntityOnboardingOther = "transactionEntityOnboardingOther";
+
+    static final IdentityProviderConfigEntityData nonOnboardingLoa1Idp = builder
+            .withSupportedLevelsOfAssurance(Collections.singletonList(LevelOfAssurance.LEVEL_1))
+            .withoutOnboarding()
+            .withSimpleId("nonOnboardingLoa1Idp")
+            .build();
+
+    static final IdentityProviderConfigEntityData nonOnboardingLoa2Idp = builder
+            .withSupportedLevelsOfAssurance(Collections.singletonList(LevelOfAssurance.LEVEL_2))
+            .withoutOnboarding()
+            .withSimpleId("nonOnboardingLoa2Idp")
+            .build();
+
+    static final IdentityProviderConfigEntityData nonOnboardingAllLevelsIdp = builder
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withoutOnboarding()
+            .withSimpleId("nonOnboardingAllLevelsIdp")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingLoa1Idp = builder
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_1))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
+            .withSimpleId("onboardingLoa1Idp")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingLoa1IdpOtherOnboardingEntity = builder
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_1))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboardingOther))
+            .withSimpleId("onboardingLoa1IdpOtherOnboardingEntity")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingLoa2Idp = builder
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_2))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
+            .withSimpleId("onboardingLoa2Idp")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingLoa2IdpOtherOnboardingEntity = builder
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_2))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboardingOther))
+            .withSimpleId("onboardingLoa2IdpOtherOnboardingEntity")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingAllLevelsIdp = builder
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
+            .withSimpleId("onboardingAllLevelsIdp")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingAllLevelsIdpOtherOnboardingEntity = builder
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboardingOther))
+            .withSimpleId("onboardingAllLevelsIdpOtherOnboardingEntity")
+            .build();
+
+    static final Set<IdentityProviderConfigEntityData> allIdps = new HashSet<>(Arrays.asList(nonOnboardingLoa1Idp,
+            nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
+            onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity, onboardingAllLevelsIdpOtherOnboardingEntity));
+
+    static Set<IdentityProviderConfigEntityData> getFilteredIdps(Set<IdentityProviderConfigEntityData> idpSet,
+                                                                 Set<Predicate<IdentityProviderConfigEntityData>> predicateSet) {
+        return Sets.filter(idpSet, Predicates.and(predicateSet));
+    }
+
+    static Set<IdentityProviderConfigEntityData> getFilteredIdps(Set<IdentityProviderConfigEntityData> idpSet,
+                                                                 Predicate<IdentityProviderConfigEntityData> predicate) {
+        return Sets.filter(idpSet, predicate);
+    }
+}

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicateTest.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.hub.config.domain.filters;
+
+import org.junit.Test;
+import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
+import uk.gov.ida.hub.config.domain.LevelOfAssurance;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.hub.config.domain.filters.PredicateTestHelper.*;
+
+public class SupportedLoaIdpPredicateTest {
+
+    @Test
+    public void shouldReturnRelevantIdpsForLoa() {
+        final SupportedLoaIdpPredicate loa1Predicate = new SupportedLoaIdpPredicate(LevelOfAssurance.LEVEL_1);
+        final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, loa1Predicate);
+
+        final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingAllLevelsIdp,
+                onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa1IdpOtherOnboardingEntity,
+                onboardingLoa2IdpOtherOnboardingEntity, onboardingAllLevelsIdpOtherOnboardingEntity};
+
+        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
+        assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
+    }
+}

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicateTest.java
@@ -20,7 +20,6 @@ public class SupportedLoaIdpPredicateTest {
                 onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa1IdpOtherOnboardingEntity,
                 onboardingLoa2IdpOtherOnboardingEntity, onboardingAllLevelsIdpOtherOnboardingEntity};
 
-        assertThat(filteredIdps).hasSameSizeAs(expectedFilteredIdps);
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
 }


### PR DESCRIPTION
…and LoA.

Implemented logic in hub to filter available IDPs on both transaction entity and supported LOA
IdentityProviderConfigEntityData: renamed isOnboarding(loa) to isOnboardingAtLoa(loa); added unit tests for the class

Authors: @CharlesIC, @hugh-emerson