### PR TITLE
ABD-35: Upgrade to use latest version of rest-utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,10 @@ ext {
 
 def dependencyVersions = [
             ida_utils:'323',
-            // rest_utils:'330' has been added to dependency temporarily for enabling Hub to send events using event emitter.
-            // Upgrading ida_utils to 330 breaks verify-hub. The fix for this issue is still being developed. Once the fix is completed,
-            // rest_utils will be removed from the dependency.
-            rest_utils:'330',
+            // rest_utils has been added to dependency temporarily for enabling Hub to send events using event emitter.
+            // Upgrading ida_utils to the latest version breaks verify-hub. The fix for this issue is still being developed.
+            // Once the fix is completed, rest_utils will be removed from the dependency.
+            rest_utils:'332',
             dropwizard:'1.1.4',
             dropwizard_infinispan:'1.1.4-41',
             pact:'3.5.6',
@@ -99,7 +99,7 @@ subprojects {
 
         rest_utils "uk.gov.ida:rest-utils:2.0.0-$dependencyVersions.rest_utils"
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-10"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-30"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils"

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionTimeoutIntegrationTests.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionTimeoutIntegrationTests.java
@@ -65,8 +65,7 @@ public class SessionTimeoutIntegrationTests {
             ConfigOverride.config("samlEngineUri", samlEngineStub.baseUri().build().toASCIIString()),
             ConfigOverride.config("configUri", configStub.baseUri().build().toASCIIString()),
             ConfigOverride.config("eventSinkUri", eventSinkStub.baseUri().build().toASCIIString()),
-            ConfigOverride.config("timeoutPeriod", format("{0}m", SOME_TIMEOUT)),
-            ConfigOverride.config("sendToRecordingSystem", "true"));
+            ConfigOverride.config("timeoutPeriod", format("{0}m", SOME_TIMEOUT)));
 
     private SamlAuthnRequestContainerDto samlRequest;
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.hub.policy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.ida.eventemitter.Configuration;
+
+import javax.validation.Valid;
+
+public class EventEmitterConfiguration implements Configuration {
+
+    @Valid
+    @JsonProperty
+    private String sourceQueueName;
+
+    private EventEmitterConfiguration() { }
+
+    public EventEmitterConfiguration(String sourceQueueName) {
+        this.sourceQueueName = sourceQueueName;
+    }
+
+    @Override
+    public String getSourceQueueName() {
+        return sourceQueueName;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
@@ -12,6 +12,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
+import uk.gov.ida.eventemitter.EventEmitterModule;
 import uk.gov.ida.hub.policy.domain.exception.SessionAlreadyExistingExceptionMapper;
 import uk.gov.ida.hub.policy.domain.exception.SessionCreationFailureExceptionMapper;
 import uk.gov.ida.hub.policy.domain.exception.SessionNotFoundExceptionMapper;
@@ -67,7 +68,7 @@ public class PolicyApplication extends Application<PolicyConfiguration> {
         // the infinispan cache manager needs to be lazy loaded because it is not initialized at this point.
         bootstrap.addBundle(infinispanBundle);
         guiceBundle = GuiceBundle.defaultBuilder(PolicyConfiguration.class)
-                .modules(getPolicyModule(), bindInfinispan(infinispanBundle.getInfinispanCacheManagerProvider()))
+                .modules(getPolicyModule(), new EventEmitterModule(),  bindInfinispan(infinispanBundle.getInfinispanCacheManagerProvider()))
                 .build();
         bootstrap.addBundle(guiceBundle);
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -91,7 +91,7 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
 
     @Valid
     @JsonProperty
-    public boolean sendToRecordingSystem = false;
+    public EventEmitterConfiguration eventEmitterConfiguration;
 
     public URI getSamlSoapProxyUri() { return samlSoapProxyUri;  }
 
@@ -154,7 +154,7 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
         return eidas;
     }
 
-    public boolean getSendToRecordingSystem() {
-        return sendToRecordingSystem;
+    public EventEmitterConfiguration getEventEmitterConfiguration() {
+        return eventEmitterConfiguration;
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -8,7 +8,7 @@ import io.dropwizard.setup.Environment;
 import org.joda.time.DateTime;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.common.shared.security.IdGenerator;
-import uk.gov.ida.eventemitter.EventEmitter;
+import uk.gov.ida.eventemitter.Configuration;
 import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkProxy;
@@ -53,6 +53,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.KeyStore;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
 public class PolicyModule extends AbstractModule {
@@ -92,9 +93,8 @@ public class PolicyModule extends AbstractModule {
     }
 
     @Provides
-    @Singleton
-    public EventEmitter getEventEmitter(PolicyConfiguration configuration) {
-        return new EventEmitter(configuration.getSendToRecordingSystem());
+    private Optional<Configuration> getEventEmitterConfiguration(final PolicyConfiguration configuration) {
+        return Optional.ofNullable(configuration.getEventEmitterConfiguration());
     }
 
     @Provides

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/PolicyApplicationTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/PolicyApplicationTest.java
@@ -25,9 +25,9 @@ public class PolicyApplicationTest {
     }
 
     @Test
-    public void shouldReturnSendToRecordingSystemAsFalseByDefault() throws Exception {
+    public void shouldReturnEventEmitterConfigurationAsNullByDefault() throws Exception {
         application.run(config, environment);
 
-        assertThat(config.getSendToRecordingSystem()).isFalse();
+        assertThat(config.getEventEmitterConfiguration()).isNull();
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.hub.samlproxy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.ida.eventemitter.Configuration;
+
+import javax.validation.Valid;
+
+public class EventEmitterConfiguration implements Configuration {
+
+    @Valid
+    @JsonProperty
+    private String sourceQueueName;
+
+    private EventEmitterConfiguration() { }
+
+    public EventEmitterConfiguration(String sourceQueueName) {
+        this.sourceQueueName = sourceQueueName;
+    }
+
+    @Override
+    public String getSourceQueueName() {
+        return sourceQueueName;
+    }
+}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
@@ -10,6 +10,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
+import uk.gov.ida.eventemitter.EventEmitterModule;
 import uk.gov.ida.hub.samlproxy.exceptions.NoKeyConfiguredForEntityExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyApplicationExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyExceptionMapper;
@@ -51,7 +52,7 @@ public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
         );
 
         guiceBundle = defaultBuilder(SamlProxyConfiguration.class)
-                .modules(new SamlProxyModule())
+                .modules(new SamlProxyModule(), new EventEmitterModule())
                 .build();
         bootstrap.addBundle(guiceBundle);
         bootstrap.addBundle(new ServiceStatusBundle());

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -97,7 +97,7 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
 
     @Valid
     @JsonProperty
-    public boolean sendToRecordingSystem = false;
+    public EventEmitterConfiguration eventEmitterConfiguration;
 
     public SamlConfiguration getSamlConfiguration() {
         return saml;
@@ -158,7 +158,7 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
         return country != null ? Optional.of(country) : Optional.empty();
     }
 
-    public boolean getSendToRecordingSystem() {
-        return sendToRecordingSystem;
+    public EventEmitterConfiguration getEventEmitterConfiguration() {
+        return eventEmitterConfiguration;
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -18,7 +18,7 @@ import uk.gov.ida.common.shared.security.PublicKeyInputStreamFactory;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.PKIXParametersProvider;
-import uk.gov.ida.eventemitter.EventEmitter;
+import uk.gov.ida.eventemitter.Configuration;
 import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkMessageSender;
@@ -131,9 +131,8 @@ public class SamlProxyModule extends AbstractModule {
     }
 
     @Provides
-    @Singleton
-    public EventEmitter getEventEmitter(SamlProxyConfiguration configuration) {
-        return new EventEmitter(configuration.getSendToRecordingSystem());
+    private Optional<Configuration> getEventEmitterConfiguration(final SamlProxyConfiguration configuration) {
+        return Optional.ofNullable(configuration.getEventEmitterConfiguration());
     }
 
     @Provides

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/SamlProxyApplicationTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/SamlProxyApplicationTest.java
@@ -36,9 +36,9 @@ public class SamlProxyApplicationTest {
     }
 
     @Test
-    public void shouldReturnSendToRecordingSystemAsFalseByDefault() throws Exception {
+    public void shouldReturnEventEmitterConfigurationAsNullByDefault() throws Exception {
         application.run(config, environment);
 
-        assertThat(config.getSendToRecordingSystem()).isFalse();
+        assertThat(config.getEventEmitterConfiguration()).isNull();
     }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.hub.samlsoapproxy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.ida.eventemitter.Configuration;
+
+import javax.validation.Valid;
+
+public class EventEmitterConfiguration implements Configuration {
+
+    @Valid
+    @JsonProperty
+    private String sourceQueueName;
+
+    private EventEmitterConfiguration() { }
+
+    public EventEmitterConfiguration(String sourceQueueName) {
+        this.sourceQueueName = sourceQueueName;
+    }
+
+    @Override
+    public String getSourceQueueName() {
+        return sourceQueueName;
+    }
+}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplication.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplication.java
@@ -10,6 +10,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
+import uk.gov.ida.eventemitter.EventEmitterModule;
 import uk.gov.ida.hub.samlsoapproxy.exceptions.IdaJsonProcessingExceptionMapperBundle;
 import uk.gov.ida.hub.samlsoapproxy.filters.SessionIdQueryParamLoggingFilter;
 import uk.gov.ida.hub.samlsoapproxy.resources.AttributeQueryRequestSenderResource;
@@ -47,7 +48,7 @@ public class SamlSoapProxyApplication extends Application<SamlSoapProxyConfigura
 
         bootstrap.addBundle(new IdaJsonProcessingExceptionMapperBundle());
         guiceBundle = defaultBuilder(SamlSoapProxyConfiguration.class)
-                .modules(new SamlSoapProxyModule())
+                .modules(new SamlSoapProxyModule(), new EventEmitterModule())
                 .build();
         bootstrap.addBundle(guiceBundle);
         bootstrap.addBundle(new ServiceStatusBundle());

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -94,7 +94,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
 
     @Valid
     @JsonProperty
-    public boolean sendToRecordingSystem = false;
+    public EventEmitterConfiguration eventEmitterConfiguration;
 
     public SamlConfiguration getSamlConfiguration() {
         return saml;
@@ -159,7 +159,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Override
     public boolean getEnableRetryTimeOutConnections() { return enableRetryTimeOutConnections; }
 
-    public boolean getSendToRecordingSystem() {
-        return sendToRecordingSystem;
+    public EventEmitterConfiguration getEventEmitterConfiguration() {
+        return eventEmitterConfiguration;
     }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -20,7 +20,7 @@ import uk.gov.ida.common.shared.security.PublicKeyInputStreamFactory;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.PKIXParametersProvider;
-import uk.gov.ida.eventemitter.EventEmitter;
+import uk.gov.ida.eventemitter.Configuration;
 import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkProxy;
@@ -83,6 +83,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.cert.CertificateException;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
@@ -138,9 +139,8 @@ public class SamlSoapProxyModule extends AbstractModule {
     }
 
     @Provides
-    @Singleton
-    public EventEmitter getEventEmitter(SamlSoapProxyConfiguration configuration) {
-        return new EventEmitter(configuration.getSendToRecordingSystem());
+    private Optional<Configuration> getEventEmitterConfiguration(final SamlSoapProxyConfiguration configuration) {
+        return Optional.ofNullable(configuration.getEventEmitterConfiguration());
     }
 
     @Provides

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplicationTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplicationTest.java
@@ -36,9 +36,9 @@ public class SamlSoapProxyApplicationTest {
     }
 
     @Test
-    public void shouldReturnSendToRecordingSystemAsFalseByDefault() throws Exception {
+    public void shouldReturnEventEmitterConfigurationAsNullByDefault() throws Exception {
         application.run(config, environment);
 
-        assertThat(config.getSendToRecordingSystem()).isFalse();
+        assertThat(config.getEventEmitterConfiguration()).isNull();
     }
 }


### PR DESCRIPTION
The latest version of rest-utils supports the ability to send encrypted events to either a source queue or a stub queue. If the source queue name is not present, encrypted event messages will be sent to the stub queue. If the source queue is present, encrypted event messages will be sent to the source queue. The stub queue will just write the encrypted event message to the standard output.

Authors: @adityapahuja