### PR TITLE
ABD-35: Add a feature toggle to send events to a recording system

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -89,6 +89,10 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @JsonProperty
     public Boolean eidas = false;
 
+    @Valid
+    @JsonProperty
+    public boolean sendToRecordingSystem = false;
+
     public URI getSamlSoapProxyUri() { return samlSoapProxyUri;  }
 
     public org.joda.time.Duration getSessionLength() {
@@ -148,5 +152,9 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
 
     public boolean isEidasEnabled() {
         return eidas;
+    }
+
+    public boolean getSendToRecordingSystem() {
+        return sendToRecordingSystem;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/AwaitingCycle3DataStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/AwaitingCycle3DataStateControllerTest.java
@@ -58,13 +58,15 @@ public class AwaitingCycle3DataStateControllerTest {
     private MatchingServiceConfigProxy matchingServiceConfigProxy;
     @Mock
     private EventEmitter eventEmitter;
+    @Mock
+    private PolicyConfiguration configuration;
 
     private ServiceInfoConfiguration serviceInfo = new ServiceInfoConfiguration("service-name");
     private HubEventLogger hubEventLogger;
 
     @Before
     public void setUp() {
-        hubEventLogger = new HubEventLogger(serviceInfo, eventSinkProxy, eventEmitter);
+        hubEventLogger = new HubEventLogger(serviceInfo, eventSinkProxy, eventEmitter, configuration);
     }
 
     @Test

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/Cycle3MatchRequestSentStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/Cycle3MatchRequestSentStateControllerTest.java
@@ -87,6 +87,9 @@ public class Cycle3MatchRequestSentStateControllerTest {
     @Mock
     private EventEmitter eventEmitter;
 
+    @Mock
+    private PolicyConfiguration configuration;
+
     private HubEventLogger hubEventLogger;
 
     private final ServiceInfoConfiguration serviceInfo = ServiceInfoConfigurationBuilder.aServiceInfo().build();
@@ -98,7 +101,7 @@ public class Cycle3MatchRequestSentStateControllerTest {
 
     @Before
     public void setUp() {
-        hubEventLogger = new HubEventLogger(serviceInfo, eventSinkProxy, eventEmitter);
+        hubEventLogger = new HubEventLogger(serviceInfo, eventSinkProxy, eventEmitter, configuration);
     }
 
     @Test

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -95,6 +95,10 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @JsonProperty
     protected CountryConfiguration country;
 
+    @Valid
+    @JsonProperty
+    public boolean sendToRecordingSystem = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -152,5 +156,9 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
 
     public Optional<CountryConfiguration> getCountryConfiguration() {
         return country != null ? Optional.of(country) : Optional.empty();
+    }
+
+    public boolean getSendToRecordingSystem() {
+        return sendToRecordingSystem;
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLogger.java
@@ -6,6 +6,7 @@ import uk.gov.ida.eventemitter.EventEmitter;
 import uk.gov.ida.eventsink.EventDetailsKey;
 import uk.gov.ida.eventsink.EventSinkHubEvent;
 import uk.gov.ida.eventsink.EventSinkProxy;
+import uk.gov.ida.hub.samlproxy.SamlProxyConfiguration;
 import uk.gov.ida.shared.utils.IpAddressResolver;
 
 import javax.inject.Inject;
@@ -29,6 +30,7 @@ public class ExternalCommunicationEventLogger {
     private final EventSinkProxy eventSinkProxy;
     private final EventEmitter eventEmitter;
     private final IpAddressResolver ipAddressResolver;
+    private final boolean sendToRecordingSystem;
 
     private enum IncludeIpAddressState {
         WITH_RESOLVED_IP_ADDRESS,
@@ -39,11 +41,13 @@ public class ExternalCommunicationEventLogger {
     public ExternalCommunicationEventLogger(ServiceInfoConfiguration serviceInfo,
                                             EventSinkProxy eventSinkProxy,
                                             EventEmitter eventEmitter,
-                                            IpAddressResolver ipAddressResolver) {
+                                            IpAddressResolver ipAddressResolver,
+                                            SamlProxyConfiguration configuration) {
         this.serviceInfo = serviceInfo;
         this.eventSinkProxy = eventSinkProxy;
         this.eventEmitter = eventEmitter;
         this.ipAddressResolver = ipAddressResolver;
+        this.sendToRecordingSystem = configuration.getSendToRecordingSystem();
     }
 
     public void logMatchingServiceRequest(String messageId, SessionId sessionId, URI targetUrl) {
@@ -88,6 +92,8 @@ public class ExternalCommunicationEventLogger {
             details
         );
         eventSinkProxy.logHubEvent(hubEvent);
-        eventEmitter.record(hubEvent);
+        if (sendToRecordingSystem) {
+            eventEmitter.record(hubEvent);
+        }
     }
 }

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLoggerTest.java
@@ -14,6 +14,7 @@ import uk.gov.ida.eventemitter.EventEmitter;
 import uk.gov.ida.eventsink.EventDetailsKey;
 import uk.gov.ida.eventsink.EventSinkHubEvent;
 import uk.gov.ida.eventsink.EventSinkProxy;
+import uk.gov.ida.hub.samlproxy.SamlProxyConfiguration;
 import uk.gov.ida.shared.utils.IpAddressResolver;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 
@@ -23,6 +24,7 @@ import java.util.Objects;
 
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.common.ServiceInfoConfigurationBuilder.aServiceInfo;
 import static uk.gov.ida.eventsink.EventDetailsKey.external_communication_type;
@@ -54,14 +56,21 @@ public class ExternalCommunicationEventLoggerTest {
     @Mock
     private EventEmitter eventEmitter;
 
-    private ExternalCommunicationEventLogger externalCommunicationEventLogger;
+    @Mock
+    private SamlProxyConfiguration configuration;
+
+    private ExternalCommunicationEventLogger externalCommunicationEventLoggerWithoutRecordingSystem;
+    private ExternalCommunicationEventLogger externalCommunicationEventLoggerWithRecordingSystem;
 
     @Before
     public void setUp() throws Exception {
         DateTimeFreezer.freezeTime();
 
         when(ipAddressResolver.lookupIpAddress(ENDPOINT_URL)).thenReturn(ENDPOINT_IP_ADDRESS);
-        externalCommunicationEventLogger = new ExternalCommunicationEventLogger(SERVICE_INFO, eventSinkProxy, eventEmitter, ipAddressResolver);
+        externalCommunicationEventLoggerWithoutRecordingSystem = new ExternalCommunicationEventLogger(SERVICE_INFO, eventSinkProxy, eventEmitter, ipAddressResolver, configuration);
+
+        when(configuration.getSendToRecordingSystem()).thenReturn(true);
+        externalCommunicationEventLoggerWithRecordingSystem = new ExternalCommunicationEventLogger(SERVICE_INFO, eventSinkProxy, eventEmitter, ipAddressResolver, configuration);
 
     }
 
@@ -71,8 +80,8 @@ public class ExternalCommunicationEventLoggerTest {
     }
 
     @Test
-    public void logMatchingServiceRequest_shouldPassHubEventToEventSinkProxy() {
-        externalCommunicationEventLogger.logMatchingServiceRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL);
+    public void logMatchingServiceRequest_shouldPassHubEventToEventSinkAndRecordingSystem() {
+        externalCommunicationEventLoggerWithRecordingSystem.logMatchingServiceRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL);
 
         final Map<EventDetailsKey, String> details = Maps.newHashMap();
         details.put(external_communication_type, MATCHING_SERVICE_REQUEST);
@@ -92,8 +101,29 @@ public class ExternalCommunicationEventLoggerTest {
     }
 
     @Test
-    public void logAuthenticationRequest_shouldPassHubEventToEventSinkProxy() {
-        externalCommunicationEventLogger.logIdpAuthnRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
+    public void logMatchingServiceRequest_shouldPassHubEventToEventSinkOnly() {
+        externalCommunicationEventLoggerWithoutRecordingSystem.logMatchingServiceRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL);
+
+        final Map<EventDetailsKey, String> details = Maps.newHashMap();
+        details.put(external_communication_type, MATCHING_SERVICE_REQUEST);
+        details.put(message_id, MESSAGE_ID);
+        details.put(external_endpoint, ENDPOINT_URL.toString());
+        details.put(external_ip_address, ENDPOINT_IP_ADDRESS);
+
+        final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
+            SERVICE_INFO,
+            SESSION_ID,
+            EXTERNAL_COMMUNICATION_EVENT,
+            details
+        );
+
+        verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
+        verifyNoMoreInteractions(eventEmitter);
+    }
+
+    @Test
+    public void logAuthenticationRequest_shouldPassHubEventToEventSinkAndRecordingSystem() {
+        externalCommunicationEventLoggerWithRecordingSystem.logIdpAuthnRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
 
         final Map<EventDetailsKey, String> details = Maps.newHashMap();
         details.put(external_communication_type, AUTHN_REQUEST);
@@ -113,8 +143,8 @@ public class ExternalCommunicationEventLoggerTest {
     }
 
     @Test
-    public void logResponseFromHub_shouldPassHubEventToEventSinkProxy() {
-        externalCommunicationEventLogger.logResponseFromHub(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
+    public void logResponseFromHub_shouldPassHubEventToEventSinkAndRecordingSystem() {
+        externalCommunicationEventLoggerWithRecordingSystem.logResponseFromHub(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
 
         final Map<EventDetailsKey, String> details = Maps.newHashMap();
         details.put(external_communication_type, RESPONSE_FROM_HUB);

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -92,6 +92,10 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
+    @Valid
+    @JsonProperty
+    public boolean sendToRecordingSystem = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -155,4 +159,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Override
     public boolean getEnableRetryTimeOutConnections() { return enableRetryTimeOutConnections; }
 
+    public boolean getSendToRecordingSystem() {
+        return sendToRecordingSystem;
+    }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/logging/ExternalCommunicationEventLogger.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/logging/ExternalCommunicationEventLogger.java
@@ -6,6 +6,7 @@ import uk.gov.ida.eventemitter.EventEmitter;
 import uk.gov.ida.eventsink.EventDetailsKey;
 import uk.gov.ida.eventsink.EventSinkHubEvent;
 import uk.gov.ida.eventsink.EventSinkProxy;
+import uk.gov.ida.hub.samlsoapproxy.SamlSoapProxyConfiguration;
 import uk.gov.ida.shared.utils.IpAddressResolver;
 
 import javax.inject.Inject;
@@ -29,6 +30,7 @@ public class ExternalCommunicationEventLogger {
     private final EventSinkProxy eventSinkProxy;
     private final EventEmitter eventEmitter;
     private final IpAddressResolver ipAddressResolver;
+    private final boolean sendToRecordingSystem;
 
     private enum IncludeIpAddressState {
         WITH_RESOLVED_IP_ADDRESS,
@@ -39,11 +41,13 @@ public class ExternalCommunicationEventLogger {
     public ExternalCommunicationEventLogger(ServiceInfoConfiguration serviceInfo,
                                             EventSinkProxy eventSinkProxy,
                                             EventEmitter eventEmitter,
-                                            IpAddressResolver ipAddressResolver) {
+                                            IpAddressResolver ipAddressResolver,
+                                            SamlSoapProxyConfiguration configuration) {
         this.serviceInfo = serviceInfo;
         this.eventSinkProxy = eventSinkProxy;
         this.eventEmitter = eventEmitter;
         this.ipAddressResolver = ipAddressResolver;
+        this.sendToRecordingSystem = configuration.getSendToRecordingSystem();
     }
 
     public void logMatchingServiceRequest(String messageId, SessionId sessionId, URI targetUrl) {
@@ -87,6 +91,8 @@ public class ExternalCommunicationEventLogger {
             EXTERNAL_COMMUNICATION_EVENT,
             details);
         eventSinkProxy.logHubEvent(hubEvent);
-        eventEmitter.record(hubEvent);
+        if (sendToRecordingSystem) {
+            eventEmitter.record(hubEvent);
+        }
     }
 }


### PR DESCRIPTION
Adding a configurable toggle to policy, saml soap proxy and saml proxy to send or not to send events to a recording system. The default is not to send events to the recording system.

Authors: @adityapahuja