### PR TITLE
Firebreak: Add Dockerfile and script to run apps in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+apps-home
+artefacts
+vendor

--- a/configuration/local/config.yml
+++ b/configuration/local/config.yml
@@ -1,57 +1,29 @@
 server:
   applicationConnectors:
     - type: http
-      port: 50240
-    - type: https
-      port: 50243
-      keyStorePath: deploy/keys/service_ssl.ks
-      keyStorePassword: puppet
-      validatePeers: false
-      validateCerts: false
-      # TLSv1.1 included as curl seems to get unset with 1.2 for some
-      # as-yet-uninvestigated reason.
-      supportedProtocols: ["TLSv1.1","TLSv1.2"]
-      supportedCipherSuites:
-        - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 # for TLS 1.2
-        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA # for TLS 1.1
+      port: 80
   adminConnectors:
     - type: http
-      port: 50241
+      port: 81
   requestLog:
     appenders:
-      - type: file
-        currentLogFilename: apps-home/config.log
-        archivedLogFilenamePattern: apps-home/config.log.%d.gz
-        logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-      - type: logstash-file
-        currentLogFilename: apps-home/logstash/config.log
-        archivedLogFilenamePattern: apps-home/logstash/config.log.%d.gz
-        archivedFileCount: 7
       - type: console
 
 
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/config.log
-      archivedLogFilenamePattern: apps-home/config.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/config.log
-      archivedLogFilenamePattern: apps-home/logstash/config.log.%d.gz
-      archivedFileCount: 7
     - type: console
 
 serviceInfo:
   name: config
 
-rootDataDirectory: configuration/config-service-data/local
+rootDataDirectory: ${FED_CONFIG_PATH:-data/stub-fed-config}
 
 clientTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_truststore.ts
-  password: puppet
+  path: data/pki/hub.ts
+  password: marshmallow
 
 rpTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_rp_truststore.ts
-  password: puppet
+  path: ${RP_TRUST_STORE_PATH:-data/pki/relying_parties.ts}
+  password: marshmallow

--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -1,45 +1,17 @@
 server:
   applicationConnectors:
     - type: http
-      port: 50110
-    - type: https
-      port: 50113
-      keyStorePath: deploy/keys/service_ssl.ks
-      keyStorePassword: puppet
-      validatePeers: false
-      validateCerts: false
-      # TLSv1.1 included as curl seems to get unset with 1.2 for some
-      # as-yet-uninvestigated reason.
-      supportedProtocols: ["TLSv1.1","TLSv1.2"]
-      supportedCipherSuites:
-        - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 # for TLS 1.2
-        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA # for TLS 1.1
+      port: 80
   adminConnectors:
     - type: http
-      port: 50111
+      port: 81
   requestLog:
     appenders:
-      - type: file
-        currentLogFilename: apps-home/policy.log
-        archivedLogFilenamePattern: apps-home/policy.log.%d.gz
-        logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-      - type: logstash-file
-        currentLogFilename: apps-home/logstash/policy.log
-        archivedLogFilenamePattern: apps-home/logstash/policy.log.%d.gz
-        archivedFileCount: 7
       - type: console
 
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/policy.log
-      archivedLogFilenamePattern: apps-home/policy.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/policy.log
-      archivedLogFilenamePattern: apps-home/logstash/policy.log.%d.gz
-      archivedFileCount: 7
     - type: console
 
 
@@ -51,13 +23,13 @@ infinispan:
   expiration: 8h
   persistenceToFileEnabled: false
 
-eventSinkUri: https://localhost:51103
+eventSinkUri: ${EVENT_SINK_URL}
 
-samlEngineUri: https://localhost:50123
+samlEngineUri: ${SAML_ENGINE_URL}
 
-samlSoapProxyUri: https://localhost:50163
+samlSoapProxyUri: ${SAML_SOAP_PROXY_URL}
 
-configUri: https://localhost:50243
+configUri: ${CONFIG_URL}
 
 httpClient:
   timeout: 2s
@@ -67,11 +39,6 @@ httpClient:
   keepAlive: 60s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
-  tls:
-    protocol: TLSv1.2
-    verifyHostname: false
-    trustStorePath: deploy/keys/service_ssl.ks
-    trustStorePassword: puppet
 
 samlSoapProxyClient:
   timeout: 2s
@@ -81,10 +48,6 @@ samlSoapProxyClient:
   keepAlive: 60s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
-  tls:
-    protocol: TLSv1.2
-    verifyHostname: false
-    trustSelfSignedCertificates: true
 
 serviceInfo:
   name: policy
@@ -94,7 +57,7 @@ assertionLifetime: 60m
 matchingServiceResponseWaitPeriod: 60s
 
 clientTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_truststore.ts
-  password: puppet
+  path: ${HUB_TRUST_STORE_PATH:-data/pki/hub.ts}
+  password: marshmallow
 
-eidas: true
+eidas: false

--- a/configuration/local/saml-engine.yml
+++ b/configuration/local/saml-engine.yml
@@ -1,58 +1,22 @@
 server:
   applicationConnectors:
     - type: http
-      port: 50120
-    - type: https
-      port: 50123
-      keyStorePath: deploy/keys/service_ssl.ks
-      keyStorePassword: puppet
-      validatePeers: false
-      validateCerts: false
-      # TLSv1.1 included as curl seems to get unset with 1.2 for some
-      # as-yet-uninvestigated reason.
-      supportedProtocols: ["TLSv1.1","TLSv1.2"]
-      supportedCipherSuites:
-        - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 # for TLS 1.2
-        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA # for TLS 1.1
+      port: 80
   adminConnectors:
     - type: http
-      port: 50121
+      port: 81
   requestLog:
     appenders:
-      - type: file
-        currentLogFilename: apps-home/saml-engine.log
-        archivedLogFilenamePattern: apps-home/saml-engine.log.%d.gz
-        logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-      - type: logstash-file
-        currentLogFilename: apps-home/logstash/saml-engine.log
-        archivedLogFilenamePattern: apps-home/logstash/saml-engine.log.%d.gz
-        archivedFileCount: 7
       - type: console
-
-metrics:
-  reporters:
-    - type: graphite
-      host: localhost
-      port: 2003
-      prefix: local-saml-engine
-      frequency: 10s
 
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/saml-engine.log
-      archivedLogFilenamePattern: apps-home/saml-engine.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/saml-engine.log
-      archivedLogFilenamePattern: apps-home/logstash/saml-engine.log.%d.gz
-      archivedFileCount: 7
     - type: console
       logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
 
 saml:
-  entityId: https://local.signin.service.gov.uk
+  entityId: https://dev-hub.local
   expectedDestination: http://localhost
 
 httpClient:
@@ -65,21 +29,16 @@ httpClient:
   gzipEnabledForRequests: false
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
-  tls:
-    protocol: TLSv1.2
-    verifyHostname: false
-    trustStorePath: deploy/keys/service_ssl.ks
-    trustStorePassword: puppet
 
 infinispan:
-  bindAddress:
-  initialHosts:
-  clusterName:
+  bindAddress: 
+  initialHosts: 
+  clusterName: 
   type: standalone
   expiration: 8h
   persistenceToFileEnabled: false
 
-configUri: https://localhost:50243
+configUri: ${CONFIG_URL}
 
 serviceInfo:
   name: saml-engine
@@ -87,37 +46,45 @@ serviceInfo:
 readKeysFromFileDescriptors: false
 
 privateSigningKeyConfiguration:
-  keyFile: deploy/keys/hub_signing_20170818075825.pk8
+  keyFile: data/pki/hub_signing_primary.pk8
 
 publicSigningCert:
-  certFile: deploy/keys/hub_signing_20170818075825.crt
-  name: someId
+   certFile: data/pki/hub_signing_primary.crt
+   name: someId
 
 primaryPrivateEncryptionKeyConfiguration:
-  keyFile: deploy/keys/hub_encryption_20170818075834.pk8
+  keyFile: data/pki/hub_encryption_primary.pk8
+
+primaryPublicEncryptionCert:
+   certFile: data/pki/hub_encryption_primary.crt
+   name: someId
 
 secondaryPrivateEncryptionKeyConfiguration:
-  keyFile: deploy/keys/hub_encryption_20170818075834.pk8
+  keyFile: data/pki/hub_encryption_primary.pk8
+
+secondaryPublicEncryptionCert:
+   certFile: data/pki/hub_encryption_primary.crt
+   name: someId
 
 clientTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_truststore.ts
-  password: puppet
+  path: data/pki/hub.ts
+  password: marshmallow
 
 rpTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_rp_truststore.ts
-  password: puppet
+  path: data/pki/relying_parties.ts
+  password: marshmallow
 
 authnRequestIdExpirationDuration: 60m
 
 authnRequestValidityDuration: 5m
 
 metadata:
-  uri: http://localhost:55000/local/metadata.xml
-  trustStorePath: deploy/keys/ida_truststore.ts
-  trustStorePassword: puppet
+  uri: ${METADATA_URL}
+  trustStorePath: data/pki/metadata.ts
+  trustStorePassword: marshmallow
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
-  expectedEntityId: https://local.signin.service.gov.uk
+  expectedEntityId: https://dev-hub.local
   jerseyClientName: verify-metadata-client
   client:
     timeout: 2s
@@ -128,33 +95,5 @@ metadata:
     keepAlive: 60s
     chunkedEncodingEnabled: false
     validateAfterInactivityPeriod: 5s
-    tls:
-      protocol: TLSv1.2
-      verifyHostname: false
-      trustSelfSignedCertificates: true
 
-country:
-  saml:
-    entityId: http://localhost:55000/local-connector/metadata.xml
-    expectedDestination: http://localhost:50300/SAML2/SSO/Response/POST
-  metadata:
-    uri: http://localhost:56002/ServiceMetadata
-    trustStorePath: deploy/keys/country_metadata_truststore.ts
-    trustStorePassword: Password
-    minRefreshDelay: 60000
-    maxRefreshDelay: 600000
-    expectedEntityId: http://localhost:56002/ServiceMetadata
-    jerseyClientName: country-metadata-client
-    client:
-      timeout: 2s
-      timeToLive: 10m
-      cookiesEnabled: false
-      connectionTimeout: 1s
-      retries: 3
-      keepAlive: 60s
-      chunkedEncodingEnabled: false
-      validateAfterInactivityPeriod: 5s
-      tls:
-        protocol: TLSv1.2
-        verifyHostname: false
-        trustSelfSignedCertificates: true
+eidas: false

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -1,51 +1,23 @@
 server:
   applicationConnectors:
     - type: http
-      port: 50220
-    - type: https
-      port: 50223
-      keyStorePath: deploy/keys/service_ssl.ks
-      keyStorePassword: puppet
-      validatePeers: false
-      validateCerts: false
-      # TLSv1.1 included as curl seems to get unset with 1.2 for some
-      # as-yet-uninvestigated reason.
-      supportedProtocols: ["TLSv1.1","TLSv1.2"]
-      supportedCipherSuites:
-        - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 # for TLS 1.2
-        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA # for TLS 1.1
+      port: 80
   adminConnectors:
     - type: http
-      port: 50221
+      port: 81
   requestLog:
     appenders:
-      - type: file
-        currentLogFilename: apps-home/saml-proxy.log
-        archivedLogFilenamePattern: apps-home/saml-proxy.log.%d.gz
-        logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-      - type: logstash-file
-        currentLogFilename: apps-home/logstash/saml-proxy.log
-        archivedLogFilenamePattern: apps-home/logstash/saml-proxy.log.%d.gz
-        archivedFileCount: 7
       - type: console
 
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/saml-proxy.log
-      archivedLogFilenamePattern: apps-home/saml-proxy.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/saml-proxy.log
-      archivedLogFilenamePattern: apps-home/logstash/saml-proxy.log.%d.gz
-      archivedFileCount: 7
     - type: console
 
 
 saml:
-  entityId: https://local.signin.service.gov.uk
-  expectedDestination: http://localhost:50300
+  entityId: https://dev-hub.local
+  expectedDestination: ${FRONTEND_URL}
 
 httpClient:
   timeout: 2s
@@ -56,42 +28,37 @@ httpClient:
   keepAlive: 60s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
-  tls:
-    protocol: TLSv1.2
-    verifyHostname: false
-    trustStorePath: deploy/keys/service_ssl.ks
-    trustStorePassword: puppet
 
 enableRetryTimeOutConnections: true
 
-frontendExternalUri: http://localhost:50300
+frontendExternalUri: ${FRONTEND_URL}
 
-configUri: https://localhost:50243
+configUri: ${CONFIG_URL}
 
-eventSinkUri: https://localhost:51103
+eventSinkUri: ${EVENT_SINK_URL}
 
-policyUri: https://localhost:50113
+policyUri: ${POLICY_URL}
 
 serviceInfo:
   name: saml-proxy
 
 clientTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_truststore.ts
-  password: puppet
+  path: data/pki/hub.ts
+  password: marshmallow
 
 rpTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_rp_truststore.ts
-  password: puppet
+  path: data/pki/relying_parties.ts
+  password: marshmallow
 
 metadataValidDuration: 1h
 
 metadata:
-  uri: http://localhost:55000/local/metadata.xml
-  trustStorePath: deploy/keys/ida_truststore.ts
-  trustStorePassword: puppet
+  uri: ${METADATA_URL}
+  trustStorePath: data/pki/metadata.ts
+  trustStorePassword: marshmallow
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
-  expectedEntityId: https://local.signin.service.gov.uk
+  expectedEntityId: https://dev-hub.local
   jerseyClientName: verify-metadata-client
   client:
     timeout: 2s
@@ -102,30 +69,5 @@ metadata:
     keepAlive: 60s
     chunkedEncodingEnabled: false
     validateAfterInactivityPeriod: 5s
-    tls:
-      protocol: TLSv1.2
-      verifyHostname: false
-      trustSelfSignedCertificates: true
 
-country:
-  metadata:
-    uri: http://localhost:56002/ServiceMetadata
-    trustStorePath: deploy/keys/country_metadata_truststore.ts
-    trustStorePassword: Password
-    minRefreshDelay: 60000
-    maxRefreshDelay: 600000
-    expectedEntityId: http://localhost:56002/ServiceMetadata
-    jerseyClientName: country-metadata-client
-    client:
-      timeout: 2s
-      timeToLive: 10m
-      cookiesEnabled: false
-      connectionTimeout: 1s
-      retries: 3
-      keepAlive: 60s
-      chunkedEncodingEnabled: false
-      validateAfterInactivityPeriod: 5s
-      tls:
-        protocol: TLSv1.2
-        verifyHostname: false
-        trustSelfSignedCertificates: true
+eidas: false

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -1,49 +1,21 @@
 server:
   applicationConnectors:
     - type: http
-      port: 50160
-    - type: https
-      port: 50163
-      keyStorePath: deploy/keys/service_ssl.ks
-      keyStorePassword: puppet
-      validatePeers: false
-      validateCerts: false
-      # TLSv1.1 included as curl seems to get unset with 1.2 for some
-      # as-yet-uninvestigated reason.
-      supportedProtocols: ["TLSv1.1","TLSv1.2"]
-      supportedCipherSuites:
-        - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 # for TLS 1.2
-        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA # for TLS 1.1
+      port: 80
   adminConnectors:
     - type: http
-      port: 50161
+      port: 81
   requestLog:
     appenders:
-      - type: file
-        currentLogFilename: apps-home/saml-soap-proxy.log
-        archivedLogFilenamePattern: apps-home/saml-soap-proxy.log.%d.gz
-        logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-      - type: logstash-file
-        currentLogFilename: apps-home/logstash/saml-soap-proxy.log
-        archivedLogFilenamePattern: apps-home/logstash/saml-soap-proxy.log.%d.gz
-        archivedFileCount: 7
       - type: console
 
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/saml-soap-proxy.log
-      archivedLogFilenamePattern: apps-home/saml-soap-proxy.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/saml-soap-proxy.log
-      archivedLogFilenamePattern: apps-home/logstash/saml-soap-proxy.log.%d.gz
-      archivedFileCount: 7
     - type: console
 
 saml:
-  entityId: https://local.signin.service.gov.uk
+  entityId: https://dev-hub.local
 
 httpClient:
   timeout: 2s
@@ -54,11 +26,6 @@ httpClient:
   keepAlive: 60s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
-  tls:
-    protocol: TLSv1.2
-    verifyHostname: false
-    trustStorePath: deploy/keys/service_ssl.ks
-    trustStorePassword: puppet
 
 enableRetryTimeOutConnections: true
 
@@ -70,11 +37,6 @@ soapHttpClient:
   keepAlive: 60s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
-  tls:
-    protocol: TLSv1.2
-    verifyHostname: true
-    trustStorePath: ../ida-hub/deploy/keys/ida_rp_truststore.ts
-    trustStorePassword: puppet
 
 healthCheckSoapHttpClient:
   timeout: 2s
@@ -84,19 +46,14 @@ healthCheckSoapHttpClient:
   keepAlive: 60s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
-  tls:
-    protocol: TLSv1.2
-    verifyHostname: true
-    trustStorePath: ../ida-hub/deploy/keys/ida_rp_truststore.ts
-    trustStorePassword: puppet
 
-samlEngineUri: https://localhost:50123
+samlEngineUri: ${SAML_ENGINE_URL}
 
-configUri: https://localhost:50243
+configUri: ${CONFIG_URL}
 
-eventSinkUri: https://localhost:51103
+eventSinkUri: ${EVENT_SINK_URL}
 
-policyUri: https://localhost:50113
+policyUri: ${POLICY_URL}
 
 serviceInfo:
   name: saml-soap-proxy
@@ -107,20 +64,20 @@ matchingServiceExecutorConfiguration:
   keepAliveDuration: 10s
 
 clientTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_truststore.ts
-  password: puppet
+  path: data/pki/hub.ts
+  password: marshmallow
 
 rpTrustStoreConfiguration:
-  path: ../ida-hub/deploy/keys/ida_rp_truststore.ts
-  password: puppet
+  path: data/pki/relying_parties.ts
+  password: marshmallow
 
 metadata:
-  uri: http://localhost:55000/local/metadata.xml
-  trustStorePath: deploy/keys/ida_truststore.ts
-  trustStorePassword: puppet
+  uri: ${METADATA_URL}
+  trustStorePath: data/pki/metadata.ts
+  trustStorePassword: marshmallow
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
-  expectedEntityId: https://local.signin.service.gov.uk
+  expectedEntityId: https://dev-hub.local
   client:
     timeout: 2s
     timeToLive: 10m
@@ -130,7 +87,3 @@ metadata:
     keepAlive: 60s
     chunkedEncodingEnabled: false
     validateAfterInactivityPeriod: 5s
-    tls:
-      protocol: TLSv1.2
-      verifyHostname: false
-      trustSelfSignedCertificates: true

--- a/configuration/local/stub-event-sink.yml
+++ b/configuration/local/stub-event-sink.yml
@@ -1,45 +1,17 @@
 server:
   applicationConnectors:
     - type: http
-      port: 51100
-    - type: https
-      port: 51103
-      keyStorePath: deploy/keys/service_ssl.ks
-      keyStorePassword: puppet
-      validatePeers: false
-      validateCerts: false
-      # TLSv1.1 included as curl seems to get unset with 1.2 for some
-      # as-yet-uninvestigated reason.
-      supportedProtocols: ["TLSv1.1","TLSv1.2"]
-      supportedCipherSuites:
-        - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 # for TLS 1.2
-        - TLS_DHE_RSA_WITH_AES_128_CBC_SHA # for TLS 1.1
+      port: 80
   adminConnectors:
     - type: http
-      port: 50101
+      port: 81
   requestLog:
     appenders:
-      - type: file
-        currentLogFilename: apps-home/stub-event-sink.log
-        archivedLogFilenamePattern: apps-home/stub-event-sink.log.%d.gz
-        logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-      - type: logstash-file
-        currentLogFilename: apps-home/logstash/stub-event-sink.log
-        archivedLogFilenamePattern: apps-home/logstash/stub-event-sink.log.%d.gz
-        archivedFileCount: 7
       - type: console
 
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/stub-event-sink.log
-      archivedLogFilenamePattern: apps-home/stub-event-sink.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/stub-event-sink.log
-      archivedLogFilenamePattern: apps-home/logstash/stub-event-sink.log.%d.gz
-      archivedFileCount: 7
     - type: console
 
 serviceInfo:

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+app="$1"
+
+./gradlew :hub:$app:clean
+./gradlew :hub:$app:distZip -Pversion=local
+docker build -t $app:latest --build-arg config_location=configuration/local/$app.yml --build-arg app_name=$app  -f run.Dockerfile .
+echo "$app:latest"

--- a/run.Dockerfile
+++ b/run.Dockerfile
@@ -1,0 +1,13 @@
+FROM govukverify/java8
+
+ARG config_location
+ARG app_name
+
+WORKDIR /app
+
+COPY $config_location config.yml
+COPY hub/$app_name/build/distributions/$app_name-0.1.local.zip $app_name.zip
+
+RUN unzip $app_name.zip
+
+CMD ${APP_NAME}-0.1.local/bin/${APP_NAME} server config.yml


### PR DESCRIPTION
Added a Dockerfile and script that can generate an image for each
app as used by local-startup. Also moved local config files into
repo due to docker build context limitations
Added .dockerignore to speed up context loading into docker

Authors: @andy-paine