### PR TITLE
ABD-35: Update an integration test to include event emitter

### DIFF
--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
@@ -469,12 +469,12 @@ public class HubEventLoggerTest {
                 return false;
             }
             EventSinkHubEvent actualEvent = (EventSinkHubEvent) other;
-            return
+            return !actualEvent.getEventId().toString().isEmpty() &&
                 Objects.equals(expectedEvent.getTimestamp(), actualEvent.getTimestamp()) &&
-                    Objects.equals(expectedEvent.getOriginatingService(), actualEvent.getOriginatingService()) &&
-                    Objects.equals(expectedEvent.getSessionId(), actualEvent.getSessionId()) &&
-                    Objects.equals(expectedEvent.getEventType(), actualEvent.getEventType()) &&
-                    Objects.equals(expectedEvent.getDetails(), actualEvent.getDetails());
+                Objects.equals(expectedEvent.getOriginatingService(), actualEvent.getOriginatingService()) &&
+                Objects.equals(expectedEvent.getSessionId(), actualEvent.getSessionId()) &&
+                Objects.equals(expectedEvent.getEventType(), actualEvent.getEventType()) &&
+                Objects.equals(expectedEvent.getDetails(), actualEvent.getDetails());
         }
     }
 }

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLoggerTest.java
@@ -147,12 +147,12 @@ public class ExternalCommunicationEventLoggerTest {
                 return false;
             }
             EventSinkHubEvent actualEvent = (EventSinkHubEvent) other;
-            return
+            return !actualEvent.getEventId().toString().isEmpty() &&
                 Objects.equals(expectedEvent.getTimestamp(), actualEvent.getTimestamp()) &&
-                    Objects.equals(expectedEvent.getOriginatingService(), actualEvent.getOriginatingService()) &&
-                    Objects.equals(expectedEvent.getSessionId(), actualEvent.getSessionId()) &&
-                    Objects.equals(expectedEvent.getEventType(), actualEvent.getEventType()) &&
-                    Objects.equals(expectedEvent.getDetails(), actualEvent.getDetails());
+                Objects.equals(expectedEvent.getOriginatingService(), actualEvent.getOriginatingService()) &&
+                Objects.equals(expectedEvent.getSessionId(), actualEvent.getSessionId()) &&
+                Objects.equals(expectedEvent.getEventType(), actualEvent.getEventType()) &&
+                Objects.equals(expectedEvent.getDetails(), actualEvent.getDetails());
         }
     }
 }

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/logging/ExternalCommunicationEventLoggerTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/logging/ExternalCommunicationEventLoggerTest.java
@@ -145,12 +145,12 @@ public class ExternalCommunicationEventLoggerTest {
                 return false;
             }
             EventSinkHubEvent actualEvent = (EventSinkHubEvent) other;
-            return
+            return !actualEvent.getEventId().toString().isEmpty() &&
                 Objects.equals(expectedEvent.getTimestamp(), actualEvent.getTimestamp()) &&
-                    Objects.equals(expectedEvent.getOriginatingService(), actualEvent.getOriginatingService()) &&
-                    Objects.equals(expectedEvent.getSessionId(), actualEvent.getSessionId()) &&
-                    Objects.equals(expectedEvent.getEventType(), actualEvent.getEventType()) &&
-                    Objects.equals(expectedEvent.getDetails(), actualEvent.getDetails());
+                Objects.equals(expectedEvent.getOriginatingService(), actualEvent.getOriginatingService()) &&
+                Objects.equals(expectedEvent.getSessionId(), actualEvent.getSessionId()) &&
+                Objects.equals(expectedEvent.getEventType(), actualEvent.getEventType()) &&
+                Objects.equals(expectedEvent.getDetails(), actualEvent.getDetails());
         }
     }
 }


### PR DESCRIPTION
This integration test ensures that Hub can send events to Event Emitter without any errors.
Update unit tests to ensure that event id is present in an event message before sending it to Event Sink and Event Emitter.

Authors: @adityapahuja