### PR TITLE
refactor: use a `NullResponseAssertionSigner`

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/CryptoModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/CryptoModule.java
@@ -39,7 +39,6 @@ public class CryptoModule extends AbstractModule {
         bind(EncryptionCredentialFactory.class);
         bind(KeyStoreCache.class);
         bind(KeyStoreLoader.class).toInstance(new KeyStoreLoader());
-        bind(SignatureFactory.class);
         bind(IdaKeyStoreCredentialRetriever.class);
         bind(SamlResponseAssertionEncrypter.class);
         bind(AssertionBlobEncrypter.class);

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -66,6 +66,7 @@ import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
 import uk.gov.ida.saml.core.transformers.outbound.decorators.AssertionBlobEncrypter;
 import uk.gov.ida.saml.core.transformers.outbound.decorators.AssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.NullResponseAssertionSigner;
 import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
 import uk.gov.ida.saml.core.validators.DestinationValidator;
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
@@ -172,7 +173,7 @@ public class SamlEngineModule extends AbstractModule {
         bind(SimpleProfileOutboundResponseFromHubToResponseTransformerProvider.class);
         bind(SimpleProfileOutboundResponseFromHubToSamlResponseTransformer.class);
         bind(ResponseToUnsignedStringTransformer.class);
-        bind(ResponseAssertionSigner.class);
+        bind(ResponseAssertionSigner.class).toInstance(new NullResponseAssertionSigner());
         bind(SimpleProfileTransactionIdaStatusMarshaller.class);
         bind(IdpAuthnResponseTranslatorService.class);
         bind(InboundResponseFromIdpDataGenerator.class);

--- a/hub/saml-engine/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/NullResponseAssertionSigner.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/NullResponseAssertionSigner.java
@@ -1,0 +1,14 @@
+package uk.gov.ida.saml.core.transformers.outbound.decorators;
+
+import org.opensaml.saml.saml2.core.Response;
+
+public class NullResponseAssertionSigner extends ResponseAssertionSigner {
+    public NullResponseAssertionSigner() {
+        super(null);
+    }
+
+    @Override
+    public Response signAssertions(Response response) {
+        return response;
+    }
+}


### PR DESCRIPTION
Saml Engine should not be able to sign assertions in Responses so it shouldn't be
using an Assertion signer. This should be updated in `verify-hub-saml`
but for now I'm quick fixing it here by using a NullObject version.