### PR TITLE
TT-2120: Transition state before sending matching request

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/Cycle3Service.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/Cycle3Service.java
@@ -25,8 +25,11 @@ public class Cycle3Service {
         String attributeName = controller.getCycle3AttributeRequestData().getAttributeName();
         Cycle3Dataset cycle3Dataset = Cycle3Dataset.createFromData(attributeName, cycle3UserInput.getCycle3Input());
         AbstractAttributeQueryRequestDto attributeQuery = controller.createAttributeQuery(cycle3Dataset);
-        attributeQueryService.sendAttributeQueryRequest(sessionId, attributeQuery);
+
+        // NOTE: transitioning the state before sending the matching request avoids a race condition
+        // where the MSA responds before the new state has been replicated across the policy instances.
         controller.handleCycle3DataSubmitted(cycle3UserInput.getPrincipalIpAddress());
+        attributeQueryService.sendAttributeQueryRequest(sessionId, attributeQuery);
     }
 
     public void cancelCycle3DataInput(SessionId sessionId) {


### PR DESCRIPTION
This avoids a potential race condition where the MSA responds to Verify
before the states in Policy have finished replicating.

The states in Policy are stored in a distributed cache, which has
synchronous writes. If we update the state before sending the matching
request it will block until all instances of Policy have updated their
state. This avoids the situation where a matching response arrives at an
instance of Policy which is still in a state where that is not
permissible.

This commit does have a potentially negative impact on the error
handling in the situation where the call to `sendAttributeQueryRequest`
fails. Previously the user would remain in `AwaitingCycle3InputState`,
which would have allowed them to recover from this error by (e.g.)
clicking back on the Something Went Wrong page. Now the user will be in
`Cycle3RequestSentState` even if the request was not successful. It's
not immediately obvious what this would mean from the point of view of
frontend, but it's likely they might end up looking at the matching
spinner for a minute until matching times out and they end up in an
error state. We (@willp-bl and I) think the risk and impact of this
hazard are low enough that it's worth making this change anyway.