### PR TITLE
BAU: Use a later version of the SAML libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-38",
             opensaml:"$opensaml_version3",
             dev_pki: '1.1.0-21',
-            saml_metadata_bindings:"$opensaml_version3-103",
+            saml_metadata_bindings:"$opensaml_version3-104",
             hub_saml:"$opensaml_version3-120"
         ]
 


### PR DESCRIPTION
It contains changes in metadata bindings to make the eIDAS metadata resolver factory thread safe.