### PR TITLE
Fix ADR dates to be correct and use ISO8601 format

### DIFF
--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,6 +1,6 @@
 # 1. Record architecture decisions
 
-Date: 10/03/2017
+Date: 2017-10-03
 
 ## Status
 

--- a/doc/adr/0002-accept-eidas-assertions-in-verify.md
+++ b/doc/adr/0002-accept-eidas-assertions-in-verify.md
@@ -1,6 +1,6 @@
 # 2. Accept eIDAS Assertions In Verify
 
-Date: 03/10/2017
+Date: 2017-10-03
 
 ## Status
 

--- a/doc/adr/0003-simple-saml-profile.md
+++ b/doc/adr/0003-simple-saml-profile.md
@@ -1,6 +1,6 @@
 # 3. Simple SAML Profile
 
-Date: 10/03/2017 (but covering previous work)
+Date: 2017-10-03 (but covering previous work)
 
 ## Status
 


### PR DESCRIPTION
YYYY-MM-DD is the one true date format.

Fixes #1

Authors: @richardtowers