### PR TITLE
BAU: Port class from security-utils to support x509 certs in fed config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'323',
+            ida_utils:'330',
             dropwizard:'1.1.4',
             dropwizard_infinispan:'1.1.4-41',
             pact:'3.5.6',

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/EncryptionCertificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/EncryptionCertificate.java
@@ -1,14 +1,11 @@
 package uk.gov.ida.hub.config.domain;
 
-
-import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
-
 public class EncryptionCertificate extends Certificate {
 
     public EncryptionCertificate() {
     }
 
-    public EncryptionCertificate(DeserializablePublicKeyConfiguration publicKeyConfiguration) {
+    public EncryptionCertificate(X509Certificate publicKeyConfiguration) {
         this.fullCert = publicKeyConfiguration.getCert();
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/MatchingServiceConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/MatchingServiceConfigEntityData.java
@@ -29,12 +29,12 @@ public class MatchingServiceConfigEntityData implements ConfigEntityData, Certif
     @Valid
     @NotNull
     @JsonProperty
-    protected DeserializablePublicKeyConfiguration encryptionCertificate;
+    protected X509Certificate encryptionCertificate;
 
     @Valid
     @NotNull
     @JsonProperty
-    protected List<DeserializablePublicKeyConfiguration> signatureVerificationCertificates;
+    protected List<X509Certificate> signatureVerificationCertificates;
 
     @Valid
     @NotNull

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/SignatureVerificationCertificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/SignatureVerificationCertificate.java
@@ -1,13 +1,11 @@
 package uk.gov.ida.hub.config.domain;
 
-import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
-
 public class SignatureVerificationCertificate extends Certificate {
 
     public SignatureVerificationCertificate() {
     }
 
-    public SignatureVerificationCertificate(DeserializablePublicKeyConfiguration publicKeyConfiguration) {
+    public SignatureVerificationCertificate(X509Certificate publicKeyConfiguration) {
         this.fullCert = publicKeyConfiguration.getCert();
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfigEntityData.java
@@ -44,7 +44,7 @@ public class TransactionConfigEntityData implements ConfigEntityData, Certificat
     @Valid
     @NotNull
     @JsonProperty
-    protected DeserializablePublicKeyConfiguration encryptionCertificate;
+    protected X509Certificate encryptionCertificate;
 
     @Valid
     @NotNull
@@ -89,7 +89,7 @@ public class TransactionConfigEntityData implements ConfigEntityData, Certificat
     @Valid
     @NotNull
     @JsonProperty
-    protected List<DeserializablePublicKeyConfiguration> signatureVerificationCertificates;
+    protected List<X509Certificate> signatureVerificationCertificates;
 
     @Valid
     @JsonProperty

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/X509Certificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/X509Certificate.java
@@ -1,0 +1,49 @@
+package uk.gov.ida.hub.config.domain;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import uk.gov.ida.common.shared.configuration.EncodedCertificateConfiguration;
+import uk.gov.ida.common.shared.configuration.PublicKeyFileConfiguration;
+import uk.gov.ida.common.shared.configuration.X509CertificateConfiguration;
+
+import java.io.ByteArrayInputStream;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+import static java.text.MessageFormat.format;
+import static uk.gov.ida.common.shared.security.Certificate.BEGIN_CERT;
+import static uk.gov.ida.common.shared.security.Certificate.END_CERT;
+
+/* This class is modified from X509CertificateConfiguration in security-utils due to an
+* outstanding bug https://github.com/FasterXML/jackson-databind/issues/1358 which means
+* we cannot directly deserialize to X509CertificateConfiguration */
+public class X509Certificate {
+
+    private String fullCertificate;
+    private Certificate certificate;
+
+    @SuppressWarnings("unused")
+    @JsonCreator
+    public X509Certificate(@JsonProperty("cert") @JsonAlias({ "x509", "fullCertificate" }) String cert) {
+        this.fullCertificate = format("{0}\n{1}\n{2}", BEGIN_CERT, cert.trim(), END_CERT);
+    }
+
+    public String getCert() {
+        return fullCertificate;
+    }
+
+    protected static Certificate getCertificateFromString(String cert) {
+        try {
+            return CertificateFactory.getInstance("X509").generateCertificate(
+                    new ByteArrayInputStream(cert.getBytes())
+            );
+        } catch (CertificateException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/MatchingServiceConfigEntityDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/MatchingServiceConfigEntityDataBuilder.java
@@ -4,6 +4,7 @@ import uk.gov.ida.common.shared.configuration.X509CertificateConfiguration;
 import uk.gov.ida.hub.config.domain.EncryptionCertificate;
 import uk.gov.ida.hub.config.domain.MatchingServiceConfigEntityData;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
+import uk.gov.ida.hub.config.domain.X509Certificate;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ public class MatchingServiceConfigEntityDataBuilder {
             boolean onboarding) {
 
             this.entityId = entityId;
-            this.encryptionCertificate = new X509CertificateConfiguration(null, "test", null);
+            this.encryptionCertificate = new X509Certificate("test");
             this.signatureVerificationCertificates = Collections.emptyList();
             this.uri = uri;
             this.userAccountCreationUri = userAccountCreationUri;

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/SignatureVerificationCertificateBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/SignatureVerificationCertificateBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.config.domain.builders;
 
 import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
+import uk.gov.ida.hub.config.domain.X509Certificate;
 
 import static java.text.MessageFormat.format;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,7 @@ public class SignatureVerificationCertificateBuilder {
 
     public SignatureVerificationCertificate build() {
         String fullCert = format("-----BEGIN CERTIFICATE-----\n{0}\n-----END CERTIFICATE-----", x509Value.trim());
-        DeserializablePublicKeyConfiguration configuration = mock(DeserializablePublicKeyConfiguration.class);
+        X509Certificate configuration = mock(X509Certificate.class);
         when(configuration.getCert()).thenReturn(fullCert);
         return new SignatureVerificationCertificate(configuration);
     }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
@@ -8,6 +8,7 @@ import uk.gov.ida.hub.config.domain.MatchingProcess;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
 import uk.gov.ida.hub.config.domain.TransactionConfigEntityData;
 import uk.gov.ida.hub.config.domain.UserAccountCreationAttribute;
+import uk.gov.ida.hub.config.domain.X509Certificate;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -159,7 +160,7 @@ public class TransactionConfigEntityDataBuilder {
             this.serviceHomepage = serviceHomepage;
             this.entityId = entityId;
             this.simpleId = simpleId;
-            this.encryptionCertificate = new X509CertificateConfiguration(null, "test", null);
+            this.encryptionCertificate = new X509Certificate("test");
             this.signatureVerificationCertificates = Collections.emptyList();
             this.matchingServiceEntityId = matchingServiceEntityId;
             this.assertionConsumerServices = assertionConsumerServices;


### PR DESCRIPTION
Due to changes to the way DeserializablePublicKeyConfiguration works,
fed-config DTOs can no longer use that class to get certificates.
Due to an outstanding bug, we cannot use the specific subtype so
this commit ports the relevant class (and merges the abstract super)
to perform the same behaviour locally in hub.

There is a plan to eventually migrate these DTOs to a database rather
than file backed system in which case this issue will be redundant

Authors: @andy-paine