### PR TITLE
refactor: assert metadata directly in tests

### DIFF
--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/HubMetadataIntegrationTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/HubMetadataIntegrationTests.java
@@ -11,29 +11,29 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
 import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
 import uk.gov.ida.common.shared.security.Certificate;
 import uk.gov.ida.hub.samlproxy.domain.SamlDto;
 import uk.gov.ida.integrationtest.hub.samlproxy.apprule.support.SamlProxyAppRule;
-import uk.gov.ida.saml.core.api.CoreTransformersFactory;
-import uk.gov.ida.saml.deserializers.ElementToOpenSamlXMLObjectTransformer;
-import uk.gov.ida.saml.hub.api.HubTransformersFactory;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.deserializers.OpenSamlXMLObjectUnmarshaller;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
 import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 import uk.gov.ida.shared.utils.xml.XmlUtils;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.UriBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
-import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_FOUR;
-import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_ONE;
-import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_THREE;
-import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_TWO;
+import static uk.gov.ida.saml.core.test.TestEntityIds.*;
 
 public class HubMetadataIntegrationTests {
 
@@ -41,6 +41,8 @@ public class HubMetadataIntegrationTests {
     public static final SamlProxyAppRule samlProxyAppRule = new SamlProxyAppRule();
 
     public static Client client;
+
+    private final SamlObjectParser samlObjectParser = new SamlObjectParser();
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -63,41 +65,63 @@ public class HubMetadataIntegrationTests {
         final DateTime time = DateTime.now(DateTimeZone.UTC).plusHours(1);
 
         SamlDto samlDto = client.target(UriBuilder.fromUri(samlProxyAppRule.getUri("/API/metadata/idp"))).request().get(SamlDto.class);
-        Function<Element, HubIdentityProviderMetadataDto> transformer = new HubTransformersFactory().getMetadataForSpTransformer(HUB_ENTITY_ID);
-        final Element element = XmlUtils.convertToElement(samlDto.getSaml());
-        HubIdentityProviderMetadataDto identityProviderMetadataDto = transformer.apply(element);
-        thenAssertIdpMetadataDto(time, identityProviderMetadataDto);
+
+        EntityDescriptor entityDescriptor = getEntityDescriptor(samlDto);
+        assertThat(entityDescriptor.getEntityID()).isEqualTo(HUB_ENTITY_ID);
+        assertThat(entityDescriptor.getSPSSODescriptor(SAMLConstants.SAML20P_NS)).isNull();
+        assertThat(entityDescriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS)).isNotNull();
+        List<KeyDescriptor> keyDescriptors = entityDescriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS).getKeyDescriptors();
+
+        //this is a bit fragile and dependent on the ordering of IDPs and in federation metadata
+        //this endpoint should be removed soon though...
+        assertThat(keyDescriptors).hasSize(7);
+
+        //signing certificates
+        validateKeyDescriptor(keyDescriptors, 0, HUB_ENTITY_ID);
+        validateKeyDescriptor(keyDescriptors, 1, HUB_ENTITY_ID, TestCertificateStrings.PUBLIC_SIGNING_CERTS.get(HUB_SECONDARY_ENTITY_ID));
+        validateKeyDescriptor(keyDescriptors, 2, STUB_IDP_ONE);
+        validateKeyDescriptor(keyDescriptors, 3, STUB_IDP_TWO);
+        validateKeyDescriptor(keyDescriptors, 4, STUB_IDP_THREE);
+        validateKeyDescriptor(keyDescriptors, 5, STUB_IDP_FOUR);
+
+
+        //encryption certificate
+        assertThat(getKeyName(keyDescriptors, 6)).isEqualTo(HUB_ENTITY_ID);
+        assertThat(getCertificateData(keyDescriptors, 6)).isEqualTo(TestCertificateStrings.getPrimaryPublicEncryptionCert(HUB_ENTITY_ID));
+
+        assertThat(entityDescriptor.getValidUntil()).isEqualTo(DateTime.now(DateTimeZone.UTC).plusHours(1));
+    }
+
+    private void validateKeyDescriptor(List<KeyDescriptor> keyDescriptors, int index, String issuer) {
+        validateKeyDescriptor(keyDescriptors, index, issuer, TestCertificateStrings.PUBLIC_SIGNING_CERTS.get(issuer));
+    }
+
+    private void validateKeyDescriptor(List<KeyDescriptor> keyDescriptors, int index, String issuer, String certificate) {
+        assertThat(getKeyName(keyDescriptors, index)).isEqualTo(issuer);
+        assertThat(getCertificateData(keyDescriptors, index)).isEqualTo(certificate);
+    }
+
+    private String getKeyName(List<KeyDescriptor> keyDescriptors, int index) {
+        return keyDescriptors.get(index).getKeyInfo().getKeyNames().get(0).getValue();
+    }
+
+    private String getCertificateData(List<KeyDescriptor> keyDescriptors, int index) {
+        return keyDescriptors.get(index).getKeyInfo().getX509Datas().get(0).getX509Certificates().get(0).getValue();
+    }
+
+    private EntityDescriptor getEntityDescriptor(SamlDto samlDto) {
+        return new OpenSamlXMLObjectUnmarshaller<EntityDescriptor>(samlObjectParser).fromString(samlDto.getSaml());
     }
 
     @Test
     public void getSpMetadataFromApi_shouldReturnTheHubFromNewMetadataAsAnSp() throws Exception {
         SamlDto samlDto = client.target(UriBuilder.fromUri(samlProxyAppRule.getUri("/API/metadata/sp"))).request().get(SamlDto.class);
-        final Element element = XmlUtils.convertToElement(samlDto.getSaml());
-        ElementToOpenSamlXMLObjectTransformer<EntityDescriptor> elementToOpenSamlXmlObjectTransformer = new CoreTransformersFactory().<EntityDescriptor>getElementToOpenSamlXmlObjectTransformer();
-        EntityDescriptor entityDescriptor = elementToOpenSamlXmlObjectTransformer.apply(element);
+        EntityDescriptor entityDescriptor = getEntityDescriptor(samlDto);
+
         assertThat(entityDescriptor.getEntityID()).isEqualTo(HUB_ENTITY_ID);
         assertThat(entityDescriptor.getSPSSODescriptor(SAMLConstants.SAML20P_NS)).isNotNull();
         assertThat(entityDescriptor.getSPSSODescriptor(SAMLConstants.SAML20P_NS).getAssertionConsumerServices().get(0).getLocation()).isEqualTo("http://foo.com/bar");
         assertThat(entityDescriptor.getValidUntil()).isEqualTo(DateTime.now(DateTimeZone.UTC).plusHours(1));
-    }
-
-    private void thenAssertIdpMetadataDto(
-            DateTime validUntil,
-            HubIdentityProviderMetadataDto metadata
-    ) {
-        assertThat(metadata.getEntityId()).isEqualTo(HUB_ENTITY_ID);
-
-        assertThat(metadata.getSigningCertificates()).hasSize(2);
-        assertThat(metadata.getSigningCertificates().get(0).getIssuerId()).isEqualTo(HUB_ENTITY_ID);
-        assertThat(metadata.getSigningCertificates().get(1).getIssuerId()).isEqualTo(HUB_ENTITY_ID);
-
-        List<String> idpIssuerIds = metadata.getIdpSigningCertificates().stream()
-                .map(Certificate::getIssuerId)
-                .collect(Collectors.toList());
-
-        assertThat(idpIssuerIds).containsOnly(STUB_IDP_ONE, STUB_IDP_TWO, STUB_IDP_THREE, STUB_IDP_FOUR);
-
-        assertThat(metadata.getValidUntil()).isEqualTo(validUntil);
     }
 
 }

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/HubMetadataIntegrationTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/HubMetadataIntegrationTests.java
@@ -115,6 +115,7 @@ public class HubMetadataIntegrationTests {
         EntityDescriptor entityDescriptor = getEntityDescriptor(samlDto);
 
         assertThat(entityDescriptor.getEntityID()).isEqualTo(HUB_ENTITY_ID);
+        assertThat(entityDescriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS)).isNull();
         assertThat(entityDescriptor.getSPSSODescriptor(SAMLConstants.SAML20P_NS)).isNotNull();
         assertThat(entityDescriptor.getSPSSODescriptor(SAMLConstants.SAML20P_NS).getAssertionConsumerServices().get(0).getLocation()).isEqualTo("http://foo.com/bar");
         assertThat(entityDescriptor.getValidUntil()).isEqualTo(DateTime.now(DateTimeZone.UTC).plusHours(1));

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/HubMetadataIntegrationTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/HubMetadataIntegrationTests.java
@@ -12,28 +12,24 @@ import org.junit.Test;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.KeyDescriptor;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
-import uk.gov.ida.common.shared.security.Certificate;
 import uk.gov.ida.hub.samlproxy.domain.SamlDto;
 import uk.gov.ida.integrationtest.hub.samlproxy.apprule.support.SamlProxyAppRule;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.deserializers.OpenSamlXMLObjectUnmarshaller;
-import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
-import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
-import uk.gov.ida.shared.utils.xml.XmlUtils;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.UriBuilder;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ida.saml.core.test.TestEntityIds.*;
+import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
+import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_SECONDARY_ENTITY_ID;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_FOUR;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_ONE;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_THREE;
+import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_TWO;
 
 public class HubMetadataIntegrationTests {
 


### PR DESCRIPTION
rather than coverting to a custom Dto object and then comparing it's not
difficult to instead read the Saml object as an `EntityDescriptor` and
then assert on the things we care about.

This should allow us to delete a bunch of dead code in verify-hub-saml.