### PR TITLE
TT-1613: ZDT deployment

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/PolicyState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/PolicyState.java
@@ -1,30 +1,72 @@
 package uk.gov.ida.hub.policy.domain;
 
-import uk.gov.ida.hub.policy.domain.state.*;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.CountrySelectedState;
+import uk.gov.ida.hub.policy.domain.state.CountrySelectingState;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.Cycle3DataInputCancelledState;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.EidasAwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.EidasCycle0And1MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.EidasSuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.MatchingServiceRequestErrorState;
+import uk.gov.ida.hub.policy.domain.state.NoMatchState;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorState;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.TimeoutState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationFailedState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentStateTransitional;
 
 import static java.text.MessageFormat.format;
 import static java.util.Arrays.stream;
 
 public enum PolicyState {
-    SESSION_STARTED(SessionStartedState.class),
+    SESSION_STARTED(SessionStartedState.class),                                             // Deprecated
+    SESSION_STARTED_TRANSITIONAL(SessionStartedStateTransitional.class),
     COUNTRY_SELECTING(CountrySelectingState.class),
     COUNTRY_SELECTED(CountrySelectedState.class),
-    IDP_SELECTED(IdpSelectedState.class),
-    CYCLE_0_AND_1_MATCH_REQUEST_SENT(Cycle0And1MatchRequestSentState.class),
+    IDP_SELECTED(IdpSelectedState.class),                                                   // Deprecated
+    IDP_SELECTED_TRANSITIONAL(IdpSelectedStateTransitional.class),
+    CYCLE_0_AND_1_MATCH_REQUEST_SENT(Cycle0And1MatchRequestSentState.class),                // Deprecated
+    CYCLE_0_AND_1_MATCH_REQUEST_SENT_TRANSITIONAL(Cycle0And1MatchRequestSentStateTransitional.class),
     EIDAS_CYCLE_0_AND_1_MATCH_REQUEST_SENT(EidasCycle0And1MatchRequestSentState.class),
-    SUCCESSFUL_MATCH(SuccessfulMatchState.class),
+    SUCCESSFUL_MATCH(SuccessfulMatchState.class),                                           // Deprecated
+    SUCCESSFUL_MATCH_TRANSITIONAL(SuccessfulMatchStateTransitional.class),
     EIDAS_SUCCESSFUL_MATCH(EidasSuccessfulMatchState.class),
     NO_MATCH(NoMatchState.class),
-    USER_ACCOUNT_CREATED(UserAccountCreatedState.class),
-    AWAITING_CYCLE3_DATA(AwaitingCycle3DataState.class),
+    USER_ACCOUNT_CREATED(UserAccountCreatedState.class),                                    // Deprecated
+    USER_ACCOUNT_CREATED_TRANSITIONAL(UserAccountCreatedStateTransitional.class),
+    AWAITING_CYCLE3_DATA(AwaitingCycle3DataState.class),                                    // Deprecated
+    AWAITING_CYCLE3_DATA_TRANSITIONAL(AwaitingCycle3DataStateTransitional.class),
     EIDAS_AWAITING_CYCLE3_DATA(EidasAwaitingCycle3DataState.class),
-    CYCLE3_MATCH_REQUEST_SENT(Cycle3MatchRequestSentState.class),
+    CYCLE3_MATCH_REQUEST_SENT(Cycle3MatchRequestSentState.class),                           // Deprecated
+    CYCLE3_MATCH_REQUEST_SENT_TRANSITIONAL(Cycle3MatchRequestSentStateTransitional.class),
     TIMEOUT(TimeoutState.class),
     MATCHING_SERVICE_REQUEST_ERROR(MatchingServiceRequestErrorState.class),
-    USER_ACCOUNT_CREATION_REQUEST_SENT(UserAccountCreationRequestSentState.class),
-    AUTHN_FAILED_ERROR(AuthnFailedErrorState.class),
-    FRAUD_EVENT_DETECTED(FraudEventDetectedState.class),
-    REQUESTER_ERROR(RequesterErrorState.class),
+    USER_ACCOUNT_CREATION_REQUEST_SENT(UserAccountCreationRequestSentState.class),          // Deprecated
+    USER_ACCOUNT_CREATION_REQUEST_SENT_TRANSITIONAL(UserAccountCreationRequestSentStateTransitional.class),
+    AUTHN_FAILED_ERROR(AuthnFailedErrorState.class),                                        // Deprecated
+    AUTHN_FAILED_ERROR_TRANSITIONAL(AuthnFailedErrorStateTransitional.class),
+    FRAUD_EVENT_DETECTED(FraudEventDetectedState.class),                                    // Deprecated
+    FRAUD_EVENT_DETECTED_TRANSITIONAL(FraudEventDetectedStateTransitional.class),
+    REQUESTER_ERROR(RequesterErrorState.class),                                             // Deprecated
+    REQUESTER_ERROR_TRANSITIONAL(RequesterErrorStateTransitional.class),
     CYCLE_3_DATA_INPUT_CANCELLED(Cycle3DataInputCancelledState.class),
     USER_ACCOUNT_CREATION_FAILED(UserAccountCreationFailedState.class);
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
@@ -8,13 +8,30 @@ import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.policy.Urls;
 import uk.gov.ida.hub.policy.domain.controller.StateControllerFactory;
 import uk.gov.ida.hub.policy.domain.exception.SessionNotFoundException;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.ErrorResponsePreparedState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorState;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.TimeoutState;
 import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentStateTransitional;
 import uk.gov.ida.hub.policy.exception.InvalidSessionStateException;
 import uk.gov.ida.hub.policy.exception.SessionTimeoutException;
 
@@ -99,7 +116,60 @@ public class SessionRepository {
             final Class<T> expectedStateClass,
             final Class<? extends State> currentStateClass) {
 
-        return currentStateClass.equals(expectedStateClass) || expectedStateClass.isAssignableFrom(currentStateClass);
+        return currentStateClass.equals(expectedStateClass) || expectedStateClass.isAssignableFrom(currentStateClass)
+                || isATransitionalKindOf(expectedStateClass, currentStateClass);
+    }
+
+    @Deprecated
+    private <T extends State> boolean isATransitionalKindOf(
+            final Class<T> expectedStateClass,
+            final Class<? extends State> currentStateClass) {
+
+        if (currentStateClass.equals(IdpSelectedStateTransitional.class) && expectedStateClass.equals(IdpSelectedState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(SessionStartedStateTransitional.class) && expectedStateClass.equals(SessionStartedState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(AuthnFailedErrorStateTransitional.class) && expectedStateClass.equals(AuthnFailedErrorState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(FraudEventDetectedStateTransitional.class) && expectedStateClass.equals(FraudEventDetectedState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(RequesterErrorStateTransitional.class) && expectedStateClass.equals(RequesterErrorState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(AwaitingCycle3DataStateTransitional.class) && expectedStateClass.equals(AwaitingCycle3DataState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(Cycle0And1MatchRequestSentStateTransitional.class) && expectedStateClass.equals(Cycle0And1MatchRequestSentState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(Cycle3MatchRequestSentStateTransitional.class) && expectedStateClass.equals(Cycle3MatchRequestSentState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(SuccessfulMatchStateTransitional.class) && expectedStateClass.equals(SuccessfulMatchState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(UserAccountCreatedStateTransitional.class) && expectedStateClass.equals(UserAccountCreatedState.class)) {
+            return true;
+        }
+
+        if (currentStateClass.equals(UserAccountCreationRequestSentStateTransitional.class) && expectedStateClass.equals(UserAccountCreationRequestSentState.class)) {
+            return true;
+        }
+
+        return false;
     }
 
     public boolean getTransactionSupportsEidas(SessionId sessionId) {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/StateControllerFactory.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/StateControllerFactory.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.policy.domain.controller;
 
+import com.google.common.base.Optional;
 import com.google.inject.Injector;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
 import uk.gov.ida.hub.policy.domain.AssertionRestrictionsFactory;
@@ -8,7 +9,38 @@ import uk.gov.ida.hub.policy.domain.ResponseFromHubFactory;
 import uk.gov.ida.hub.policy.domain.State;
 import uk.gov.ida.hub.policy.domain.StateController;
 import uk.gov.ida.hub.policy.domain.StateTransitionAction;
-import uk.gov.ida.hub.policy.domain.state.*;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.CountrySelectedState;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.Cycle3DataInputCancelledState;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.EidasAwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.EidasCycle0And1MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.EidasSuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.MatchingServiceRequestErrorState;
+import uk.gov.ida.hub.policy.domain.state.NoMatchState;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorState;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedStateFactory;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.TimeoutState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationFailedState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentStateTransitional;
 import uk.gov.ida.hub.policy.logging.EventSinkHubEventLogger;
 import uk.gov.ida.hub.policy.proxy.IdentityProvidersConfigProxy;
 import uk.gov.ida.hub.policy.proxy.MatchingServiceConfigProxy;
@@ -33,14 +65,36 @@ public class StateControllerFactory {
     public <T extends State> StateController build(final T state, final StateTransitionAction stateTransitionAction) {
         PolicyState policyState = PolicyState.fromStateClass(state.getClass());
         switch (policyState) {
-            case SESSION_STARTED:
+            case SESSION_STARTED_TRANSITIONAL:
+                final SessionStartedStateTransitional startedStateTransitional = (SessionStartedStateTransitional) state;
                 return new SessionStartedStateController(
-                    (SessionStartedState) state,
+                    new SessionStartedState(
+                            startedStateTransitional.getRequestId(),
+                            startedStateTransitional.getRelayState(),
+                            startedStateTransitional.getRequestIssuerEntityId(),
+                            startedStateTransitional.getAssertionConsumerServiceUri(),
+                            startedStateTransitional.getForceAuthentication(),
+                            injector.getInstance(IdentityProvidersConfigProxy.class)
+                                    .getEnabledIdentityProviders(Optional.of(startedStateTransitional.getRequestIssuerEntityId())),
+                            startedStateTransitional.getSessionExpiryTimestamp(),
+                            startedStateTransitional.getSessionId(),
+                            startedStateTransitional.getTransactionSupportsEidas()
+                    ),
                     injector.getInstance(EventSinkHubEventLogger.class),
                     stateTransitionAction,
                     injector.getInstance(TransactionsConfigProxy.class),
                     injector.getInstance(ResponseFromHubFactory.class),
                     injector.getInstance(IdentityProvidersConfigProxy.class));
+
+            // Deprecated
+            case SESSION_STARTED:
+                return new SessionStartedStateController(
+                        (SessionStartedState) state,
+                        injector.getInstance(EventSinkHubEventLogger.class),
+                        stateTransitionAction,
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        injector.getInstance(IdentityProvidersConfigProxy.class));
 
             case COUNTRY_SELECTED:
                 return new CountrySelectedStateController(
@@ -49,9 +103,25 @@ public class StateControllerFactory {
                         stateTransitionAction,
                         injector.getInstance(TransactionsConfigProxy.class));
 
-            case IDP_SELECTED:
+            case IDP_SELECTED_TRANSITIONAL:
+                final IdpSelectedStateTransitional idpSelectedStateTransitional = (IdpSelectedStateTransitional) state;
                 return new IdpSelectedStateController(
-                    (IdpSelectedState) state,
+                    new IdpSelectedState(
+                            idpSelectedStateTransitional.getRequestId(),
+                            idpSelectedStateTransitional.getIdpEntityId(),
+                            idpSelectedStateTransitional.getMatchingServiceEntityId(),
+                            idpSelectedStateTransitional.getLevelsOfAssurance(),
+                            idpSelectedStateTransitional.getUseExactComparisonType(),
+                            idpSelectedStateTransitional.getForceAuthentication(),
+                            idpSelectedStateTransitional.getAssertionConsumerServiceUri(),
+                            idpSelectedStateTransitional.getRequestIssuerEntityId(),
+                            idpSelectedStateTransitional.getRelayState(),
+                            idpSelectedStateTransitional.getSessionExpiryTimestamp(),
+                            idpSelectedStateTransitional.isRegistering(),
+                            idpSelectedStateTransitional.getSessionId(),
+                            idpSelectedStateTransitional.getAvailableIdentityProviderEntityIds(),
+                            idpSelectedStateTransitional.getTransactionSupportsEidas()
+                    ),
                     injector.getInstance(SessionStartedStateFactory.class),
                     injector.getInstance(EventSinkHubEventLogger.class),
                     stateTransitionAction,
@@ -62,9 +132,40 @@ public class StateControllerFactory {
                     injector.getInstance(AssertionRestrictionsFactory.class),
                     injector.getInstance(MatchingServiceConfigProxy.class)
                 );
-            case CYCLE_0_AND_1_MATCH_REQUEST_SENT:
+
+            // Deprecated
+            case IDP_SELECTED:
+                return new IdpSelectedStateController(
+                        (IdpSelectedState) state,
+                        injector.getInstance(SessionStartedStateFactory.class),
+                        injector.getInstance(EventSinkHubEventLogger.class),
+                        stateTransitionAction,
+                        injector.getInstance(IdentityProvidersConfigProxy.class),
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        injector.getInstance(PolicyConfiguration.class),
+                        injector.getInstance(AssertionRestrictionsFactory.class),
+                        injector.getInstance(MatchingServiceConfigProxy.class)
+                );
+
+            case CYCLE_0_AND_1_MATCH_REQUEST_SENT_TRANSITIONAL:
+                final Cycle0And1MatchRequestSentStateTransitional cycle0And1MatchRequestSentStateTransitional = (Cycle0And1MatchRequestSentStateTransitional) state;
                 return new Cycle0And1MatchRequestSentStateController(
-                    (Cycle0And1MatchRequestSentState) state,
+                    new Cycle0And1MatchRequestSentState(
+                            cycle0And1MatchRequestSentStateTransitional.getRequestId(),
+                            cycle0And1MatchRequestSentStateTransitional.getRequestIssuerEntityId(),
+                            cycle0And1MatchRequestSentStateTransitional.getSessionExpiryTimestamp(),
+                            cycle0And1MatchRequestSentStateTransitional.getAssertionConsumerServiceUri(),
+                            cycle0And1MatchRequestSentStateTransitional.getSessionId(),
+                            cycle0And1MatchRequestSentStateTransitional.getTransactionSupportsEidas(),
+                            cycle0And1MatchRequestSentStateTransitional.getIdentityProviderEntityId(),
+                            cycle0And1MatchRequestSentStateTransitional.getRelayState(),
+                            cycle0And1MatchRequestSentStateTransitional.getIdpLevelOfAssurance(),
+                            cycle0And1MatchRequestSentStateTransitional.getMatchingServiceAdapterEntityId(),
+                            cycle0And1MatchRequestSentStateTransitional.getEncryptedMatchingDatasetAssertion(),
+                            cycle0And1MatchRequestSentStateTransitional.getAuthnStatementAssertion(),
+                            cycle0And1MatchRequestSentStateTransitional.getPersistentId()
+                    ),
                     injector.getInstance(EventSinkHubEventLogger.class),
                     stateTransitionAction,
                     injector.getInstance(PolicyConfiguration.class),
@@ -75,6 +176,22 @@ public class StateControllerFactory {
                     injector.getInstance(MatchingServiceConfigProxy.class),
                     injector.getInstance(AttributeQueryService.class)
                 );
+
+            // Deprecated
+            case CYCLE_0_AND_1_MATCH_REQUEST_SENT:
+                return new Cycle0And1MatchRequestSentStateController(
+                        (Cycle0And1MatchRequestSentState) state,
+                        injector.getInstance(EventSinkHubEventLogger.class),
+                        stateTransitionAction,
+                        injector.getInstance(PolicyConfiguration.class),
+                        new LevelOfAssuranceValidator(),
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        injector.getInstance(AssertionRestrictionsFactory.class),
+                        injector.getInstance(MatchingServiceConfigProxy.class),
+                        injector.getInstance(AttributeQueryService.class)
+                );
+
             case EIDAS_CYCLE_0_AND_1_MATCH_REQUEST_SENT:
                 return new EidasCycle0And1MatchRequestSentStateController(
                     (EidasCycle0And1MatchRequestSentState) state,
@@ -86,12 +203,34 @@ public class StateControllerFactory {
                     injector.getInstance(AttributeQueryService.class),
                     injector.getInstance(TransactionsConfigProxy.class)
                 );
-            case SUCCESSFUL_MATCH:
+
+            case SUCCESSFUL_MATCH_TRANSITIONAL:
+                final SuccessfulMatchStateTransitional successfulMatchStateTransitional = (SuccessfulMatchStateTransitional) state;
                 return new SuccessfulMatchStateController(
-                    (SuccessfulMatchState) state,
+                    new SuccessfulMatchState(
+                            successfulMatchStateTransitional.getRequestId(),
+                            successfulMatchStateTransitional.getSessionExpiryTimestamp(),
+                            successfulMatchStateTransitional.getIdentityProviderEntityId(),
+                            successfulMatchStateTransitional.getMatchingServiceAssertion(),
+                            successfulMatchStateTransitional.getRelayState(),
+                            successfulMatchStateTransitional.getRequestIssuerEntityId(),
+                            successfulMatchStateTransitional.getAssertionConsumerServiceUri(),
+                            successfulMatchStateTransitional.getSessionId(),
+                            successfulMatchStateTransitional.getLevelOfAssurance(),
+                            successfulMatchStateTransitional.getTransactionSupportsEidas()
+                    ),
                     injector.getInstance(ResponseFromHubFactory.class),
                     injector.getInstance(IdentityProvidersConfigProxy.class)
                 );
+
+            // Deprecated
+            case SUCCESSFUL_MATCH:
+                return new SuccessfulMatchStateController(
+                        (SuccessfulMatchState) state,
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        injector.getInstance(IdentityProvidersConfigProxy.class)
+                );
+
             case EIDAS_SUCCESSFUL_MATCH:
                 return new EidasSuccessfulMatchStateController(
                     (EidasSuccessfulMatchState) state,
@@ -103,15 +242,51 @@ public class StateControllerFactory {
                     (NoMatchState) state,
                     injector.getInstance(ResponseFromHubFactory.class)
                 );
-            case USER_ACCOUNT_CREATED:
+            case USER_ACCOUNT_CREATED_TRANSITIONAL:
+                final UserAccountCreatedStateTransitional userAccountCreatedStateTransitional = (UserAccountCreatedStateTransitional) state;
                 return new UserAccountCreatedStateController(
-                    (UserAccountCreatedState) state,
+                    new UserAccountCreatedState(
+                            userAccountCreatedStateTransitional.getRequestId(),
+                            userAccountCreatedStateTransitional.getRequestIssuerEntityId(),
+                            userAccountCreatedStateTransitional.getSessionExpiryTimestamp(),
+                            userAccountCreatedStateTransitional.getAssertionConsumerServiceUri(),
+                            userAccountCreatedStateTransitional.getSessionId(),
+                            userAccountCreatedStateTransitional.getIdentityProviderEntityId(),
+                            userAccountCreatedStateTransitional.getMatchingServiceAssertion(),
+                            userAccountCreatedStateTransitional.getRelayState(),
+                            userAccountCreatedStateTransitional.getLevelOfAssurance(),
+                            userAccountCreatedStateTransitional.getTransactionSupportsEidas()
+                    ),
                     injector.getInstance(IdentityProvidersConfigProxy.class),
                     injector.getInstance(ResponseFromHubFactory.class)
                 );
-            case AWAITING_CYCLE3_DATA:
+
+            // Deprecated
+            case USER_ACCOUNT_CREATED:
+                return new UserAccountCreatedStateController(
+                        (UserAccountCreatedState) state,
+                        injector.getInstance(IdentityProvidersConfigProxy.class),
+                        injector.getInstance(ResponseFromHubFactory.class)
+                );
+
+            case AWAITING_CYCLE3_DATA_TRANSITIONAL:
+                final AwaitingCycle3DataStateTransitional awaitingCycle3DataStateTransitional = (AwaitingCycle3DataStateTransitional) state;
                 return new AwaitingCycle3DataStateController(
-                    (AwaitingCycle3DataState) state,
+                    new AwaitingCycle3DataState(
+                            awaitingCycle3DataStateTransitional.getRequestId(),
+                            awaitingCycle3DataStateTransitional.getIdentityProviderEntityId(),
+                            awaitingCycle3DataStateTransitional.getSessionExpiryTimestamp(),
+                            awaitingCycle3DataStateTransitional.getRequestIssuerEntityId(),
+                            awaitingCycle3DataStateTransitional.getEncryptedMatchingDatasetAssertion(),
+                            awaitingCycle3DataStateTransitional.getAuthnStatementAssertion(),
+                            awaitingCycle3DataStateTransitional.getRelayState(),
+                            awaitingCycle3DataStateTransitional.getAssertionConsumerServiceUri(),
+                            awaitingCycle3DataStateTransitional.getMatchingServiceEntityId(),
+                            awaitingCycle3DataStateTransitional.getSessionId(),
+                            awaitingCycle3DataStateTransitional.getPersistentId(),
+                            awaitingCycle3DataStateTransitional.getLevelOfAssurance(),
+                            awaitingCycle3DataStateTransitional.getTransactionSupportsEidas()
+                    ),
                     injector.getInstance(EventSinkHubEventLogger.class),
                     stateTransitionAction,
                     injector.getInstance(TransactionsConfigProxy.class),
@@ -120,6 +295,20 @@ public class StateControllerFactory {
                     injector.getInstance(AssertionRestrictionsFactory.class),
                     injector.getInstance(MatchingServiceConfigProxy.class)
                 );
+
+            // Deprecated
+            case AWAITING_CYCLE3_DATA:
+                return new AwaitingCycle3DataStateController(
+                        (AwaitingCycle3DataState) state,
+                        injector.getInstance(EventSinkHubEventLogger.class),
+                        stateTransitionAction,
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        injector.getInstance(PolicyConfiguration.class),
+                        injector.getInstance(AssertionRestrictionsFactory.class),
+                        injector.getInstance(MatchingServiceConfigProxy.class)
+                );
+
             case EIDAS_AWAITING_CYCLE3_DATA:
                 return new EidasAwaitingCycle3DataStateController(
                     (EidasAwaitingCycle3DataState) state,
@@ -131,9 +320,24 @@ public class StateControllerFactory {
                     injector.getInstance(AssertionRestrictionsFactory.class),
                     injector.getInstance(MatchingServiceConfigProxy.class)
                 );
-            case CYCLE3_MATCH_REQUEST_SENT:
+            case CYCLE3_MATCH_REQUEST_SENT_TRANSITIONAL:
+                final Cycle3MatchRequestSentStateTransitional cycle3MatchRequestSentStateTransitional = (Cycle3MatchRequestSentStateTransitional) state;
                 return new Cycle3MatchRequestSentStateController(
-                    (Cycle3MatchRequestSentState) state,
+                    new Cycle3MatchRequestSentState(
+                            cycle3MatchRequestSentStateTransitional.getRequestId(),
+                            cycle3MatchRequestSentStateTransitional.getRequestIssuerEntityId(),
+                            cycle3MatchRequestSentStateTransitional.getSessionExpiryTimestamp(),
+                            cycle3MatchRequestSentStateTransitional.getAssertionConsumerServiceUri(),
+                            cycle3MatchRequestSentStateTransitional.getSessionId(),
+                            cycle3MatchRequestSentStateTransitional.getTransactionSupportsEidas(),
+                            cycle3MatchRequestSentStateTransitional.getIdentityProviderEntityId(),
+                            cycle3MatchRequestSentStateTransitional.getRelayState(),
+                            cycle3MatchRequestSentStateTransitional.getIdpLevelOfAssurance(),
+                            cycle3MatchRequestSentStateTransitional.getMatchingServiceAdapterEntityId(),
+                            cycle3MatchRequestSentStateTransitional.getEncryptedMatchingDatasetAssertion(),
+                            cycle3MatchRequestSentStateTransitional.getAuthnStatementAssertion(),
+                            cycle3MatchRequestSentStateTransitional.getPersistentId()
+                    ),
                     injector.getInstance(EventSinkHubEventLogger.class),
                     stateTransitionAction,
                     injector.getInstance(PolicyConfiguration.class),
@@ -144,6 +348,22 @@ public class StateControllerFactory {
                     injector.getInstance(AssertionRestrictionsFactory.class),
                     injector.getInstance(AttributeQueryService.class)
                 );
+
+            // Deprecated
+            case CYCLE3_MATCH_REQUEST_SENT:
+                return new Cycle3MatchRequestSentStateController(
+                        (Cycle3MatchRequestSentState) state,
+                        injector.getInstance(EventSinkHubEventLogger.class),
+                        stateTransitionAction,
+                        injector.getInstance(PolicyConfiguration.class),
+                        new LevelOfAssuranceValidator(),
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(MatchingServiceConfigProxy.class),
+                        injector.getInstance(AssertionRestrictionsFactory.class),
+                        injector.getInstance(AttributeQueryService.class)
+                );
+
             case TIMEOUT:
                 return new TimeoutStateController(
                     (TimeoutState) state,
@@ -154,9 +374,21 @@ public class StateControllerFactory {
                     (MatchingServiceRequestErrorState) state,
                     injector.getInstance(ResponseFromHubFactory.class)
                 );
-            case USER_ACCOUNT_CREATION_REQUEST_SENT:
+            case USER_ACCOUNT_CREATION_REQUEST_SENT_TRANSITIONAL:
+                final UserAccountCreationRequestSentStateTransitional userAccountCreationRequestSentStateTransitional = (UserAccountCreationRequestSentStateTransitional) state;
                 return new UserAccountCreationRequestSentStateController(
-                    (UserAccountCreationRequestSentState) state,
+                    new UserAccountCreationRequestSentState(
+                            userAccountCreationRequestSentStateTransitional.getRequestId(),
+                            userAccountCreationRequestSentStateTransitional.getRequestIssuerEntityId(),
+                            userAccountCreationRequestSentStateTransitional.getSessionExpiryTimestamp(),
+                            userAccountCreationRequestSentStateTransitional.getAssertionConsumerServiceUri(),
+                            userAccountCreationRequestSentStateTransitional.getSessionId(),
+                            userAccountCreationRequestSentStateTransitional.getTransactionSupportsEidas(),
+                            userAccountCreationRequestSentStateTransitional.getIdentityProviderEntityId(),
+                            userAccountCreationRequestSentStateTransitional.getRelayState(),
+                            userAccountCreationRequestSentStateTransitional.getIdpLevelOfAssurance(),
+                            userAccountCreationRequestSentStateTransitional.getMatchingServiceAdapterEntityId()
+                    ),
                     stateTransitionAction,
                     injector.getInstance(EventSinkHubEventLogger.class),
                     injector.getInstance(PolicyConfiguration.class),
@@ -164,9 +396,71 @@ public class StateControllerFactory {
                     injector.getInstance(ResponseFromHubFactory.class),
                     injector.getInstance(AttributeQueryService.class)
                 );
+
+            // Deprecated
+            case USER_ACCOUNT_CREATION_REQUEST_SENT:
+                return new UserAccountCreationRequestSentStateController(
+                        (UserAccountCreationRequestSentState) state,
+                        stateTransitionAction,
+                        injector.getInstance(EventSinkHubEventLogger.class),
+                        injector.getInstance(PolicyConfiguration.class),
+                        new LevelOfAssuranceValidator(),
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        injector.getInstance(AttributeQueryService.class)
+                );
+
+            case AUTHN_FAILED_ERROR_TRANSITIONAL:
+                final AuthnFailedErrorStateTransitional authnFailedErrorStateTransitional = (AuthnFailedErrorStateTransitional) state;
+                return new AuthnFailedErrorStateController(
+                    new AuthnFailedErrorState(
+                            authnFailedErrorStateTransitional.getRequestId(),
+                            authnFailedErrorStateTransitional.getRequestIssuerEntityId(),
+                            authnFailedErrorStateTransitional.getSessionExpiryTimestamp(),
+                            authnFailedErrorStateTransitional.getAssertionConsumerServiceUri(),
+                            authnFailedErrorStateTransitional.getRelayState(),
+                            authnFailedErrorStateTransitional.getSessionId(),
+                            authnFailedErrorStateTransitional.getIdpEntityId(),
+                            injector.getInstance(IdentityProvidersConfigProxy.class)
+                                    .getEnabledIdentityProviders(Optional.of(authnFailedErrorStateTransitional.getRequestIssuerEntityId())),
+                            authnFailedErrorStateTransitional.getForceAuthentication(),
+                            authnFailedErrorStateTransitional.getTransactionSupportsEidas()
+                    ),
+                    injector.getInstance(ResponseFromHubFactory.class),
+                    stateTransitionAction,
+                    injector.getInstance(SessionStartedStateFactory.class),
+                    injector.getInstance(TransactionsConfigProxy.class),
+                    injector.getInstance(IdentityProvidersConfigProxy.class),
+                    injector.getInstance(EventSinkHubEventLogger.class)
+                );
+
+            // Deprecated
             case AUTHN_FAILED_ERROR:
                 return new AuthnFailedErrorStateController(
-                    (AuthnFailedErrorState) state,
+                        (AuthnFailedErrorState) state,
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        stateTransitionAction,
+                        injector.getInstance(SessionStartedStateFactory.class),
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(IdentityProvidersConfigProxy.class),
+                        injector.getInstance(EventSinkHubEventLogger.class)
+                );
+
+            case FRAUD_EVENT_DETECTED_TRANSITIONAL:
+                final FraudEventDetectedStateTransitional fraudEventDetectedStateTransitional = (FraudEventDetectedStateTransitional) state;
+                return new FraudEventDetectedStateController(
+                    new FraudEventDetectedState(
+                            fraudEventDetectedStateTransitional.getRequestId(),
+                            fraudEventDetectedStateTransitional.getRequestIssuerEntityId(),
+                            fraudEventDetectedStateTransitional.getSessionExpiryTimestamp(),
+                            fraudEventDetectedStateTransitional.getAssertionConsumerServiceUri(),
+                            fraudEventDetectedStateTransitional.getRelayState(),
+                            fraudEventDetectedStateTransitional.getSessionId(),
+                            fraudEventDetectedStateTransitional.getIdpEntityId(),
+                            injector.getInstance(IdentityProvidersConfigProxy.class)
+                                    .getEnabledIdentityProviders(Optional.of(fraudEventDetectedStateTransitional.getRequestIssuerEntityId())),
+                            fraudEventDetectedStateTransitional.getForceAuthentication(),
+                            fraudEventDetectedStateTransitional.getTransactionSupportsEidas()
+                    ),
                     injector.getInstance(ResponseFromHubFactory.class),
                     stateTransitionAction,
                     injector.getInstance(SessionStartedStateFactory.class),
@@ -174,25 +468,52 @@ public class StateControllerFactory {
                     injector.getInstance(IdentityProvidersConfigProxy.class),
                     injector.getInstance(EventSinkHubEventLogger.class)
                 );
+
+            // Deprecated
             case FRAUD_EVENT_DETECTED:
                 return new FraudEventDetectedStateController(
-                    (FraudEventDetectedState) state,
+                        (FraudEventDetectedState) state,
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        stateTransitionAction,
+                        injector.getInstance(SessionStartedStateFactory.class),
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(IdentityProvidersConfigProxy.class),
+                        injector.getInstance(EventSinkHubEventLogger.class)
+                );
+
+            case REQUESTER_ERROR_TRANSITIONAL:
+                final RequesterErrorStateTransitional requesterErrorStateTransitional = (RequesterErrorStateTransitional) state;
+                return new RequesterErrorStateController(
+                    new RequesterErrorState(
+                            requesterErrorStateTransitional.getRequestId(),
+                            requesterErrorStateTransitional.getRequestIssuerEntityId(),
+                            requesterErrorStateTransitional.getSessionExpiryTimestamp(),
+                            requesterErrorStateTransitional.getAssertionConsumerServiceUri(),
+                            requesterErrorStateTransitional.getRelayState(),
+                            requesterErrorStateTransitional.getSessionId(),
+                            requesterErrorStateTransitional.getForceAuthentication(),
+                            injector.getInstance(IdentityProvidersConfigProxy.class)
+                                    .getEnabledIdentityProviders(Optional.of(requesterErrorStateTransitional.getRequestIssuerEntityId())),
+                            requesterErrorStateTransitional.getTransactionSupportsEidas()
+                    ),
                     injector.getInstance(ResponseFromHubFactory.class),
                     stateTransitionAction,
-                    injector.getInstance(SessionStartedStateFactory.class),
                     injector.getInstance(TransactionsConfigProxy.class),
                     injector.getInstance(IdentityProvidersConfigProxy.class),
                     injector.getInstance(EventSinkHubEventLogger.class)
                 );
+
+            // Deprecated
             case REQUESTER_ERROR:
                 return new RequesterErrorStateController(
-                    (RequesterErrorState) state,
-                    injector.getInstance(ResponseFromHubFactory.class),
-                    stateTransitionAction,
-                    injector.getInstance(TransactionsConfigProxy.class),
-                    injector.getInstance(IdentityProvidersConfigProxy.class),
-                    injector.getInstance(EventSinkHubEventLogger.class)
+                        (RequesterErrorState) state,
+                        injector.getInstance(ResponseFromHubFactory.class),
+                        stateTransitionAction,
+                        injector.getInstance(TransactionsConfigProxy.class),
+                        injector.getInstance(IdentityProvidersConfigProxy.class),
+                        injector.getInstance(EventSinkHubEventLogger.class)
                 );
+
             case CYCLE_3_DATA_INPUT_CANCELLED:
                 return new Cycle3DataInputCancelledStateController(
                     (Cycle3DataInputCancelledState) state,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AbstractMatchRequestSentState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AbstractMatchRequestSentState.java
@@ -1,0 +1,67 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.AbstractState;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.net.URI;
+
+public abstract class AbstractMatchRequestSentState extends AbstractState implements ResponseProcessingState, WaitingForMatchingServiceResponseState {
+
+    private final String identityProviderEntityId;
+    private final Optional<String> relayState;
+    private final LevelOfAssurance idpLevelOfAssurance;
+    private final String matchingServiceAdapterEntityId;
+    private final DateTime requestSentTime;
+
+    protected AbstractMatchRequestSentState(
+            final String requestId,
+            final String requestIssuerEntityId,
+            final DateTime sessionExpiryTimestamp,
+            final URI assertionConsumerServiceUri,
+            final SessionId sessionId,
+            final boolean transactionSupportsEidas,
+            final String identityProviderEntityId,
+            final Optional<String> relayState,
+            final LevelOfAssurance idpLevelOfAssurance,
+            final String matchingServiceAdapterEntityId) {
+
+        super(
+                requestId,
+                requestIssuerEntityId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                sessionId,
+                transactionSupportsEidas
+        );
+
+        this.identityProviderEntityId = identityProviderEntityId;
+        this.relayState = relayState;
+        this.idpLevelOfAssurance = idpLevelOfAssurance;
+        this.matchingServiceAdapterEntityId = matchingServiceAdapterEntityId;
+        this.requestSentTime = DateTime.now();
+    }
+
+    @Override
+    public Optional<String> getRelayState() {
+        return relayState;
+    }
+
+    public String getIdentityProviderEntityId() {
+        return identityProviderEntityId;
+    }
+
+    public DateTime getRequestSentTime() {
+        return requestSentTime;
+    }
+
+    public LevelOfAssurance getIdpLevelOfAssurance() {
+        return idpLevelOfAssurance;
+    }
+
+    public String getMatchingServiceAdapterEntityId() {
+        return matchingServiceAdapterEntityId;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AuthnFailedErrorStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AuthnFailedErrorStateTransitional.java
@@ -1,0 +1,47 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.AbstractState;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.net.URI;
+
+public class AuthnFailedErrorStateTransitional extends AbstractState implements ResponsePreparedState, IdpSelectingStateTransitional {
+
+    private Optional<String> relayState;
+    private String idpEntityId;
+    private Optional<Boolean> forceAuthentication;
+
+    public AuthnFailedErrorStateTransitional(
+            String requestId,
+            String authnRequestIssuerEntityId,
+            DateTime sessionExpiryTimestamp,
+            URI assertionConsumerServiceUri,
+            Optional<String> relayState,
+            SessionId sessionId,
+            String idpEntityId,
+            Optional<Boolean> forceAuthentication,
+            boolean transactionSupportsEidas) {
+
+        super(requestId, authnRequestIssuerEntityId, sessionExpiryTimestamp, assertionConsumerServiceUri, sessionId, transactionSupportsEidas);
+
+        this.relayState = relayState;
+        this.idpEntityId = idpEntityId;
+        this.forceAuthentication = forceAuthentication;
+    }
+
+    @Override
+    public Optional<Boolean> getForceAuthentication() {
+        return forceAuthentication;
+    }
+
+    @Override
+    public Optional<String> getRelayState() {
+        return relayState;
+    }
+
+    public String getIdpEntityId() {
+        return idpEntityId;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AwaitingCycle3DataStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AwaitingCycle3DataStateTransitional.java
@@ -1,0 +1,61 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.PersistentId;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.io.Serializable;
+import java.net.URI;
+
+public class AwaitingCycle3DataStateTransitional extends AbstractAwaitingCycle3DataState implements ResponseProcessingState, Serializable {
+    private final String encryptedMatchingDatasetAssertion;
+    private final String authnStatementAssertion;
+    private final boolean registering;
+
+    public AwaitingCycle3DataStateTransitional(
+            String requestId,
+            String identityProviderEntityId,
+            DateTime sessionExpiryTimestamp,
+            String requestIssuerId,
+            String encryptedMatchingDatasetAssertion,
+            String authnStatementAssertion,
+            Optional<String> relayState,
+            URI assertionConsumerServiceUri,
+            String matchingServiceEntityId,
+            SessionId sessionId,
+            PersistentId persistentId,
+            LevelOfAssurance levelOfAssurance,
+            boolean registering,
+            boolean transactionSupportsEidas) {
+
+        super(
+            requestId,
+            requestIssuerId,
+            sessionExpiryTimestamp,
+            assertionConsumerServiceUri,
+            sessionId,
+            transactionSupportsEidas,
+            identityProviderEntityId,
+            matchingServiceEntityId,
+            relayState,
+            persistentId,
+            levelOfAssurance);
+
+        this.encryptedMatchingDatasetAssertion = encryptedMatchingDatasetAssertion;
+        this.authnStatementAssertion = authnStatementAssertion;
+        this.registering = registering;
+    }
+    public String getAuthnStatementAssertion() {
+        return authnStatementAssertion;
+    }
+
+    public String getEncryptedMatchingDatasetAssertion() {
+        return encryptedMatchingDatasetAssertion;
+    }
+
+    public boolean isRegistering() {
+        return registering;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/Cycle0And1MatchRequestSentStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/Cycle0And1MatchRequestSentStateTransitional.java
@@ -1,0 +1,63 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.PersistentId;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.net.URI;
+
+public class Cycle0And1MatchRequestSentStateTransitional extends MatchRequestSentStateTransitional {
+
+    private final String encryptedMatchingDatasetAssertion;
+    private final String authnStatementAssertion;
+    private final PersistentId persistentId;
+
+    public Cycle0And1MatchRequestSentStateTransitional(
+        final String requestId,
+        final String requestIssuerEntityId,
+        final DateTime sessionExpiryTimestamp,
+        final URI assertionConsumerServiceUri,
+        final SessionId sessionId,
+        final boolean transactionSupportsEidas,
+        final boolean registering,
+        final String identityProviderEntityId,
+        final Optional<String> relayState,
+        final LevelOfAssurance idpLevelOfAssurance,
+        final String matchingServiceAdapterEntityId,
+        final String encryptedMatchingDatasetAssertion,
+        final String authnStatementAssertion,
+        final PersistentId persistentId) {
+
+        super(
+            requestId,
+            requestIssuerEntityId,
+            sessionExpiryTimestamp,
+            assertionConsumerServiceUri,
+            sessionId,
+            transactionSupportsEidas,
+            identityProviderEntityId,
+            relayState,
+            idpLevelOfAssurance,
+            registering,
+            matchingServiceAdapterEntityId
+        );
+
+        this.encryptedMatchingDatasetAssertion = encryptedMatchingDatasetAssertion;
+        this.authnStatementAssertion = authnStatementAssertion;
+        this.persistentId = persistentId;
+    }
+
+    public String getAuthnStatementAssertion() {
+        return authnStatementAssertion;
+    }
+
+    public PersistentId getPersistentId() {
+        return persistentId;
+    }
+
+    public String getEncryptedMatchingDatasetAssertion() {
+        return encryptedMatchingDatasetAssertion;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/Cycle3MatchRequestSentStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/Cycle3MatchRequestSentStateTransitional.java
@@ -1,0 +1,47 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.PersistentId;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.io.Serializable;
+import java.net.URI;
+
+public class Cycle3MatchRequestSentStateTransitional extends Cycle0And1MatchRequestSentStateTransitional implements Serializable {
+
+    public Cycle3MatchRequestSentStateTransitional(
+        final String requestId,
+        final String requestIssuerEntityId,
+        final DateTime sessionExpiryTime,
+        final URI assertionConsumerServiceIndex,
+        final SessionId sessionId,
+        final boolean transactionSupportsEidas,
+        final String identityProviderEntityId,
+        final Optional<String> relayState,
+        final LevelOfAssurance idpLevelOfAssurance,
+        final boolean registering,
+        final String matchingServiceAdapterEntityId,
+        final String encryptedMatchingDatasetAssertion,
+        final String authnStatementAssertion,
+        final PersistentId persistentId) {
+
+        super(
+            requestId,
+            requestIssuerEntityId,
+            sessionExpiryTime,
+            assertionConsumerServiceIndex,
+            sessionId,
+            transactionSupportsEidas,
+            registering,
+            identityProviderEntityId,
+            relayState,
+            idpLevelOfAssurance,
+            matchingServiceAdapterEntityId,
+            encryptedMatchingDatasetAssertion,
+            authnStatementAssertion,
+            persistentId
+        );
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/FraudEventDetectedStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/FraudEventDetectedStateTransitional.java
@@ -1,0 +1,33 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.net.URI;
+
+public class FraudEventDetectedStateTransitional extends AuthnFailedErrorStateTransitional {
+
+    public FraudEventDetectedStateTransitional(
+            String requestId,
+            String requestIssuerId,
+            DateTime sessionExpiryTimestamp,
+            URI assertionConsumerServiceUri,
+            Optional<String> relayState,
+            SessionId sessionId,
+            String idpEntityId,
+            Optional<Boolean> forceAuthentication,
+            boolean transactionSupportsEidas) {
+
+        super(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                relayState,
+                sessionId,
+                idpEntityId,
+                forceAuthentication,
+                transactionSupportsEidas);
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/IdpSelectedStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/IdpSelectedStateTransitional.java
@@ -1,0 +1,90 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.AbstractState;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.List;
+
+public class IdpSelectedStateTransitional extends AbstractState implements IdpSelectingStateTransitional, Serializable {
+    private final String idpEntityId;
+    private final String matchingServiceEntityId;
+
+    private Boolean useExactComparisonType;
+    private List<LevelOfAssurance> levelsOfAssurance;
+    private final Optional<Boolean> forceAuthentication;
+    private final Optional<String> relayState;
+    private final boolean registering;
+    private final LevelOfAssurance requestedLoa;
+    private final List<String> availableIdentityProviders;
+
+    public IdpSelectedStateTransitional(
+            String requestId,
+            String idpEntityId,
+            String matchingServiceEntityId,
+            List<LevelOfAssurance> levelsOfAssurance,
+            Boolean useExactComparisonType,
+            Optional<Boolean> forceAuthentication,
+            URI assertionConsumerServiceUri,
+            String requestIssuerId,
+            Optional<String> relayState,
+            DateTime sessionExpiryTimestamp,
+            boolean registering,
+            LevelOfAssurance requestedLoa,
+            SessionId sessionId,
+            List<String> availableIdentityProviders,
+            boolean transactionSupportsEidas) {
+
+        super(requestId, requestIssuerId, sessionExpiryTimestamp, assertionConsumerServiceUri, sessionId, transactionSupportsEidas);
+
+        this.idpEntityId = idpEntityId;
+        this.matchingServiceEntityId = matchingServiceEntityId;
+        this.levelsOfAssurance = levelsOfAssurance;
+        this.useExactComparisonType = useExactComparisonType;
+        this.forceAuthentication = forceAuthentication;
+        this.relayState = relayState;
+        this.registering = registering;
+        this.requestedLoa = requestedLoa;
+        this.availableIdentityProviders = availableIdentityProviders;
+    }
+
+    public String getIdpEntityId() {
+        return idpEntityId;
+    }
+
+    public Optional<Boolean> getForceAuthentication() {
+        return forceAuthentication;
+    }
+
+    public Optional<String> getRelayState() {
+        return relayState;
+    }
+
+    public List<String> getAvailableIdentityProviderEntityIds() {
+        return availableIdentityProviders;
+    }
+
+    public boolean isRegistering() {
+        return registering;
+    }
+
+    public LevelOfAssurance getRequestedLoa() {
+        return requestedLoa;
+    }
+
+    public String getMatchingServiceEntityId() {
+        return matchingServiceEntityId;
+    }
+
+    public Boolean getUseExactComparisonType() {
+        return useExactComparisonType;
+    }
+
+    public List<LevelOfAssurance> getLevelsOfAssurance() {
+        return levelsOfAssurance;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/IdpSelectingStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/IdpSelectingStateTransitional.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import uk.gov.ida.hub.policy.domain.State;
+
+public interface IdpSelectingStateTransitional extends State {
+    Optional<Boolean> getForceAuthentication();
+    Optional<String> getRelayState();
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/MatchRequestSentStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/MatchRequestSentStateTransitional.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.net.URI;
+
+public abstract class MatchRequestSentStateTransitional extends AbstractMatchRequestSentState {
+
+    private final boolean registering;
+
+    protected MatchRequestSentStateTransitional(
+            final String requestId,
+            final String requestIssuerEntityId,
+            final DateTime sessionExpiryTimestamp,
+            final URI assertionConsumerServiceUri,
+            final SessionId sessionId,
+            final boolean transactionSupportsEidas,
+            final String identityProviderEntityId,
+            final Optional<String> relayState,
+            final LevelOfAssurance idpLevelOfAssurance,
+            final boolean registering,
+            final String matchingServiceAdapterEntityId) {
+
+        super(
+                requestId,
+                requestIssuerEntityId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                sessionId,
+                transactionSupportsEidas,
+                identityProviderEntityId,
+                relayState,
+                idpLevelOfAssurance,
+                matchingServiceAdapterEntityId
+        );
+
+        this.registering = registering;
+    }
+
+    public boolean isRegistering() {
+        return registering;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/RequesterErrorStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/RequesterErrorStateTransitional.java
@@ -1,0 +1,39 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.AbstractState;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.net.URI;
+
+public class RequesterErrorStateTransitional extends AbstractState implements IdpSelectingStateTransitional, ResponsePreparedState {
+
+    private Optional<String> relayState;
+    private Optional<Boolean> forceAuthentication;
+
+    public RequesterErrorStateTransitional(
+            String requestId,
+            String authnRequestIssuerEntityId,
+            DateTime sessionExpiryTimestamp,
+            URI assertionConsumerServiceUri,
+            Optional<String> relayState,
+            SessionId sessionId,
+            Optional<Boolean> forceAuthentication,
+            boolean transactionSupportsEidas) {
+
+        super(requestId, authnRequestIssuerEntityId, sessionExpiryTimestamp, assertionConsumerServiceUri, sessionId, transactionSupportsEidas);
+
+        this.relayState = relayState;
+        this.forceAuthentication = forceAuthentication;
+    }
+
+    @Override
+    public Optional<Boolean> getForceAuthentication() {
+        return forceAuthentication;
+    }
+
+    public Optional<String> getRelayState() {
+        return relayState;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/SessionStartedStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/SessionStartedStateTransitional.java
@@ -1,0 +1,39 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.AbstractState;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.io.Serializable;
+import java.net.URI;
+
+public class SessionStartedStateTransitional extends AbstractState implements IdpSelectingStateTransitional, CountrySelectingState, ResponseProcessingState, Serializable {
+
+    private final Optional<String> relayState;
+    private final Optional<Boolean> forceAuthentication;
+
+    public SessionStartedStateTransitional(
+            String requestId,
+            Optional<String> relayState,
+            String requestIssuerId,
+            URI assertionConsumerServiceUri,
+            Optional<Boolean> forceAuthentication,
+            DateTime sessionExpiryTimestamp,
+            SessionId sessionId,
+            boolean transactionSupportsEidas) {
+
+        super(requestId, requestIssuerId, sessionExpiryTimestamp, assertionConsumerServiceUri, sessionId, transactionSupportsEidas);
+
+        this.relayState = relayState;
+        this.forceAuthentication = forceAuthentication;
+    }
+
+    public Optional<String> getRelayState() {
+        return relayState;
+    }
+
+    public Optional<Boolean> getForceAuthentication() {
+        return forceAuthentication;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/SuccessfulMatchStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/SuccessfulMatchStateTransitional.java
@@ -1,0 +1,66 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.net.URI;
+import java.util.Objects;
+
+public final class SuccessfulMatchStateTransitional extends AbstractSuccessfulMatchState {
+
+    private final boolean isRegistering;
+
+    public SuccessfulMatchStateTransitional(
+            String requestId,
+            DateTime sessionExpiryTimestamp,
+            String identityProviderEntityId,
+            String matchingServiceAssertion,
+            Optional<String> relayState,
+            String requestIssuerId,
+            URI assertionConsumerServiceUri,
+            SessionId sessionId,
+            LevelOfAssurance levelOfAssurance,
+            boolean isRegistering,
+            boolean transactionSupportsEidas) {
+
+        super(
+                requestId,
+                sessionExpiryTimestamp,
+                identityProviderEntityId,
+                matchingServiceAssertion,
+                relayState,
+                requestIssuerId,
+                assertionConsumerServiceUri,
+                sessionId,
+                levelOfAssurance,
+                transactionSupportsEidas);
+
+        this.isRegistering = isRegistering;
+    }
+
+    public boolean isRegistering() {
+        return isRegistering;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SuccessfulMatchStateTransitional that = (SuccessfulMatchStateTransitional) o;
+
+        return Objects.equals(isRegistering, that.isRegistering) && super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isRegistering, super.hashCode());
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/UserAccountCreatedStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/UserAccountCreatedStateTransitional.java
@@ -1,0 +1,60 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.AbstractState;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.io.Serializable;
+import java.net.URI;
+
+public class UserAccountCreatedStateTransitional extends AbstractState implements ResponseProcessingState, ResponsePreparedState, Serializable {
+
+    private final String identityProviderEntityId;
+    private final String matchingServiceAssertion;
+    private final Optional<String> relayState;
+    private final LevelOfAssurance levelOfAssurance;
+    private final boolean registering;
+
+    public UserAccountCreatedStateTransitional(
+            final String requestId,
+            final String requestIssuerId,
+            final DateTime sessionExpiryTimestamp,
+            final URI assertionConsumerServiceUri,
+            final SessionId sessionId,
+            final String identityProviderEntityId,
+            final String matchingServiceAssertion,
+            final Optional<String> relayState,
+            LevelOfAssurance levelOfAssurance,
+            boolean registering,
+            boolean transactionSupportsEidas) {
+        super(requestId, requestIssuerId, sessionExpiryTimestamp, assertionConsumerServiceUri, sessionId, transactionSupportsEidas);
+        this.identityProviderEntityId = identityProviderEntityId;
+        this.matchingServiceAssertion = matchingServiceAssertion;
+        this.relayState = relayState;
+        this.levelOfAssurance = levelOfAssurance;
+        this.registering = registering;
+    }
+
+    @Override
+    public Optional<String> getRelayState() {
+        return relayState;
+    }
+
+    public String getIdentityProviderEntityId() {
+        return identityProviderEntityId;
+    }
+
+    public String getMatchingServiceAssertion() {
+        return matchingServiceAssertion;
+    }
+
+    public LevelOfAssurance getLevelOfAssurance() {
+        return levelOfAssurance;
+    }
+
+    public boolean isRegistering() {
+        return registering;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/UserAccountCreationRequestSentStateTransitional.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/UserAccountCreationRequestSentStateTransitional.java
@@ -1,0 +1,40 @@
+package uk.gov.ida.hub.policy.domain.state;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.io.Serializable;
+import java.net.URI;
+
+public class UserAccountCreationRequestSentStateTransitional extends MatchRequestSentStateTransitional implements Serializable {
+
+    public UserAccountCreationRequestSentStateTransitional(
+        final String requestId,
+        final String requestIssuerEntityId,
+        final DateTime sessionExpiryTimestamp,
+        final URI assertionConsumerServiceUri,
+        final SessionId sessionId,
+        final boolean transactionSupportsEidas,
+        final String identityProviderEntityId,
+        final Optional<String> relayState,
+        final LevelOfAssurance idpLevelOfAssurance,
+        final boolean registering,
+        final String matchingServiceAdapterEntityId) {
+
+        super(
+            requestId,
+            requestIssuerEntityId,
+            sessionExpiryTimestamp,
+            assertionConsumerServiceUri,
+            sessionId,
+            transactionSupportsEidas,
+            identityProviderEntityId,
+            relayState,
+            idpLevelOfAssurance,
+            registering,
+            matchingServiceAdapterEntityId
+        );
+    }
+}

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/AuthnFailedErrorStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/AuthnFailedErrorStateBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorStateTransitional;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -30,16 +31,26 @@ public class AuthnFailedErrorStateBuilder {
         return new AuthnFailedErrorStateBuilder();
     }
 
+    @Deprecated
     public AuthnFailedErrorStateBuilder withAvailableIdpEntityIds(List<String> availableIdpEntityIds) {
         this.availableIdpEntityIds = availableIdpEntityIds;
         return this;
     }
 
-    public AuthnFailedErrorStateBuilder withTransactionSupportsEidas(boolean transactionSupportsEidas) {
-        this.transactionSupportsEidas = transactionSupportsEidas;
-        return this;
+    public AuthnFailedErrorStateTransitional buildTransitional() {
+        return new AuthnFailedErrorStateTransitional(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceIndex,
+                relayState,
+                sessionId,
+                idpEntityId,
+                forceAuthentication,
+                transactionSupportsEidas);
     }
 
+    @Deprecated
     public AuthnFailedErrorState build() {
         return new AuthnFailedErrorState(
                 requestId,
@@ -52,5 +63,10 @@ public class AuthnFailedErrorStateBuilder {
                 availableIdpEntityIds,
                 forceAuthentication,
                 transactionSupportsEidas);
+    }
+
+    public AuthnFailedErrorStateBuilder withTransactionSupportsEidas(boolean transactionSupportsEidas) {
+        this.transactionSupportsEidas = transactionSupportsEidas;
+        return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/AwaitingCycle3DataStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/AwaitingCycle3DataStateBuilder.java
@@ -6,6 +6,7 @@ import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataStateTransitional;
 
 import java.net.URI;
 
@@ -22,11 +23,31 @@ public class AwaitingCycle3DataStateBuilder {
     private String transactionEntityId = "transaction entity id";
     private String encryptedMatchingDatasetAssertion = "encrypted-matching-dataset-assertion";
     private boolean transactionSupportsEidas = false;
+    private boolean registering = false;
 
     public static AwaitingCycle3DataStateBuilder anAwaitingCycle3DataState() {
         return new AwaitingCycle3DataStateBuilder();
     }
 
+    public AwaitingCycle3DataStateTransitional buildTransitional() {
+        return new AwaitingCycle3DataStateTransitional(
+                requestId,
+                "idp entity-id",
+                sessionExpiryTimestamp,
+                transactionEntityId,
+                encryptedMatchingDatasetAssertion,
+                "aPassthroughAssertion().buildAuthnStatementAssertion()",
+                relayState,
+                assertionConsumerServiceUri,
+                "matchingServiceEntityId",
+                sessionId,
+                aPersistentId().build(),
+                LevelOfAssurance.LEVEL_1,
+                registering,
+                transactionSupportsEidas);
+    }
+
+    @Deprecated
     public AwaitingCycle3DataState build() {
         return new AwaitingCycle3DataState(
                 requestId,
@@ -43,7 +64,6 @@ public class AwaitingCycle3DataStateBuilder {
                 LevelOfAssurance.LEVEL_1,
                 transactionSupportsEidas);
     }
-
 
     public AwaitingCycle3DataStateBuilder withRequestId(String requestId) {
         this.requestId = requestId;
@@ -62,6 +82,11 @@ public class AwaitingCycle3DataStateBuilder {
 
     public AwaitingCycle3DataStateBuilder withSessionId(SessionId sessionId) {
         this.sessionId = sessionId;
+        return this;
+    }
+
+    public AwaitingCycle3DataStateBuilder withRegistering(boolean registering) {
+        this.registering = registering;
         return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/Cycle0And1MatchRequestSentStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/Cycle0And1MatchRequestSentStateBuilder.java
@@ -6,6 +6,7 @@ import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentStateTransitional;
 
 import java.net.URI;
 
@@ -22,26 +23,47 @@ public class Cycle0And1MatchRequestSentStateBuilder {
     private String requestId = "requestId";
     private String encryptedMatchingDatasetAssertion = "encrypted-matching-dataset-assertion";
     private boolean transactionSupportsEidas = false;
+    private boolean registering = false;
 
     public static Cycle0And1MatchRequestSentStateBuilder aCycle0And1MatchRequestSentState() {
         return new Cycle0And1MatchRequestSentStateBuilder();
     }
 
+    public Cycle0And1MatchRequestSentStateTransitional buildTransitional() {
+        return new Cycle0And1MatchRequestSentStateTransitional(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                URI.create("default-service-uri"),
+                sessionId,
+                transactionSupportsEidas,
+                registering,
+                "idp-entity-id",
+                Optional.<String>absent(),
+                LevelOfAssurance.LEVEL_1,
+                matchingServiceEntityId,
+                encryptedMatchingDatasetAssertion,
+                "aPassthroughAssertion().buildAuthnStatementAssertion()",
+                persistentId
+        );
+    }
+
+    @Deprecated
     public Cycle0And1MatchRequestSentState build() {
         return new Cycle0And1MatchRequestSentState(
-            requestId,
-            requestIssuerId,
-            sessionExpiryTimestamp,
-            URI.create("default-service-uri"),
-            sessionId,
-            transactionSupportsEidas,
-            "idp-entity-id",
-            Optional.<String>absent(),
-            LevelOfAssurance.LEVEL_1,
-            matchingServiceEntityId,
-            encryptedMatchingDatasetAssertion,
-            "aPassthroughAssertion().buildAuthnStatementAssertion()",
-            persistentId
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                URI.create("default-service-uri"),
+                sessionId,
+                transactionSupportsEidas,
+                "idp-entity-id",
+                Optional.<String>absent(),
+                LevelOfAssurance.LEVEL_1,
+                matchingServiceEntityId,
+                encryptedMatchingDatasetAssertion,
+                "aPassthroughAssertion().buildAuthnStatementAssertion()",
+                persistentId
         );
     }
 
@@ -62,6 +84,11 @@ public class Cycle0And1MatchRequestSentStateBuilder {
 
     public Cycle0And1MatchRequestSentStateBuilder withRequestIssuerEntityId(String requestIssuerEntityId) {
         this.requestIssuerId = requestIssuerEntityId;
+        return this;
+    }
+
+    public Cycle0And1MatchRequestSentStateBuilder withRegistering(boolean registering) {
+        this.registering = registering;
         return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/Cycle3MatchRequestSentStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/Cycle3MatchRequestSentStateBuilder.java
@@ -6,6 +6,7 @@ import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentStateTransitional;
 
 import java.net.URI;
 import java.util.UUID;
@@ -27,9 +28,48 @@ public class Cycle3MatchRequestSentStateBuilder {
     private PersistentId persistentId = aPersistentId().build();
     private String encryptedMatchingDatasetAssertion = "encrypted-matching-dataset-assertion";
     private boolean transactionSupportsEidas = false;
+    private boolean registering = false;
 
     public static Cycle3MatchRequestSentStateBuilder aCycle3MatchRequestSentState() {
         return new Cycle3MatchRequestSentStateBuilder();
+    }
+
+    public Cycle3MatchRequestSentStateTransitional buildTransitional() {
+        return new Cycle3MatchRequestSentStateTransitional(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                sessionId,
+                transactionSupportsEidas,
+                identityProviderEntityId,
+                relayState,
+                levelOfAssurance,
+                registering,
+                "matchingServiceEntityId",
+                encryptedMatchingDatasetAssertion,
+                "aPassthroughAssertion().buildAuthnStatementAssertion()",
+                persistentId
+        );
+    }
+
+    @Deprecated
+    public Cycle3MatchRequestSentState build() {
+        return new Cycle3MatchRequestSentState(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                sessionId,
+                transactionSupportsEidas,
+                identityProviderEntityId,
+                relayState,
+                levelOfAssurance,
+                "matchingServiceEntityId",
+                encryptedMatchingDatasetAssertion,
+                "aPassthroughAssertion().buildAuthnStatementAssertion()",
+                persistentId
+        );
     }
 
     public Cycle3MatchRequestSentStateBuilder withSessionId(SessionId sessionId) {
@@ -42,21 +82,8 @@ public class Cycle3MatchRequestSentStateBuilder {
         return this;
     }
 
-    public Cycle3MatchRequestSentState build() {
-        return new Cycle3MatchRequestSentState(
-            requestId,
-            requestIssuerId,
-            sessionExpiryTimestamp,
-            assertionConsumerServiceUri,
-            sessionId,
-            transactionSupportsEidas,
-            identityProviderEntityId,
-            relayState,
-            levelOfAssurance,
-            "matchingServiceEntityId",
-            encryptedMatchingDatasetAssertion,
-            "aPassthroughAssertion().buildAuthnStatementAssertion()",
-            persistentId
-        );
+    public Cycle3MatchRequestSentStateBuilder withRegistering(boolean registering) {
+        this.registering = registering;
+        return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/FraudEventDetectedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/FraudEventDetectedStateBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedStateTransitional;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -25,8 +26,31 @@ public class FraudEventDetectedStateBuilder {
         return new FraudEventDetectedStateBuilder();
     }
 
-    public FraudEventDetectedState build() {
-        return new FraudEventDetectedState(requestId, requestIssuerId, sessionExpiryTimestamp, assertionConsumerServiceUri, relayState, sessionId, idpEntityId, availableIdpEntityIds, forceAuthentication, false);
+    public FraudEventDetectedStateTransitional buildTransitional() {
+        return new FraudEventDetectedStateTransitional(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                relayState,
+                sessionId,
+                idpEntityId,
+                forceAuthentication,
+                false);
     }
 
+    @Deprecated
+    public FraudEventDetectedState build() {
+        return new FraudEventDetectedState(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                relayState,
+                sessionId,
+                idpEntityId,
+                availableIdpEntityIds,
+                forceAuthentication,
+                false);
+    }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/IdpSelectedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/IdpSelectedStateBuilder.java
@@ -7,6 +7,7 @@ import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedStateTransitional;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ public class IdpSelectedStateBuilder {
     private Optional<String> relayState = Optional.absent();
     private DateTime sessionExpiryTimestamp = DateTime.now().plusDays(5);
     private boolean isRegistration = false;
+    private LevelOfAssurance requestedLoa = LevelOfAssurance.LEVEL_2;
     private SessionId sessionId = SessionIdBuilder.aSessionId().build();
     private List<String> availableIdentityProviders = ImmutableList.of("idp-a", "idp-b", "idp-c");
     private boolean transactionSupportsEidas = false;
@@ -33,6 +35,26 @@ public class IdpSelectedStateBuilder {
         return new IdpSelectedStateBuilder();
     }
 
+    public IdpSelectedStateTransitional buildTransitional() {
+        return new IdpSelectedStateTransitional(
+                requestId,
+                idpEntityId,
+                matchingServiceEntityId,
+                levelsOfAssurance,
+                useExactComparisonType,
+                forceAuthentication,
+                assertionConsumerServiceUri,
+                requestIssuerId,
+                relayState,
+                sessionExpiryTimestamp,
+                isRegistration,
+                requestedLoa,
+                sessionId,
+                availableIdentityProviders,
+                transactionSupportsEidas);
+    }
+
+    @Deprecated
     public IdpSelectedState build() {
         return new IdpSelectedState(
                 requestId,
@@ -83,6 +105,11 @@ public class IdpSelectedStateBuilder {
 
     public IdpSelectedStateBuilder withRegistration(boolean registering) {
         this.isRegistration = registering;
+        return this;
+    }
+
+    public IdpSelectedStateBuilder withRequestedLoa(LevelOfAssurance requestedLoa) {
+        this.requestedLoa = requestedLoa;
         return this;
     }
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/RequesterErrorStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/RequesterErrorStateBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.RequesterErrorState;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorStateTransitional;
 
 import java.net.URI;
 import java.util.Collections;
@@ -25,17 +26,29 @@ public class RequesterErrorStateBuilder {
         return new RequesterErrorStateBuilder();
     }
 
-    public RequesterErrorState build() {
-        return new RequesterErrorState(
-            requestId,
-            authnRequestIssuerEntityId,
-            sessionExpiryTimestamp,
-            assertionConsumerServiceUri,
-            relayState,
-            sessionId,
-            forceAuthentication,
-            availableIdentityProviderEntityIds,
-            transactionSupportsEidas);
+    public RequesterErrorStateTransitional buildTransitional() {
+        return new RequesterErrorStateTransitional(
+                requestId,
+                authnRequestIssuerEntityId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                relayState,
+                sessionId,
+                forceAuthentication,
+                transactionSupportsEidas);
     }
 
+    @Deprecated
+    public RequesterErrorState build() {
+        return new RequesterErrorState(
+                requestId,
+                authnRequestIssuerEntityId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                relayState,
+                sessionId,
+                forceAuthentication,
+                availableIdentityProviderEntityIds,
+                transactionSupportsEidas);
+    }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/SessionStartedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/SessionStartedStateBuilder.java
@@ -5,6 +5,7 @@ import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedStateTransitional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +13,7 @@ import java.util.List;
 public class SessionStartedStateBuilder {
 
     private String requestId = "requestId";
+    private String requestIssuerId = "requestIssuerId";
     private List<String> availableIdpEntityIds = new ArrayList<>();
     private DateTime sessionExpiryTimestamp = DateTime.now().plusDays(5);
     private SessionId sessionId = SessionIdBuilder.aSessionId().build();
@@ -21,11 +23,24 @@ public class SessionStartedStateBuilder {
         return new SessionStartedStateBuilder();
     }
 
+    public SessionStartedStateTransitional buildTransitional() {
+        return new SessionStartedStateTransitional(
+                requestId,
+                Optional.absent(),
+                requestIssuerId,
+                null,
+                null,
+                sessionExpiryTimestamp,
+                sessionId,
+                transactionSupportsEidas);
+    }
+
+    @Deprecated
     public SessionStartedState build() {
         return new SessionStartedState(
                 requestId,
-                Optional.<String>absent(),
-                null,
+                Optional.absent(),
+                requestIssuerId,
                 null,
                 null,
                 availableIdpEntityIds,

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/SuccessfulMatchStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/SuccessfulMatchStateBuilder.java
@@ -6,6 +6,7 @@ import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchStateTransitional;
 
 import java.net.URI;
 
@@ -20,12 +21,29 @@ public class SuccessfulMatchStateBuilder {
     private DateTime sessionExpiryTimestamp = DateTime.now().plusMinutes(10);
     private SessionId getSessionId = SessionIdBuilder.aSessionId().build();
     private LevelOfAssurance levelOfAssurance = LevelOfAssurance.LEVEL_2;
+    private boolean isRegistering = false;
     private boolean transactionSupportsEidas = false;
 
     public static SuccessfulMatchStateBuilder aSuccessfulMatchState() {
         return new SuccessfulMatchStateBuilder();
     }
 
+    public SuccessfulMatchStateTransitional buildTransitional() {
+        return new SuccessfulMatchStateTransitional(
+                requestId,
+                sessionExpiryTimestamp,
+                identityProviderEntityId,
+                matchingServiceAssertion,
+                relayState,
+                requestIssuerId,
+                assertionConsumerServiceUri,
+                getSessionId,
+                levelOfAssurance,
+                isRegistering,
+                transactionSupportsEidas);
+    }
+
+    @Deprecated
     public SuccessfulMatchState build() {
         return new SuccessfulMatchState(
                 requestId,
@@ -47,6 +65,16 @@ public class SuccessfulMatchStateBuilder {
 
     public SuccessfulMatchStateBuilder withIdentityProviderEntityId(String identityProviderEntityId) {
         this.identityProviderEntityId = identityProviderEntityId;
+        return this;
+    }
+
+    public SuccessfulMatchStateBuilder withRequestIssuerEntityId(String requestIssuerEntityId) {
+        this.requestIssuerId = requestIssuerEntityId;
+        return this;
+    }
+
+    public SuccessfulMatchStateBuilder withRegistering(boolean isRegistering) {
+        this.isRegistering = isRegistering;
         return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/UserAccountCreatedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/UserAccountCreatedStateBuilder.java
@@ -6,6 +6,7 @@ import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedStateTransitional;
 
 import java.net.URI;
 
@@ -23,11 +24,28 @@ public class UserAccountCreatedStateBuilder {
     private Optional<String> relayState = absent();
     private LevelOfAssurance levelOfAssurance = LevelOfAssurance.LEVEL_2;
     private boolean transactionSupportsEidas = false;
+    private boolean registering = false;
 
     public static UserAccountCreatedStateBuilder aUserAccountCreatedState() {
         return new UserAccountCreatedStateBuilder();
     }
 
+    public UserAccountCreatedStateTransitional buildTransitional() {
+        return new UserAccountCreatedStateTransitional(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                sessionId,
+                identityProviderEntityId,
+                matchingServiceAssertion,
+                relayState,
+                levelOfAssurance,
+                registering,
+                transactionSupportsEidas);
+    }
+
+    @Deprecated
     public UserAccountCreatedState build() {
         return new UserAccountCreatedState(
                 requestId,
@@ -49,6 +67,11 @@ public class UserAccountCreatedStateBuilder {
 
     public UserAccountCreatedStateBuilder withRelayState(Optional<String> relayState) {
         this.relayState = relayState;
+        return this;
+    }
+
+    public UserAccountCreatedStateBuilder withRegistering(boolean registering) {
+        this.registering = registering;
         return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/UserAccountCreationRequestSentStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/UserAccountCreationRequestSentStateBuilder.java
@@ -5,6 +5,7 @@ import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentStateTransitional;
 
 import java.net.URI;
 import java.util.UUID;
@@ -23,9 +24,42 @@ public class UserAccountCreationRequestSentStateBuilder {
     private DateTime sessionExpiryTimestamp = DateTime.now().plusMinutes(10);
     private SessionId sessionId = aSessionId().build();
     private boolean transactionSupportsEidas = false;
+    private boolean registering = false;
 
     public static UserAccountCreationRequestSentStateBuilder aUserAccountCreationRequestSentState() {
         return new UserAccountCreationRequestSentStateBuilder();
+    }
+
+    public UserAccountCreationRequestSentStateTransitional buildTransitional() {
+        return new UserAccountCreationRequestSentStateTransitional(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                sessionId,
+                transactionSupportsEidas,
+                identityProviderEntityId,
+                relayState,
+                levelOfAssurance,
+                registering,
+                "matchingServiceEntityId"
+        );
+    }
+
+    @Deprecated
+    public UserAccountCreationRequestSentState build() {
+        return new UserAccountCreationRequestSentState(
+                requestId,
+                requestIssuerId,
+                sessionExpiryTimestamp,
+                assertionConsumerServiceUri,
+                sessionId,
+                transactionSupportsEidas,
+                identityProviderEntityId,
+                relayState,
+                levelOfAssurance,
+                "matchingServiceEntityId"
+        );
     }
 
     public UserAccountCreationRequestSentStateBuilder withRelayState(Optional<String> relayState) {
@@ -33,18 +67,8 @@ public class UserAccountCreationRequestSentStateBuilder {
         return this;
     }
 
-    public UserAccountCreationRequestSentState build() {
-        return new UserAccountCreationRequestSentState(
-            requestId,
-            requestIssuerId,
-            sessionExpiryTimestamp,
-            assertionConsumerServiceUri,
-            sessionId,
-            transactionSupportsEidas,
-            identityProviderEntityId,
-            relayState,
-            levelOfAssurance,
-            "matchingServiceEntityId"
-        );
+    public UserAccountCreationRequestSentStateBuilder withRegistering(boolean registering) {
+        this.registering = registering;
+        return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
@@ -8,13 +8,44 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ida.hub.policy.builder.state.AuthnFailedErrorStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.AwaitingCycle3DataStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.Cycle0And1MatchRequestSentStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.Cycle3MatchRequestSentStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.FraudEventDetectedStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.IdpSelectedStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.RequesterErrorStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.SuccessfulMatchStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.UserAccountCreatedStateBuilder;
+import uk.gov.ida.hub.policy.builder.state.UserAccountCreationRequestSentStateBuilder;
 import uk.gov.ida.hub.policy.domain.controller.StateControllerFactory;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
+import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.ErrorResponsePreparedState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedState;
+import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
+import uk.gov.ida.hub.policy.domain.state.IdpSelectedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorState;
+import uk.gov.ida.hub.policy.domain.state.RequesterErrorStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.ResponsePreparedState;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchStateTransitional;
 import uk.gov.ida.hub.policy.domain.state.TimeoutState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedStateTransitional;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentStateTransitional;
 import uk.gov.ida.hub.policy.exception.InvalidSessionStateException;
 import uk.gov.ida.hub.policy.exception.SessionTimeoutException;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
@@ -53,6 +84,194 @@ public class SessionRepositoryTest {
         dataStore = new ConcurrentHashMap<>();
         sessionStartedMap = new ConcurrentHashMap<>();
         sessionRepository = new SessionRepository(dataStore, sessionStartedMap, controllerFactory);
+    }
+
+    @Deprecated
+    @Test
+    public void testIdpSelectedStateNewIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final IdpSelectedStateTransitional idpSelectedStateTransitional = IdpSelectedStateBuilder.anIdpSelectedState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, idpSelectedStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, IdpSelectedState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(idpSelectedStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, IdpSelectedStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(idpSelectedStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void testSessionStartedStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final SessionStartedStateTransitional sessionStartedStateTransitional = aSessionStartedState().withSessionId(expectedSessionId).buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, sessionStartedStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, SessionStartedState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(sessionStartedStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, SessionStartedStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(sessionStartedStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void authnFailedErrorStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final AuthnFailedErrorStateTransitional authnFailedErrorStateTransitional = AuthnFailedErrorStateBuilder.anAuthnFailedErrorState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, authnFailedErrorStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, AuthnFailedErrorState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(authnFailedErrorStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, AuthnFailedErrorStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(authnFailedErrorStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void fraudEventDetectedStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final FraudEventDetectedStateTransitional fraudEventDetectedStateTransitional = FraudEventDetectedStateBuilder.aFraudEventDetectedState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, fraudEventDetectedStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, FraudEventDetectedState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(fraudEventDetectedStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, FraudEventDetectedStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(fraudEventDetectedStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void requesterErrorStateStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final RequesterErrorStateTransitional requesterErrorStateTransitional = RequesterErrorStateBuilder.aRequesterErrorState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, requesterErrorStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, RequesterErrorState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(requesterErrorStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, RequesterErrorStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(requesterErrorStateTransitional), any(StateTransitionAction.class));
+    }
+
+
+    @Deprecated
+    @Test
+    public void awaitingCycle3DataStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final AwaitingCycle3DataStateTransitional awaitingCycle3DataStateTransitional = AwaitingCycle3DataStateBuilder.anAwaitingCycle3DataState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, awaitingCycle3DataStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, AwaitingCycle3DataState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(awaitingCycle3DataStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, AwaitingCycle3DataStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(awaitingCycle3DataStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void cycle0And1MatchRequestSentStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final Cycle0And1MatchRequestSentStateTransitional cycle0And1MatchRequestSentStateTransitional = Cycle0And1MatchRequestSentStateBuilder.aCycle0And1MatchRequestSentState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, cycle0And1MatchRequestSentStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, Cycle0And1MatchRequestSentState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(cycle0And1MatchRequestSentStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, Cycle0And1MatchRequestSentStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(cycle0And1MatchRequestSentStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void cycle3MatchRequestSentStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final Cycle3MatchRequestSentStateTransitional cycle3MatchRequestSentStateTransitional = Cycle3MatchRequestSentStateBuilder.aCycle3MatchRequestSentState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, cycle3MatchRequestSentStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, Cycle3MatchRequestSentState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(cycle3MatchRequestSentStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, Cycle3MatchRequestSentStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(cycle3MatchRequestSentStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void successfulMatchStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final SuccessfulMatchStateTransitional successfulMatchStateTransitional = SuccessfulMatchStateBuilder.aSuccessfulMatchState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, successfulMatchStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, SuccessfulMatchState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(successfulMatchStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, SuccessfulMatchStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(successfulMatchStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void userAccountCreatedStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final UserAccountCreatedStateTransitional userAccountCreatedStateTransitional = UserAccountCreatedStateBuilder.aUserAccountCreatedState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, userAccountCreatedStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, UserAccountCreatedState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(userAccountCreatedStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, UserAccountCreatedStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(userAccountCreatedStateTransitional), any(StateTransitionAction.class));
+    }
+
+    @Deprecated
+    @Test
+    public void userAccountCreationRequestSentStateIsCompatibleWithOldClass() {
+        final SessionId expectedSessionId = aSessionId().build();
+        final SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        final UserAccountCreationRequestSentStateTransitional userAccountCreationRequestSentStateTransitional = UserAccountCreationRequestSentStateBuilder.aUserAccountCreationRequestSentState().buildTransitional();
+
+        final SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        dataStore.replace(sessionId, sessionStartedState, userAccountCreationRequestSentStateTransitional);
+
+        sessionRepository.getStateController(expectedSessionId, UserAccountCreationRequestSentState.class);
+        verify(controllerFactory, VerificationModeFactory.times(1)).build(eq(userAccountCreationRequestSentStateTransitional), any(StateTransitionAction.class));
+
+        sessionRepository.getStateController(expectedSessionId, UserAccountCreationRequestSentStateTransitional.class);
+        verify(controllerFactory, VerificationModeFactory.times(2)).build(eq(userAccountCreationRequestSentStateTransitional), any(StateTransitionAction.class));
     }
 
     @Test(expected = InvalidSessionStateException.class)

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/StateControllerFactoryTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/StateControllerFactoryTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
@@ -25,8 +26,10 @@ import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 import uk.gov.ida.hub.policy.services.AttributeQueryService;
 
 import java.net.URI;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder.aSessionId;
 import static uk.gov.ida.hub.policy.builder.state.AuthnFailedErrorStateBuilder.anAuthnFailedErrorState;
@@ -61,6 +64,9 @@ public class StateControllerFactoryTest {
     @Mock
     private StateTransitionAction stateTransitionAction;
 
+    @Mock
+    private IdentityProvidersConfigProxy identityProvidersConfigProxy;
+
     private StateControllerFactory stateControllerFactory;
 
     @Before
@@ -69,17 +75,27 @@ public class StateControllerFactoryTest {
         when(injector.getInstance(AssertionRestrictionsFactory.class)).thenReturn(null);
         when(injector.getInstance(AttributeQueryService.class)).thenReturn(null);
         when(injector.getInstance(EventSinkHubEventLogger.class)).thenReturn(null);
-        when(injector.getInstance(IdentityProvidersConfigProxy.class)).thenReturn(null);
+        when(injector.getInstance(IdentityProvidersConfigProxy.class)).thenReturn(identityProvidersConfigProxy);
         when(injector.getInstance(MatchingServiceConfigProxy.class)).thenReturn(null);
         when(injector.getInstance(PolicyConfiguration.class)).thenReturn(null);
         when(injector.getInstance(ResponseFromHubFactory.class)).thenReturn(null);
         when(injector.getInstance(SessionStartedStateFactory.class)).thenReturn(null);
         when(injector.getInstance(TransactionsConfigProxy.class)).thenReturn(null);
+
+        when(identityProvidersConfigProxy.getEnabledIdentityProviders(any(Optional.class))).thenReturn(Collections.emptyList());
     }
 
     @Test
     public void shouldCreateASessionStartedStateController() {
         StateController controller = stateControllerFactory.build(aSessionStartedState().build(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(SessionStartedStateController.class);
+    }
+
+    @Deprecated
+    @Test
+    public void shouldCreateASessionStartedStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aSessionStartedState().buildTransitional(), stateTransitionAction);
 
         assertThat(controller).isInstanceOf(SessionStartedStateController.class);
     }
@@ -98,9 +114,25 @@ public class StateControllerFactoryTest {
         assertThat(controller).isInstanceOf(IdpSelectedStateController.class);
     }
 
+    @Deprecated
+    @Test
+    public void shouldCreateAnIdpSelectedStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(anIdpSelectedState().buildTransitional(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(IdpSelectedStateController.class);
+    }
+
     @Test
     public void shouldCreateACycle0And1MatchRequestSentStateController() {
         StateController controller = stateControllerFactory.build(aCycle0And1MatchRequestSentState().build(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(Cycle0And1MatchRequestSentStateController.class);
+    }
+
+    @Deprecated
+    @Test
+    public void shouldCreateACycle0And1MatchRequestSentStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aCycle0And1MatchRequestSentState().buildTransitional(), stateTransitionAction);
 
         assertThat(controller).isInstanceOf(Cycle0And1MatchRequestSentStateController.class);
     }
@@ -115,6 +147,14 @@ public class StateControllerFactoryTest {
     @Test
     public void shouldCreateASuccessfulMatchStateController() {
         StateController controller = stateControllerFactory.build(aSuccessfulMatchState().build(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(SuccessfulMatchStateController.class);
+    }
+
+    @Deprecated
+    @Test
+    public void shouldCreateASuccessfulMatchStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aSuccessfulMatchState().buildTransitional(), stateTransitionAction);
 
         assertThat(controller).isInstanceOf(SuccessfulMatchStateController.class);
     }
@@ -140,9 +180,25 @@ public class StateControllerFactoryTest {
         assertThat(controller).isInstanceOf(UserAccountCreatedStateController.class);
     }
 
+    @Deprecated
+    @Test
+    public void shouldCreateAUserAccountCreatedStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aUserAccountCreatedState().buildTransitional(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(UserAccountCreatedStateController.class);
+    }
+
     @Test
     public void shouldCreateAnAwaitingCycle3DataStateController() {
         StateController controller = stateControllerFactory.build(anAwaitingCycle3DataState().build(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(AwaitingCycle3DataStateController.class);
+    }
+
+    @Deprecated
+    @Test
+    public void shouldCreateAnAwaitingCycle3DataStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(anAwaitingCycle3DataState().buildTransitional(), stateTransitionAction);
 
         assertThat(controller).isInstanceOf(AwaitingCycle3DataStateController.class);
     }
@@ -157,6 +213,14 @@ public class StateControllerFactoryTest {
     @Test
     public void shouldCreateACycle3MatchRequestSentStateController() {
         StateController controller = stateControllerFactory.build(aCycle3MatchRequestSentState().build(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(Cycle3MatchRequestSentStateController.class);
+    }
+
+    @Deprecated
+    @Test
+    public void shouldCreateACycle3MatchRequestSentStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aCycle3MatchRequestSentState().buildTransitional(), stateTransitionAction);
 
         assertThat(controller).isInstanceOf(Cycle3MatchRequestSentStateController.class);
     }
@@ -182,9 +246,25 @@ public class StateControllerFactoryTest {
         assertThat(controller).isInstanceOf(UserAccountCreationRequestSentStateController.class);
     }
 
+    @Deprecated
+    @Test
+    public void shouldCreateAUserAccountCreationRequestSentStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aUserAccountCreationRequestSentState().buildTransitional(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(UserAccountCreationRequestSentStateController.class);
+    }
+
     @Test
     public void shouldCreateAnAuthnFailedErrorStateController() {
         StateController controller = stateControllerFactory.build(anAuthnFailedErrorState().build(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(AuthnFailedErrorStateController.class);
+    }
+
+    @Deprecated
+    @Test
+    public void shouldCreateAnAuthnFailedErrorStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(anAuthnFailedErrorState().buildTransitional(), stateTransitionAction);
 
         assertThat(controller).isInstanceOf(AuthnFailedErrorStateController.class);
     }
@@ -196,9 +276,25 @@ public class StateControllerFactoryTest {
         assertThat(controller).isInstanceOf(FraudEventDetectedStateController.class);
     }
 
+    @Deprecated
+    @Test
+    public void shouldCreateAFraudEventDetectedStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aFraudEventDetectedState().buildTransitional(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(FraudEventDetectedStateController.class);
+    }
+
     @Test
     public void shouldCreateARequesterErrorStateController() {
         StateController controller = stateControllerFactory.build(aRequesterErrorState().build(), stateTransitionAction);
+
+        assertThat(controller).isInstanceOf(RequesterErrorStateController.class);
+    }
+
+    @Deprecated
+    @Test
+    public void shouldCreateARequesterErrorStateControllerFromTransitionalClass() {
+        StateController controller = stateControllerFactory.build(aRequesterErrorState().buildTransitional(), stateTransitionAction);
 
         assertThat(controller).isInstanceOf(RequesterErrorStateController.class);
     }


### PR DESCRIPTION
Add transitional versions of state classes to be replaced to enable a zero-downtime deployment. The app will be able to consume these new versions but will not create new instances of them just yet to avoid breaking the caching and to enable ZDT deployment. If an new version is retrieved from the cache, its instance is converted into the old definition for internal use.

Authors: @CharlesIC