### PR TITLE
BAU: Add application plugin to hub apps

### DIFF
--- a/hub/config/build.gradle
+++ b/hub/config/build.gradle
@@ -10,7 +10,9 @@ dependencies {
             configurations.common
 }
 
+apply plugin: 'application'
 ext.mainclass = 'uk.gov.ida.hub.config.ConfigApplication'
+mainClassName = ext.mainclass
 
 task copyToLib(dependsOn: jar, type: Copy) {
     into "$buildDir/output/lib"

--- a/hub/policy/build.gradle
+++ b/hub/policy/build.gradle
@@ -14,7 +14,9 @@ dependencies {
             configurations.dropwizard_infinispan
 }
 
+apply plugin: 'application'
 ext.mainclass = 'uk.gov.ida.hub.policy.PolicyApplication'
+mainClassName = ext.mainclass
 
 task copyToLib(dependsOn: jar, type: Copy) {
     into "$buildDir/output/lib"

--- a/hub/saml-engine/build.gradle
+++ b/hub/saml-engine/build.gradle
@@ -15,7 +15,9 @@ dependencies {
             configurations.ida_utils
 }
 
+apply plugin: 'application'
 ext.mainclass = 'uk.gov.ida.hub.samlengine.SamlEngineApplication'
+mainClassName = ext.mainclass
 
 task copyToLib(dependsOn: jar, type: Copy) {
     into "$buildDir/output/lib"

--- a/hub/saml-proxy/build.gradle
+++ b/hub/saml-proxy/build.gradle
@@ -10,7 +10,9 @@ dependencies {
             configurations.common
 }
 
+apply plugin: 'application'
 ext.mainclass = 'uk.gov.ida.hub.samlproxy.SamlProxyApplication'
+mainClassName = ext.mainclass
 
 task copyToLib(dependsOn: jar, type: Copy) {
     into "$buildDir/output/lib"

--- a/hub/saml-soap-proxy/build.gradle
+++ b/hub/saml-soap-proxy/build.gradle
@@ -11,7 +11,9 @@ dependencies {
             configurations.soap
 }
 
+apply plugin: 'application'
 ext.mainclass = 'uk.gov.ida.hub.samlsoapproxy.SamlSoapProxyApplication'
+mainClassName = ext.mainclass
 
 task copyToLib(dependsOn: jar, type: Copy) {
     into "$buildDir/output/lib"

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,4 @@ include "hub:stub-event-sink",
         "hub:policy",
         "hub:saml-engine",
         "hub:saml-proxy",
-        "hub:saml-soap-proxy",
-        "configuration"
+        "hub:saml-soap-proxy"


### PR DESCRIPTION
We currently deploy our app as debian packages using a custom script to
generate these. For running the apps locally, it is more convenient to use
the application plugin (distZip) to build the apps as this creates a
consistent startup script

Authors: @andy-paine