### PR TITLE
ABD-35: Add a feature toggle to send events to a recording system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ subprojects {
 
         rest_utils "uk.gov.ida:rest-utils:2.0.0-$dependencyVersions.rest_utils"
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-7"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-10"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils"

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
@@ -12,7 +12,6 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
-import uk.gov.ida.eventemitter.EventEmitterModule;
 import uk.gov.ida.hub.policy.domain.exception.SessionAlreadyExistingExceptionMapper;
 import uk.gov.ida.hub.policy.domain.exception.SessionCreationFailureExceptionMapper;
 import uk.gov.ida.hub.policy.domain.exception.SessionNotFoundExceptionMapper;
@@ -68,7 +67,7 @@ public class PolicyApplication extends Application<PolicyConfiguration> {
         // the infinispan cache manager needs to be lazy loaded because it is not initialized at this point.
         bootstrap.addBundle(infinispanBundle);
         guiceBundle = GuiceBundle.defaultBuilder(PolicyConfiguration.class)
-                .modules(new EventEmitterModule(), getPolicyModule(), bindInfinispan(infinispanBundle.getInfinispanCacheManagerProvider()))
+                .modules(getPolicyModule(), bindInfinispan(infinispanBundle.getInfinispanCacheManagerProvider()))
                 .build();
         bootstrap.addBundle(guiceBundle);
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -89,6 +89,10 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @JsonProperty
     public Boolean eidas = false;
 
+    @Valid
+    @JsonProperty
+    public boolean sendToRecordingSystem = false;
+
     public URI getSamlSoapProxyUri() { return samlSoapProxyUri;  }
 
     public org.joda.time.Duration getSessionLength() {
@@ -148,5 +152,9 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
 
     public boolean isEidasEnabled() {
         return eidas;
+    }
+
+    public boolean getSendToRecordingSystem() {
+        return sendToRecordingSystem;
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Environment;
 import org.joda.time.DateTime;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.common.shared.security.IdGenerator;
+import uk.gov.ida.eventemitter.EventEmitter;
 import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkProxy;
@@ -88,6 +89,12 @@ public class PolicyModule extends AbstractModule {
         bind(Cycle3Service.class);
         bind(MatchingServiceResponseService.class);
         bind(ResponseFromIdpHandler.class);
+    }
+
+    @Provides
+    @Singleton
+    public EventEmitter getEventEmitter(PolicyConfiguration configuration) {
+        return new EventEmitter(configuration.getSendToRecordingSystem());
     }
 
     @Provides

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/exception/PolicyApplicationExceptionMapper.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/exception/PolicyApplicationExceptionMapper.java
@@ -58,7 +58,11 @@ public class PolicyApplicationExceptionMapper extends PolicyExceptionMapper<Appl
         boolean isAudited = exception.isAudited();
 
         if (!isAudited && exception.requiresAuditing()) {
-            eventLogger.logErrorEvent(exception.getErrorId(), getSessionId().or(NO_SESSION_CONTEXT_IN_ERROR), exception.getMessage(), exception.getUri().or(URI.create("uri-not-present")).toASCIIString());
+            eventLogger.logErrorEvent(
+                exception.getErrorId(),
+                getSessionId().or(NO_SESSION_CONTEXT_IN_ERROR),
+                exception.getMessage(),
+                exception.getUri().or(URI.create("uri-not-present")).toASCIIString());
             isAudited = true;
         }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/logging/HubEventLogger.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/logging/HubEventLogger.java
@@ -77,7 +77,9 @@ public class HubEventLogger {
     private final EventEmitter eventEmitter;
 
     @Inject
-    public HubEventLogger(ServiceInfoConfiguration serviceInfo, EventSinkProxy eventSinkProxy, EventEmitter eventEmitter) {
+    public HubEventLogger(ServiceInfoConfiguration serviceInfo,
+                          EventSinkProxy eventSinkProxy,
+                          EventEmitter eventEmitter) {
         this.serviceInfo = serviceInfo;
         this.eventSinkProxy = eventSinkProxy;
         this.eventEmitter = eventEmitter;
@@ -262,14 +264,7 @@ public class HubEventLogger {
         final Map<EventDetailsKey, String> details = ImmutableMap.of(
             message, errorMessage,
             error_id, errorId.toString());
-        final EventSinkHubEvent eventSinkHubEvent = new EventSinkHubEvent(
-            serviceInfo,
-            sessionId,
-            EventSinkHubEventConstants.EventTypes.ERROR_EVENT,
-            details);
-
-        eventSinkProxy.logHubEvent(eventSinkHubEvent);
-        eventEmitter.record(eventSinkHubEvent);
+        logErrorEvent(details, sessionId);
     }
 
     public void logErrorEvent(final UUID errorId, final String entityId, final SessionId sessionId) {

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/PolicyApplicationTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/PolicyApplicationTest.java
@@ -1,0 +1,33 @@
+package uk.gov.ida.hub.policy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PolicyApplicationTest {
+
+    private final Environment environment = mock(Environment.class);
+    private final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
+    private final PolicyApplication application = new PolicyApplication();
+    private final PolicyConfiguration config = new PolicyConfiguration();
+    private final ObjectMapper objectMapper = mock(ObjectMapper.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(environment.jersey()).thenReturn(jersey);
+        when(environment.getObjectMapper()).thenReturn(objectMapper);
+    }
+
+    @Test
+    public void shouldReturnSendToRecordingSystemAsFalseByDefault() throws Exception {
+        application.run(config, environment);
+
+        assertThat(config.getSendToRecordingSystem()).isFalse();
+    }
+}

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
@@ -380,7 +380,6 @@ public class HubEventLoggerTest {
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
     }
 
-
     @Test
     public void shouldLogErrorEventContainingIDPEntityId() {
         final String idpEntityId = "IDP entity id";

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
@@ -10,7 +10,6 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
-import uk.gov.ida.eventemitter.EventEmitterModule;
 import uk.gov.ida.hub.samlproxy.exceptions.NoKeyConfiguredForEntityExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyApplicationExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyExceptionMapper;
@@ -52,7 +51,7 @@ public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
         );
 
         guiceBundle = defaultBuilder(SamlProxyConfiguration.class)
-                .modules(new EventEmitterModule(),new SamlProxyModule())
+                .modules(new SamlProxyModule())
                 .build();
         bootstrap.addBundle(guiceBundle);
         bootstrap.addBundle(new ServiceStatusBundle());

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -95,6 +95,10 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @JsonProperty
     protected CountryConfiguration country;
 
+    @Valid
+    @JsonProperty
+    public boolean sendToRecordingSystem = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -152,5 +156,9 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
 
     public Optional<CountryConfiguration> getCountryConfiguration() {
         return country != null ? Optional.of(country) : Optional.empty();
+    }
+
+    public boolean getSendToRecordingSystem() {
+        return sendToRecordingSystem;
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -18,6 +18,7 @@ import uk.gov.ida.common.shared.security.PublicKeyInputStreamFactory;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.PKIXParametersProvider;
+import uk.gov.ida.eventemitter.EventEmitter;
 import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkMessageSender;
@@ -127,6 +128,12 @@ public class SamlProxyModule extends AbstractModule {
         bind(SamlMessageSenderHandler.class);
         bind(ExternalCommunicationEventLogger.class);
         bind(IpAddressResolver.class).toInstance(new IpAddressResolver());
+    }
+
+    @Provides
+    @Singleton
+    public EventEmitter getEventEmitter(SamlProxyConfiguration configuration) {
+        return new EventEmitter(configuration.getSendToRecordingSystem());
     }
 
     @Provides

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/SamlProxyApplicationTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/SamlProxyApplicationTest.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.hub.samlproxy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.jetty.setup.ServletEnvironment;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.ida.hub.samlproxy.filters.SessionIdQueryParamLoggingFilter;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SamlProxyApplicationTest {
+    private final Environment environment = mock(Environment.class);
+    private final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
+    private final SamlProxyApplication application = new SamlProxyApplication();
+    private final SamlProxyConfiguration config = new SamlProxyConfiguration();
+    private final ObjectMapper objectMapper = mock(ObjectMapper.class);
+    private final ServletEnvironment servletEnvironment = mock(ServletEnvironment.class);
+    private final FilterRegistration.Dynamic dynamic = mock(FilterRegistration.Dynamic.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(environment.jersey()).thenReturn(jersey);
+        when(environment.getObjectMapper()).thenReturn(objectMapper);
+        when(environment.servlets()).thenReturn(servletEnvironment);
+        when(servletEnvironment.addFilter("Logging SessionId registration Filter", SessionIdQueryParamLoggingFilter.class)).thenReturn(dynamic);
+        doNothing().when(dynamic).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+    }
+
+    @Test
+    public void shouldReturnSendToRecordingSystemAsFalseByDefault() throws Exception {
+        application.run(config, environment);
+
+        assertThat(config.getSendToRecordingSystem()).isFalse();
+    }
+}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplication.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplication.java
@@ -10,7 +10,6 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
-import uk.gov.ida.eventemitter.EventEmitterModule;
 import uk.gov.ida.hub.samlsoapproxy.exceptions.IdaJsonProcessingExceptionMapperBundle;
 import uk.gov.ida.hub.samlsoapproxy.filters.SessionIdQueryParamLoggingFilter;
 import uk.gov.ida.hub.samlsoapproxy.resources.AttributeQueryRequestSenderResource;
@@ -48,7 +47,7 @@ public class SamlSoapProxyApplication extends Application<SamlSoapProxyConfigura
 
         bootstrap.addBundle(new IdaJsonProcessingExceptionMapperBundle());
         guiceBundle = defaultBuilder(SamlSoapProxyConfiguration.class)
-                .modules(new SamlSoapProxyModule(), new EventEmitterModule())
+                .modules(new SamlSoapProxyModule())
                 .build();
         bootstrap.addBundle(guiceBundle);
         bootstrap.addBundle(new ServiceStatusBundle());

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -92,6 +92,10 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
+    @Valid
+    @JsonProperty
+    public boolean sendToRecordingSystem = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -155,4 +159,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Override
     public boolean getEnableRetryTimeOutConnections() { return enableRetryTimeOutConnections; }
 
+    public boolean getSendToRecordingSystem() {
+        return sendToRecordingSystem;
+    }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -20,6 +20,7 @@ import uk.gov.ida.common.shared.security.PublicKeyInputStreamFactory;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.PKIXParametersProvider;
+import uk.gov.ida.eventemitter.EventEmitter;
 import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkProxy;
@@ -134,6 +135,12 @@ public class SamlSoapProxyModule extends AbstractModule {
         bind(IpAddressResolver.class).toInstance(new IpAddressResolver());
         bind(TimeoutEvaluator.class).toInstance(new TimeoutEvaluator());
         bind(MetadataHealthCheckRegistry.class).asEagerSingleton();
+    }
+
+    @Provides
+    @Singleton
+    public EventEmitter getEventEmitter(SamlSoapProxyConfiguration configuration) {
+        return new EventEmitter(configuration.getSendToRecordingSystem());
     }
 
     @Provides

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplicationTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplicationTest.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.hub.samlsoapproxy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.jetty.setup.ServletEnvironment;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.ida.hub.samlsoapproxy.filters.SessionIdQueryParamLoggingFilter;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SamlSoapProxyApplicationTest {
+    private final Environment environment = mock(Environment.class);
+    private final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
+    private final SamlSoapProxyApplication application = new SamlSoapProxyApplication();
+    private final SamlSoapProxyConfiguration config = new SamlSoapProxyConfiguration();
+    private final ObjectMapper objectMapper = mock(ObjectMapper.class);
+    private final ServletEnvironment servletEnvironment = mock(ServletEnvironment.class);
+    private final FilterRegistration.Dynamic dynamic = mock(FilterRegistration.Dynamic.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(environment.jersey()).thenReturn(jersey);
+        when(environment.getObjectMapper()).thenReturn(objectMapper);
+        when(environment.servlets()).thenReturn(servletEnvironment);
+        when(servletEnvironment.addFilter("Logging SessionId registration Filter", SessionIdQueryParamLoggingFilter.class)).thenReturn(dynamic);
+        doNothing().when(dynamic).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+    }
+
+    @Test
+    public void shouldReturnSendToRecordingSystemAsFalseByDefault() throws Exception {
+        application.run(config, environment);
+
+        assertThat(config.getSendToRecordingSystem()).isFalse();
+    }
+}


### PR DESCRIPTION
Adding a configurable toggle to policy, saml soap proxy and saml proxy to send or not to send events to a new recording system (not Event Sink). The default is not to send events to the recording system since the recording system is not set up in production at this moment. Please note that this change does not affect Hub sending events to Event Sink. 

Authors: @adityapahuja