### PR TITLE
bau: make sure metadata refresh tasks are available on admin port

### DIFF
--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/MetadataRefreshTaskIntegrationTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/MetadataRefreshTaskIntegrationTest.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.integrationtest.hub.samlengine;
+
+import helpers.JerseyClientConfigurationBuilder;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetadataRefreshTaskIntegrationTest {
+    
+    private static Client client;
+
+    @ClassRule
+    public static SamlEngineAppRule samlEngineAppRule = new SamlEngineAppRule();
+
+    @BeforeClass
+    public static void setUpClass() {
+        JerseyClientConfiguration jerseyClientConfiguration = JerseyClientConfigurationBuilder.aJerseyClientConfiguration().withTimeout(Duration.seconds(10)).build();
+        client = new JerseyClientBuilder(samlEngineAppRule.getEnvironment()).using(jerseyClientConfiguration).build(MetadataRefreshTaskIntegrationTest.class.getSimpleName());
+    }
+
+    @Test
+    public void verifyFederationMetadataRefreshTaskWorks() {
+        final Response response = client.target(UriBuilder.fromUri("http://localhost")
+                .path("/tasks/metadata-refresh")
+                .port(samlEngineAppRule.getAdminPort())
+                .build())
+                .request()
+                .post(Entity.text("refresh!"));
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void eidasConnectorMetadataRefreshTaskWorks() {
+        final Response response = client.target(UriBuilder.fromUri("http://localhost")
+                .path("/tasks/connector-metadata-refresh")
+                .port(samlEngineAppRule.getAdminPort())
+                .build())
+                .request()
+                .post(Entity.text("refresh!"));
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+}

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/MetadataRefreshTaskIntegrationTest.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/MetadataRefreshTaskIntegrationTest.java
@@ -1,0 +1,60 @@
+package uk.gov.ida.integrationtest.hub.samlproxy;
+
+import helpers.JerseyClientConfigurationBuilder;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.integrationtest.hub.samlproxy.apprule.support.CountryMetadataRule;
+import uk.gov.ida.integrationtest.hub.samlproxy.apprule.support.SamlProxyAppRule;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetadataRefreshTaskIntegrationTest {
+    
+    private static Client client;
+
+    private static final String COUNTRY_ENTITY_ID = "/metadata/country";
+
+    @ClassRule
+    public static final CountryMetadataRule countryMetadata = new CountryMetadataRule(COUNTRY_ENTITY_ID);
+
+    @ClassRule
+    public static SamlProxyAppRule samlProxyAppRule = new SamlProxyAppRule(config("country.metadata.uri", countryMetadata.getCountryMetadataUri()));
+
+    @BeforeClass
+    public static void setUpClass() {
+        JerseyClientConfiguration jerseyClientConfiguration = JerseyClientConfigurationBuilder.aJerseyClientConfiguration().withTimeout(Duration.seconds(10)).build();
+        client = new JerseyClientBuilder(samlProxyAppRule.getEnvironment()).using(jerseyClientConfiguration).build(MetadataRefreshTaskIntegrationTest.class.getSimpleName());
+    }
+
+    @Test
+    public void verifyFederationMetadataRefreshTaskWorks() {
+        final Response response = client.target(UriBuilder.fromUri("http://localhost")
+                .path("/tasks/metadata-refresh")
+                .port(samlProxyAppRule.getAdminPort())
+                .build())
+                .request()
+                .post(Entity.text("refresh!"));
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void eidasConnectorMetadataRefreshTaskWorks() {
+        final Response response = client.target(UriBuilder.fromUri("http://localhost")
+                .path("/tasks/connector-metadata-refresh")
+                .port(samlProxyAppRule.getAdminPort())
+                .build())
+                .request()
+                .post(Entity.text("refresh!"));
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -1,12 +1,15 @@
 package uk.gov.ida.hub.samlproxy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
+import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
@@ -62,6 +65,7 @@ import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
 import uk.gov.ida.saml.metadata.HubMetadataPublicKeyStore;
 import uk.gov.ida.saml.metadata.IdpMetadataPublicKeyStore;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
+import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 import uk.gov.ida.saml.security.CredentialFactorySignatureValidator;
@@ -82,6 +86,7 @@ import uk.gov.ida.truststore.TrustStoreConfiguration;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
@@ -139,7 +144,9 @@ public class SamlProxyModule extends AbstractModule {
     @Singleton
     @Named("VerifyMetadataResolver")
     public MetadataResolver getVerifyMetadataResolver(Environment environment, SamlProxyConfiguration configuration) {
-        return new DropwizardMetadataResolverFactory().createMetadataResolver(environment, configuration.getMetadataConfiguration());
+        final MetadataResolver metadataResolver = new DropwizardMetadataResolverFactory().createMetadataResolver(environment, configuration.getMetadataConfiguration());
+        registerMetadataRefreshTask(environment, metadataResolver, configuration.getMetadataConfiguration(), "metadata");
+        return metadataResolver;
     }
 
     @Provides
@@ -193,7 +200,11 @@ public class SamlProxyModule extends AbstractModule {
     @Singleton
     @Named("CountryMetadataResolver")
     public Optional<MetadataResolver> getCountryMetadataResolver(Environment environment, SamlProxyConfiguration configuration) {
-        return configuration.getCountryConfiguration().map(config -> new DropwizardMetadataResolverFactory().createMetadataResolver(environment, config.getMetadataConfiguration()));
+        final Optional<MetadataResolver> metadataResolver = configuration.getCountryConfiguration().map(config -> new DropwizardMetadataResolverFactory().createMetadataResolver(environment, config.getMetadataConfiguration()));
+        if(metadataResolver.isPresent()) {
+            registerMetadataRefreshTask(environment, metadataResolver.get(), configuration.getCountryConfiguration().get().getMetadataConfiguration(), "connector-metadata");
+        }
+        return metadataResolver;
     }
 
     @Provides
@@ -381,5 +392,14 @@ public class SamlProxyModule extends AbstractModule {
     @Provides
     public ServiceInfoConfiguration serviceInfoConfiguration(SamlProxyConfiguration samlProxyConfiguration) {
         return samlProxyConfiguration.getServiceInfo();
+    }
+
+    private void registerMetadataRefreshTask(Environment environment, MetadataResolver metadataResolver, MetadataResolverConfiguration metadataResolverConfiguration, String name) {
+        environment.admin().addTask(new Task(name + "-refresh") {
+            @Override
+            public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+                ((AbstractReloadingMetadataResolver) metadataResolver).refresh();
+            }
+        });
     }
 }

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MetadataRefreshTaskIntegrationTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MetadataRefreshTaskIntegrationTest.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule;
+
+import helpers.JerseyClientConfigurationBuilder;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlSoapProxyAppRule;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetadataRefreshTaskIntegrationTest {
+    
+    private static Client client;
+
+    @ClassRule
+    public static SamlSoapProxyAppRule samlSoapProxyAppRule = new SamlSoapProxyAppRule();
+
+    @BeforeClass
+    public static void setUpClass() {
+        JerseyClientConfiguration jerseyClientConfiguration = JerseyClientConfigurationBuilder.aJerseyClientConfiguration().withTimeout(Duration.seconds(10)).build();
+        client = new JerseyClientBuilder(samlSoapProxyAppRule.getEnvironment()).using(jerseyClientConfiguration).build(MetadataRefreshTaskIntegrationTest.class.getSimpleName());
+    }
+
+    @Test
+    public void verifyFederationMetadataRefreshTaskWorks() {
+        final Response response = client.target(UriBuilder.fromUri("http://localhost")
+                .path("/tasks/metadata-refresh")
+                .port(samlSoapProxyAppRule.getAdminPort())
+                .build())
+                .request()
+                .post(Entity.text("refresh!"));
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+}


### PR DESCRIPTION
These seem to have been removed?

Pair: WillPa