### PR TITLE
BAU: Upgrade security utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,7 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'323',
-            // rest_utils:'330' has been added to dependency temporarily for enabling Hub to send events using event emitter.
-            // Upgrading ida_utils to 330 breaks verify-hub. The fix for this issue is still being developed. Once the fix is completed,
-            // rest_utils will be removed from the dependency.
-            rest_utils:'330',
+            ida_utils:'330',
             dropwizard:'1.1.4',
             dropwizard_infinispan:'1.1.4-41',
             pact:'3.5.6',
@@ -97,13 +93,13 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        rest_utils "uk.gov.ida:rest-utils:2.0.0-$dependencyVersions.rest_utils"
+        rest_utils "uk.gov.ida:rest-utils:2.0.0-$dependencyVersions.ida_utils"
 
         verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-7"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils"
-
+        
         ida_test_utils "uk.gov.ida:common-test-utils:$dependencyVersions.ida_test_utils"
 
         dev_pki "uk.gov.ida:ida-dev-pki:$dependencyVersions.dev_pki"
@@ -156,7 +152,7 @@ task(outputDependencies) doLast {
     println "saml_extensions="+dependencyVersions.saml_extensions
     println "saml_metadata="+dependencyVersions.saml_metadata
     println "saml_serializers="+dependencyVersions.saml_serializers
-    println "rest_utils="+dependencyVersions.rest_utils
+    println "rest_utils="+dependencyVersions.ida_utils
     println "ida_utils="+dependencyVersions.ida_utils
     println "dropwizard_infinispan="+dependencyVersions.dropwizard_infinispan
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/Certificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/Certificate.java
@@ -64,4 +64,19 @@ public abstract class Certificate {
     }
 
     public abstract CertificateType getType();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Certificate that = (Certificate) o;
+
+        return fullCert != null ? fullCert.equals(that.fullCert) : that.fullCert == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return fullCert != null ? fullCert.hashCode() : 0;
+    }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateDetails.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateDetails.java
@@ -24,7 +24,7 @@ public class CertificateDetails {
         this.isEnabled = isEnabled;
     }
 
-    public static CertificateDetails aCertifcateDetail(String issuerId, Certificate certificate, FederationEntityType federationEntityType) {
+    public static CertificateDetails aCertificateDetail(String issuerId, Certificate certificate, FederationEntityType federationEntityType) {
         return new CertificateDetails(issuerId, certificate, federationEntityType);
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/EncryptionCertificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/EncryptionCertificate.java
@@ -1,14 +1,12 @@
 package uk.gov.ida.hub.config.domain;
 
 
-import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
-
 public class EncryptionCertificate extends Certificate {
 
     public EncryptionCertificate() {
     }
 
-    public EncryptionCertificate(DeserializablePublicKeyConfiguration publicKeyConfiguration) {
+    public EncryptionCertificate(X509Certificate publicKeyConfiguration) {
         this.fullCert = publicKeyConfiguration.getCert();
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/MatchingServiceConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/MatchingServiceConfigEntityData.java
@@ -29,12 +29,12 @@ public class MatchingServiceConfigEntityData implements ConfigEntityData, Certif
     @Valid
     @NotNull
     @JsonProperty
-    protected DeserializablePublicKeyConfiguration encryptionCertificate;
+    protected X509Certificate encryptionCertificate;
 
     @Valid
     @NotNull
     @JsonProperty
-    protected List<DeserializablePublicKeyConfiguration> signatureVerificationCertificates;
+    protected List<X509Certificate> signatureVerificationCertificates;
 
     @Valid
     @NotNull

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/SignatureVerificationCertificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/SignatureVerificationCertificate.java
@@ -1,13 +1,11 @@
 package uk.gov.ida.hub.config.domain;
 
-import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
-
 public class SignatureVerificationCertificate extends Certificate {
 
     public SignatureVerificationCertificate() {
     }
 
-    public SignatureVerificationCertificate(DeserializablePublicKeyConfiguration publicKeyConfiguration) {
+    public SignatureVerificationCertificate(X509Certificate publicKeyConfiguration) {
         this.fullCert = publicKeyConfiguration.getCert();
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfigEntityData.java
@@ -44,7 +44,7 @@ public class TransactionConfigEntityData implements ConfigEntityData, Certificat
     @Valid
     @NotNull
     @JsonProperty
-    protected DeserializablePublicKeyConfiguration encryptionCertificate;
+    protected X509Certificate encryptionCertificate;
 
     @Valid
     @NotNull
@@ -89,7 +89,7 @@ public class TransactionConfigEntityData implements ConfigEntityData, Certificat
     @Valid
     @NotNull
     @JsonProperty
-    protected List<DeserializablePublicKeyConfiguration> signatureVerificationCertificates;
+    protected List<X509Certificate> signatureVerificationCertificates;
 
     @Valid
     @JsonProperty

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/X509Certificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/X509Certificate.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.hub.config.domain;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.text.MessageFormat.format;
+import static uk.gov.ida.common.shared.security.Certificate.BEGIN_CERT;
+import static uk.gov.ida.common.shared.security.Certificate.END_CERT;
+
+/* This class is modified from X509CertificateConfiguration in security-utils due to an
+* outstanding bug https://github.com/FasterXML/jackson-databind/issues/1358 which means
+* we cannot directly deserialize to X509CertificateConfiguration */
+public class X509Certificate {
+    @JsonProperty
+    private String cert;
+    private String fullCert;
+
+    @JsonCreator
+    public X509Certificate(@JsonProperty("cert") @JsonAlias({ "x509", "fullCertificate" }) String cert) {
+        this.cert = cert;
+        this.fullCert = format("{0}\n{1}\n{2}", BEGIN_CERT, cert.trim(), END_CERT);
+    }
+
+    @JsonIgnore
+    public String getCert() {
+        return fullCert;
+    }
+}

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.ida.hub.config.domain.CertificateDetails.aCertifcateDetail;
+import static uk.gov.ida.hub.config.domain.CertificateDetails.aCertificateDetail;
 import static uk.gov.ida.hub.config.domain.builders.MatchingServiceConfigEntityDataBuilder.aMatchingServiceConfigEntityData;
 import static uk.gov.ida.hub.config.domain.builders.SignatureVerificationCertificateBuilder.aSignatureVerificationCertificate;
 import static uk.gov.ida.hub.config.domain.builders.TransactionConfigEntityDataBuilder.aTransactionConfigData;
@@ -63,7 +63,7 @@ public class CertificateServiceTest {
 
         CertificateDetails certificateDetails = certificateService.encryptionCertificateFor(ENTITY_ID);
 
-        assertThat(certificateDetails).isEqualTo(aCertifcateDetail(ENTITY_ID,
+        assertThat(certificateDetails).isEqualTo(aCertificateDetail(ENTITY_ID,
                 transactionConfigEntityData.getEncryptionCertificate(), FederationEntityType.RP));
     }
 
@@ -93,7 +93,7 @@ public class CertificateServiceTest {
 
         CertificateDetails certificateDetails = certificateService.encryptionCertificateFor(ENTITY_ID);
 
-        assertThat(certificateDetails).isEqualTo(aCertifcateDetail(ENTITY_ID,
+        assertThat(certificateDetails).isEqualTo(aCertificateDetail(ENTITY_ID,
                 matchingServiceConfigEntityData.getEncryptionCertificate(), FederationEntityType.MS));
     }
 
@@ -150,8 +150,8 @@ public class CertificateServiceTest {
         List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificatonCertificatesFor(ENTITY_ID);
 
         assertThat(certificateDetailsFound.size()).isEqualTo(2);
-        assertThat(certificateDetailsFound).contains(aCertifcateDetail(ENTITY_ID, sigCert1, FederationEntityType.RP),
-                aCertifcateDetail(ENTITY_ID, sigCert2, FederationEntityType.RP));
+        assertThat(certificateDetailsFound).contains(aCertificateDetail(ENTITY_ID, sigCert1, FederationEntityType.RP),
+                aCertificateDetail(ENTITY_ID, sigCert2, FederationEntityType.RP));
     }
 
     @Test
@@ -165,8 +165,8 @@ public class CertificateServiceTest {
                 .addSignatureVerificationCertificate(invalidCert)
                 .build();
 
-        CertificateDetails validCertificate = aCertifcateDetail(ENTITY_ID, validCert, FederationEntityType.RP);
-        CertificateDetails invalidCertificate = aCertifcateDetail(ENTITY_ID, invalidCert, FederationEntityType.RP);
+        CertificateDetails validCertificate = aCertificateDetail(ENTITY_ID, validCert, FederationEntityType.RP);
+        CertificateDetails invalidCertificate = aCertificateDetail(ENTITY_ID, invalidCert, FederationEntityType.RP);
 
         when(matchingServiceDataSource.getData(ENTITY_ID)).thenReturn(Optional.empty());
         when(transactionDataSource.getData(ENTITY_ID)).thenReturn(Optional.of(transactionConfigEntityData));
@@ -197,8 +197,8 @@ public class CertificateServiceTest {
         List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificatonCertificatesFor(ENTITY_ID);
 
         assertThat(certificateDetailsFound.size()).isEqualTo(2);
-        assertThat(certificateDetailsFound).contains(aCertifcateDetail(ENTITY_ID, sigCert1, FederationEntityType.MS),
-                aCertifcateDetail(ENTITY_ID, sigCert2, FederationEntityType.MS));
+        assertThat(certificateDetailsFound).contains(aCertificateDetail(ENTITY_ID, sigCert1, FederationEntityType.MS),
+                aCertificateDetail(ENTITY_ID, sigCert2, FederationEntityType.MS));
     }
 
     @Test

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/MatchingServiceConfigEntityDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/MatchingServiceConfigEntityDataBuilder.java
@@ -1,15 +1,18 @@
 package uk.gov.ida.hub.config.domain.builders;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import uk.gov.ida.common.shared.configuration.X509CertificateConfiguration;
 import uk.gov.ida.hub.config.domain.EncryptionCertificate;
 import uk.gov.ida.hub.config.domain.MatchingServiceConfigEntityData;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
+import uk.gov.ida.hub.config.domain.X509Certificate;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static uk.gov.ida.hub.config.domain.builders.SignatureVerificationCertificateBuilder.aSignatureVerificationCertificate;
 
@@ -70,9 +73,8 @@ public class MatchingServiceConfigEntityDataBuilder {
         return this;
     }
 
+    @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
     private static class TestMatchingServiceConfigEntityData extends MatchingServiceConfigEntityData {
-        private final EncryptionCertificate encCertificate;
-        private final List<SignatureVerificationCertificate> sigCertificates;
 
         private TestMatchingServiceConfigEntityData(
             String entityId,
@@ -84,25 +86,14 @@ public class MatchingServiceConfigEntityDataBuilder {
             boolean onboarding) {
 
             this.entityId = entityId;
-            this.encryptionCertificate = new X509CertificateConfiguration(null, "test", null);
-            this.signatureVerificationCertificates = Collections.emptyList();
+            this.encryptionCertificate = new X509Certificate(encryptionCertificate.getX509());
+            this.signatureVerificationCertificates = signatureVerificationCertificates.stream().map(
+                    s -> new X509Certificate(s.getX509())
+            ).collect(Collectors.toList());
             this.uri = uri;
             this.userAccountCreationUri = userAccountCreationUri;
             this.healthCheckEnabled = healthCheckEnabled;
             this.onboarding = onboarding;
-
-            this.encCertificate = encryptionCertificate;
-            this.sigCertificates = signatureVerificationCertificates;
-        }
-
-        @Override
-        public EncryptionCertificate getEncryptionCertificate() {
-            return encCertificate;
-        }
-
-        @Override
-        public Collection<SignatureVerificationCertificate> getSignatureVerificationCertificates() {
-            return sigCertificates;
         }
     }
 }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/SignatureVerificationCertificateBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/SignatureVerificationCertificateBuilder.java
@@ -1,7 +1,7 @@
 package uk.gov.ida.hub.config.domain.builders;
 
-import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
+import uk.gov.ida.hub.config.domain.X509Certificate;
 
 import static java.text.MessageFormat.format;
 import static org.mockito.Mockito.mock;
@@ -18,7 +18,7 @@ public class SignatureVerificationCertificateBuilder {
 
     public SignatureVerificationCertificate build() {
         String fullCert = format("-----BEGIN CERTIFICATE-----\n{0}\n-----END CERTIFICATE-----", x509Value.trim());
-        DeserializablePublicKeyConfiguration configuration = mock(DeserializablePublicKeyConfiguration.class);
+        X509Certificate configuration = mock(X509Certificate.class);
         when(configuration.getCert()).thenReturn(fullCert);
         return new SignatureVerificationCertificate(configuration);
     }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.config.domain.builders;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import uk.gov.ida.common.shared.configuration.X509CertificateConfiguration;
 import uk.gov.ida.hub.config.domain.AssertionConsumerService;
 import uk.gov.ida.hub.config.domain.EncryptionCertificate;
@@ -8,6 +9,7 @@ import uk.gov.ida.hub.config.domain.MatchingProcess;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
 import uk.gov.ida.hub.config.domain.TransactionConfigEntityData;
 import uk.gov.ida.hub.config.domain.UserAccountCreationAttribute;
+import uk.gov.ida.hub.config.domain.X509Certificate;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -15,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static uk.gov.ida.hub.config.domain.builders.AssertionConsumerServiceBuilder.anAssertionConsumerService;
 
@@ -138,9 +141,8 @@ public class TransactionConfigEntityDataBuilder {
         return this;
     }
 
+    @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
     private static class TestTransactionConfigEntityData extends TransactionConfigEntityData {
-        private final EncryptionCertificate encCertificate;
-        private final List<SignatureVerificationCertificate> sigCertificates;
 
         private TestTransactionConfigEntityData(
                 String entityId,
@@ -159,8 +161,10 @@ public class TransactionConfigEntityDataBuilder {
             this.serviceHomepage = serviceHomepage;
             this.entityId = entityId;
             this.simpleId = simpleId;
-            this.encryptionCertificate = new X509CertificateConfiguration(null, "test", null);
-            this.signatureVerificationCertificates = Collections.emptyList();
+            this.encryptionCertificate = new X509Certificate(encryptionCertificate.getX509());
+            this.signatureVerificationCertificates = signatureVerificationCertificates.stream().map(
+                    s -> new X509Certificate(s.getX509())
+            ).collect(Collectors.toList());
             this.matchingServiceEntityId = matchingServiceEntityId;
             this.assertionConsumerServices = assertionConsumerServices;
             this.userAccountCreationAttributes = userAccountCreationAttributes;
@@ -169,19 +173,6 @@ public class TransactionConfigEntityDataBuilder {
             this.eidasEnabled = eidasEnabled;
             this.shouldHubSignResponseMessages = shouldHubSignResponseMessages;
             this.levelsOfAssurance = levelsOfAssurance;
-
-            this.encCertificate = encryptionCertificate;
-            this.sigCertificates = signatureVerificationCertificates;
-        }
-
-        @Override
-        public EncryptionCertificate getEncryptionCertificate() {
-            return encCertificate;
-        }
-
-        @Override
-        public Collection<SignatureVerificationCertificate> getSignatureVerificationCertificates() {
-            return sigCertificates;
         }
     }
 }

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -70,7 +70,7 @@ serviceInfo:
 readKeysFromFileDescriptors: false
 
 privateSigningKeyConfiguration:
-  type: base64
+  type: encoded
   key: ${HUB_SIGNING_KEY}
 
 publicSigningCert:
@@ -79,10 +79,10 @@ publicSigningCert:
   name: ${HUB_SIGNING_CERT_NAME}
 
 primaryPrivateEncryptionKeyConfiguration:
-  type: base64
+  type: encoded
   key: ${HUB_PRIMARY_ENC_KEY}
 secondaryPrivateEncryptionKeyConfiguration:
-  type: base64
+  type: encoded
   key: ${HUB_SECONDARY_ENC_KEY:}
 clientTrustStoreConfiguration:
   path: ${IDP_TRUSTSTORE_PATH}


### PR DESCRIPTION
Due to changes to the way DeserializablePublicKeyConfiguration works,
fed-config DTOs can no longer use that class to get certificates.
Due to an outstanding bug, we cannot use the specific subtype so
this commit ports the relevant class (and merges the abstract super)
to perform the same behaviour locally in hub.
To allow the DTO getters to remain the same, certificates are new-ed
inside the getters. This requires the base Certificate class to be
comparable to prevent referencing issues so an equals and hashCode
method were added

There is a plan to eventually migrate these DTOs to a database rather
than file backed system in which case this issue will be redundant