### PR TITLE
bau: fix threaded race condition

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/EidasValidatorFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/EidasValidatorFactory.java
@@ -19,8 +19,6 @@ import java.util.List;
 
 public class EidasValidatorFactory {
 
-    private SamlResponseSignatureValidator samlResponseSignatureValidator;
-    private SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
     private EidasMetadataResolverRepository eidasMetadataResolverRepository;
 
     @Inject
@@ -29,12 +27,12 @@ public class EidasValidatorFactory {
     }
 
     public ValidatedResponse getValidatedResponse(Response response) {
-        samlResponseSignatureValidator = new SamlResponseSignatureValidator(getSamlMessageSignatureValidator(response.getIssuer().getValue()));
+        SamlResponseSignatureValidator samlResponseSignatureValidator = new SamlResponseSignatureValidator(getSamlMessageSignatureValidator(response.getIssuer().getValue()));
         return samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     public void getValidatedAssertion(ValidatedResponse validatedResponse, List<Assertion> decryptedAssertions) {
-        samlAssertionsSignatureValidator = new SamlAssertionsSignatureValidator(getSamlMessageSignatureValidator(validatedResponse.getIssuer().getValue()));
+        SamlAssertionsSignatureValidator samlAssertionsSignatureValidator = new SamlAssertionsSignatureValidator(getSamlMessageSignatureValidator(validatedResponse.getIssuer().getValue()));
         samlAssertionsSignatureValidator.validate(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/factories/EidasValidatorFactory.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/factories/EidasValidatorFactory.java
@@ -14,7 +14,6 @@ import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValida
 
 public class EidasValidatorFactory {
 
-    private SamlResponseSignatureValidator samlResponseSignatureValidator;
     private EidasMetadataResolverRepository metadataResolverRepository;
 
     @Inject
@@ -24,7 +23,7 @@ public class EidasValidatorFactory {
 
     public ValidatedResponse getValidatedResponse(Response response) {
         String entityId = response.getIssuer().getValue();
-        samlResponseSignatureValidator = new SamlResponseSignatureValidator(getSamlMessageSignatureValidator(entityId));
+        SamlResponseSignatureValidator samlResponseSignatureValidator = new SamlResponseSignatureValidator(getSamlMessageSignatureValidator(entityId));
         return samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 


### PR DESCRIPTION
There was a race condition in `EidasValidatorFactory` where it was assigning
signature validators into member fields when validating an eidas
signature. Two calls to the validate functions from different threads
could lead to the wrong validator being used on a message.