### PR TITLE
BAU: Merge hub-saml repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,19 +5,19 @@ buildscript {
     dependencies {
         classpath 'com.github.spullara.mustache.java:compiler:0.8.10',
                 'org.yaml:snakeyaml:1.10',
+                'uk.gov.ida:ida-gradle:1.1.0-20',
                 'com.google.guava:guava:14.0.1',
                 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     }
 }
 
-//apply from: 'idea.gradle'
-//apply from: 'publish.gradle'
+apply from: 'idea.gradle'
+apply from: 'publish.gradle'
 apply plugin: 'java'
-apply plugin: 'idea'
 apply plugin: 'com.github.ben-manes.versions'
 
 ext {
-    opensaml_version3 = '3.3.0'
+    opensaml_version = '3.3.0'
 }
 
 def dependencyVersions = [
@@ -25,16 +25,16 @@ def dependencyVersions = [
             dropwizard:'1.1.4',
             dropwizard_infinispan:'1.1.4-41',
             pact:'3.5.6',
-            stub_idp_saml:"$opensaml_version3-68",
+            stub_idp_saml:"$opensaml_version-68",
             ida_test_utils:"2.0.0-38",
-            opensaml:"$opensaml_version3",
+            opensaml:"$opensaml_version",
             dev_pki: '1.1.0-21',
-            saml_libs:"$opensaml_version3-112",
-            hub_saml:"$opensaml_version3-123"
+            saml_libs:"$opensaml_version-112",
         ]
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'idaJar'
 
     group = "uk.gov.ida"
     version = "0.1.$version"
@@ -145,6 +145,14 @@ subprojects {
 
         soap('org.apache.ws.commons:ws-commons-util:1.0.1') { transitive = false }
     }
+}
+
+task(outputDependencies) doLast {
+    println "hub_saml="+dependencyVersions.hub_saml
+    println "saml_metadata="+dependencyVersions.saml_metadata
+    println "rest_utils="+dependencyVersions.rest_utils
+    println "ida_utils="+dependencyVersions.ida_utils
+    println "dropwizard_infinispan="+dependencyVersions.dropwizard_infinispan
 }
 
 import javax.crypto.Cipher

--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,15 @@ buildscript {
     dependencies {
         classpath 'com.github.spullara.mustache.java:compiler:0.8.10',
                 'org.yaml:snakeyaml:1.10',
-                'uk.gov.ida:ida-gradle:1.1.0-20',
                 'com.google.guava:guava:14.0.1',
                 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     }
 }
 
-apply from: 'idea.gradle'
+//apply from: 'idea.gradle'
+//apply from: 'publish.gradle'
 apply plugin: 'java'
+apply plugin: 'idea'
 apply plugin: 'com.github.ben-manes.versions'
 
 ext {
@@ -20,11 +21,7 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'323',
-            // rest_utils has been added to dependency temporarily for enabling Hub to send events using event emitter.
-            // Upgrading ida_utils to the latest version breaks verify-hub. The fix for this issue is still being developed.
-            // Once the fix is completed, rest_utils will be removed from the dependency.
-            rest_utils:'332',
+            ida_utils:'332',
             dropwizard:'1.1.4',
             dropwizard_infinispan:'1.1.4-41',
             pact:'3.5.6',
@@ -32,13 +29,12 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-38",
             opensaml:"$opensaml_version3",
             dev_pki: '1.1.0-21',
-            saml_metadata_bindings:"$opensaml_version3-109",
-            hub_saml:"$opensaml_version3-124"
+            saml_libs:"$opensaml_version3-112",
+            hub_saml:"$opensaml_version3-123"
         ]
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'idaJar'
 
     group = "uk.gov.ida"
     version = "0.1.$version"
@@ -74,17 +70,18 @@ subprojects {
         dropwizard_infinispan
         integrationtests
         config
-        rest_utils
         verify_event_emitter
         ida_utils
         ida_test_utils
         dev_pki
         trust_anchor
+        saml_libs
     }
 
     dependencies {
 
-        common 'joda-time:joda-time:2.3'
+        common 'joda-time:joda-time:2.3',
+                'com.google.inject:guice:4.0'
 
         dropwizard 'io.dropwizard:dropwizard-core:' + dependencyVersions.dropwizard,
                 'io.dropwizard:dropwizard-client:' + dependencyVersions.dropwizard,
@@ -97,12 +94,11 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        rest_utils "uk.gov.ida:rest-utils:2.0.0-$dependencyVersions.rest_utils"
-
         verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-31"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
-                "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils"
+                "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",
+                "uk.gov.ida:rest-utils:2.0.0-$dependencyVersions.ida_utils"
 
         ida_test_utils "uk.gov.ida:common-test-utils:$dependencyVersions.ida_test_utils"
 
@@ -111,19 +107,17 @@ subprojects {
         dropwizard_infinispan "uk.gov.ida:dropwizard-infinispan:$dependencyVersions.dropwizard_infinispan"
 
         saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
-             "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_metadata_bindings",
-             "uk.gov.ida:hub-saml:$dependencyVersions.hub_saml"
+             "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_libs",
+             project(":hub-saml")
 
         trust_anchor "uk.gov.ida.eidas:trust-anchor:1.0-19"
 
-        stub_saml_test("uk.gov.ida:stub-idp-saml-test:$dependencyVersions.stub_idp_saml") {
-            changing = true
-            exclude group: "uk.gov.ida"
-        }
-        saml_test("uk.gov.ida:hub-saml-test-utils:$dependencyVersions.hub_saml") {
-            changing = true
-            exclude group: "uk.gov.ida"
-        }
+        stub_saml_test "uk.gov.ida:stub-idp-saml-test:$dependencyVersions.stub_idp_saml"
+
+        saml_test project(":hub-saml-test-utils")
+
+        saml_libs "uk.gov.ida:saml-utils:$dependencyVersions.saml_libs",
+                "uk.gov.ida:saml-extensions:$dependencyVersions.saml_libs"
 
         pact_test "au.com.dius:pact-jvm-consumer-junit_2.11:$dependencyVersions.pact",
                 "au.com.dius:pact-jvm-consumer_2.11:$dependencyVersions.pact",
@@ -141,7 +135,7 @@ subprojects {
                 'org.json:json:20170516',
                 'com.jayway.awaitility:awaitility:1.6.0',
                 'com.github.tomakehurst:wiremock:2.16.0',
-                "uk.gov.ida:saml-metadata-bindings-test:$dependencyVersions.saml_metadata_bindings",
+                "uk.gov.ida:saml-metadata-bindings-test:$dependencyVersions.saml_libs",
                 'io.dropwizard:dropwizard-testing:' + dependencyVersions.dropwizard]
 
         test_deps_deps.each { dep ->
@@ -151,14 +145,6 @@ subprojects {
 
         soap('org.apache.ws.commons:ws-commons-util:1.0.1') { transitive = false }
     }
-}
-
-task(outputDependencies) doLast {
-    println "hub_saml="+dependencyVersions.hub_saml
-    println "saml_metadata="+dependencyVersions.saml_metadata
-    println "rest_utils="+dependencyVersions.rest_utils
-    println "ida_utils="+dependencyVersions.ida_utils
-    println "dropwizard_infinispan="+dependencyVersions.dropwizard_infinispan
 }
 
 import javax.crypto.Cipher

--- a/configuration/local/saml-engine.yml
+++ b/configuration/local/saml-engine.yml
@@ -101,9 +101,9 @@ country:
     entityId: http://localhost:55000/local-connector/metadata.xml
     expectedDestination: http://localhost:50300/SAML2/SSO/EidasResponse/POST
   metadata:
-    trustAnchorUri: http://localhost:55000/local/trust-anchor.jws 
+    trustAnchorUri: http://localhost:50140/stub-country/ServiceMetadata
     trustStore:
-      store: truststores/ida_truststore.ts
+      store: truststores/country_metadata_truststore.ts
       trustStorePassword: password
     minRefreshDelay: 5000
     maxRefreshDelay: 60000

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -72,9 +72,9 @@ metadata:
 
 country:
   metadata:
-    trustAnchorUri: http://localhost:55000/local/trust-anchor.jws
+    trustAnchorUri: http://localhost:50140/stub-country/ServiceMetadata
     trustStore:
-      store: truststores/ida_truststore.ts
+      store: truststores/country_metadata_truststore.ts
       trustStorePassword: password
     minRefreshDelay: 5000
     maxRefreshDelay: 60000

--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    compile configurations.common,
+            configurations.test_deps_compile,
+            project(':hub-saml')
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/AuthnRequestFactory.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/AuthnRequestFactory.java
@@ -1,0 +1,95 @@
+package uk.gov.ida.saml.core.test;
+
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import uk.gov.ida.saml.core.test.builders.AuthnRequestBuilder;
+import uk.gov.ida.saml.core.test.builders.IssuerBuilder;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class AuthnRequestFactory {
+    private final Function<AuthnRequest, String> authnRequestToStringTransformer;
+
+    public AuthnRequestFactory(Function<AuthnRequest, String> authnRequestToStringTransformer) {
+        this.authnRequestToStringTransformer = authnRequestToStringTransformer;
+    }
+
+    public String anAuthnRequest(
+            String id,
+            String issuer,
+            Optional<Boolean> forceAuthentication,
+            Optional<URI> assertionConsumerServiceUrl,
+            Optional<Integer> assertionConsumerServiceIndex,
+            String publicCert,
+            String privateKey,
+            String ssoRequestEndpoint,
+            Optional<DateTime> issueInstant) {
+        AuthnRequest authnRequest = getAuthnRequest(
+                id,
+                issuer,
+                forceAuthentication,
+                assertionConsumerServiceUrl,
+                assertionConsumerServiceIndex,
+                publicCert,
+                privateKey,
+                ssoRequestEndpoint,
+                issueInstant);
+        return authnRequestToStringTransformer.apply(authnRequest);
+    }
+
+    private AuthnRequest getAuthnRequest(
+            String id,
+            String issuer,
+            Optional<Boolean> forceAuthentication,
+            Optional<URI> assertionConsumerServiceUrl,
+            Optional<Integer> assertionConsumerServiceIndex,
+            String publicCert,
+            String privateKey,
+            String ssoRequestEndpoint,
+            Optional<DateTime> issueInstant) {
+        AuthnRequestBuilder authnRequestBuilder = AuthnRequestBuilder.anAuthnRequest()
+                .withId(id)
+                .withIssuer(IssuerBuilder.anIssuer().withIssuerId(issuer).build())
+                .withDestination("http://localhost" + ssoRequestEndpoint)
+                .withSigningCredential(new TestCredentialFactory(publicCert, privateKey).getSigningCredential());
+
+        forceAuthentication.ifPresent(authnRequestBuilder::withForceAuthn);
+        assertionConsumerServiceIndex.ifPresent(authnRequestBuilder::withAssertionConsumerServiceIndex);
+        assertionConsumerServiceUrl.ifPresent(uri -> authnRequestBuilder.withAssertionConsumerServiceUrl(uri.toString()));
+        issueInstant.ifPresent(authnRequestBuilder::withIssueInstant);
+
+        return authnRequestBuilder.build();
+    }
+
+    public String anInvalidAuthnRequest(
+            String id,
+            String issuer,
+            Optional<Boolean> forceAuthentication,
+            Optional<URI> assertionConsumerServiceUrl,
+            Optional<Integer> assertionConsumerServiceIndex,
+            String publicCert,
+            String privateKey,
+            String ssoRequestEndpoint,
+            Optional<DateTime> issueInstant) {
+        // Pad ID to ensure request is long enough
+        AuthnRequest authnRequest = getAuthnRequest(
+                StringUtils.rightPad(id, 1200, "x"),
+                issuer,
+                forceAuthentication,
+                assertionConsumerServiceUrl,
+                assertionConsumerServiceIndex,
+                publicCert,
+                privateKey,
+                ssoRequestEndpoint,
+                issueInstant);
+        authnRequest.setSignature(null);
+        // Use a different transformer to ensure that no Signature elements are added
+        XmlObjectToBase64EncodedStringTransformer<XMLObject> transformer = new XmlObjectToBase64EncodedStringTransformer<>();
+        return transformer.apply(authnRequest);
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/AuthnRequestIdGenerator.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/AuthnRequestIdGenerator.java
@@ -1,0 +1,11 @@
+package uk.gov.ida.saml.core.test;
+
+import java.util.UUID;
+
+public final class AuthnRequestIdGenerator {
+    private AuthnRequestIdGenerator() {}
+
+    public static String generateRequestId() {
+        return "_" + UUID.randomUUID().toString();
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/HardCodedKeyStore.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/HardCodedKeyStore.java
@@ -1,0 +1,78 @@
+package uk.gov.ida.saml.core.test;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import org.apache.commons.codec.binary.Base64;
+import uk.gov.ida.common.shared.security.InternalPublicKeyStore;
+import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.PublicKeyInputStreamFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.saml.security.EncryptionKeyStore;
+import uk.gov.ida.saml.security.SigningKeyStore;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HardCodedKeyStore implements SigningKeyStore, EncryptionKeyStore, InternalPublicKeyStore, PublicKeyInputStreamFactory {
+
+    private final PublicKeyFactory publicKeyFactory = new PublicKeyFactory(new X509CertificateFactory());
+    private final String entityId;
+
+    public HardCodedKeyStore(String whoAmI) {
+        this.entityId = whoAmI;
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity(String entityId) {
+        List<String> certs = Arrays.asList(TestCertificateStrings.PUBLIC_SIGNING_CERTS.get(entityId));
+        return certs.stream().map(cert -> publicKeyFactory.createPublicKey(cert)).collect(Collectors.toList());
+    }
+
+    @Override
+    public PublicKey getEncryptionKeyForEntity(String entityId) {
+        return getPrimaryEncryptionKeyForEntity(entityId);
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity() {
+        return getVerifyingKeysForEntity(this.entityId);
+    }
+
+    @Override
+    public InputStream createInputStream(String publicKeyUri) {
+        switch (publicKeyUri) {
+            case "../deploy/keys/test-rp.crt":
+                return new ByteArrayInputStream(TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT.getBytes());
+            case "../deploy/keys/test-rp.pk8":
+                return new ByteArrayInputStream(Base64.decodeBase64(TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY));
+            case "../deploy/keys/hub_encryption.crt":
+                return new ByteArrayInputStream(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT.getBytes());
+            case "../deploy/keys/hub_signing.crt":
+                return new ByteArrayInputStream(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT.getBytes());
+            case "../deploy/keys/hub_encryption.pk8":
+                return new ByteArrayInputStream(Base64.decodeBase64(TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY));
+            case "../deploy/keys/hub_signing.pk8":
+                return new ByteArrayInputStream(Base64.decodeBase64(TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY));
+            default:
+                throw new RuntimeException("Cert not found: " + publicKeyUri);
+        }
+    }
+
+    public PublicKey getPrimaryEncryptionKeyForEntity(String entityId) {
+        String cert = TestCertificateStrings.getPrimaryPublicEncryptionCert(entityId);
+
+        return publicKeyFactory.createPublicKey(cert);
+    }
+
+    public PublicKey getSecondaryEncryptionKeyForEntity(String entityId) {
+        String cert = TestCertificateStrings.getSecondaryPublicEncryptionCert(entityId);
+
+        return publicKeyFactory.createPublicKey(cert);
+    }
+
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/PrivateKeyStoreFactory.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/PrivateKeyStoreFactory.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.core.test;
+
+import org.apache.commons.codec.binary.Base64;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.PrivateKeyStore;
+
+import java.security.PrivateKey;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class PrivateKeyStoreFactory {
+    public PrivateKeyStore create(String entityId) {
+        PrivateKey privateSigningKey = new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(TestCertificateStrings.PRIVATE_SIGNING_KEYS.get(entityId)));
+        List<String> encryptionKeyStrings = TestCertificateStrings.PRIVATE_ENCRYPTION_KEYS.get(entityId);
+        List<PrivateKey> privateEncryptionKeys = encryptionKeyStrings.stream()
+            .map(input -> new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(input)))
+            .collect(toList());
+        return new PrivateKeyStore(privateSigningKey, privateEncryptionKeys);
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/SamlTransformationErrorManagerTestHelper.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/SamlTransformationErrorManagerTestHelper.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.saml.core.test;
+
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public final class SamlTransformationErrorManagerTestHelper {
+
+    private SamlTransformationErrorManagerTestHelper() {
+    }
+
+    public static void validateFail(Action action, SamlValidationSpecificationFailure failure) {
+        try {
+            action.execute();
+            fail("Expected action to throw");
+        } catch (SamlTransformationErrorException e) {
+            assertThat(e.getMessage()).isEqualTo(failure.getErrorMessage());
+            assertThat(e.getLogLevel()).isEqualTo(failure.getLogLevel());
+        }
+    }
+
+    public interface Action {
+        void execute();
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionRestrictionsBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AssertionRestrictionsBuilder.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+
+public class AssertionRestrictionsBuilder {
+
+    private DateTime notOnOrAfter = DateTime.now().plusDays(2);
+    private String inResponseTo = "default-in-response-to";
+    private String recipient = "recipient";
+
+    public static AssertionRestrictionsBuilder anAssertionRestrictions() {
+        return new AssertionRestrictionsBuilder();
+    }
+
+    public AssertionRestrictions build() {
+        return new AssertionRestrictions(
+                notOnOrAfter,
+                inResponseTo,
+                recipient);
+    }
+
+    public AssertionRestrictionsBuilder withNotOnOrAfter(DateTime notOnOrAfter) {
+        this.notOnOrAfter = notOnOrAfter;
+        return this;
+    }
+
+    public AssertionRestrictionsBuilder withInResponseTo(String inResponseTo) {
+        this.inResponseTo = inResponseTo;
+        return this;
+    }
+
+    public AssertionRestrictionsBuilder withRecipient(String recipient) {
+        this.recipient = recipient;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AttributeQueryBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AttributeQueryBuilder.java
@@ -1,0 +1,94 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.opensaml.xmlsec.signature.support.Signer;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Throwables.propagate;
+
+public class AttributeQueryBuilder {
+
+    private Optional<Signature> signature = Optional.fromNullable(SignatureBuilder.aSignature().build());
+    private boolean shouldSign = true;
+    private Optional<Subject> subject = Optional.fromNullable(SubjectBuilder.aSubject().build());
+    private Optional<Issuer> issuer = Optional.fromNullable(IssuerBuilder.anIssuer().build());
+    private Optional<String> id = Optional.fromNullable("anId");
+    private List<Attribute> attributes = new ArrayList<>();
+
+    public static AttributeQueryBuilder anAttributeQuery() {
+        return new AttributeQueryBuilder();
+    }
+
+    public AttributeQuery build() {
+        AttributeQuery attributeQuery = new OpenSamlXmlObjectFactory().createAttributeQuery();
+
+        if (subject.isPresent()) {
+            attributeQuery.setSubject(subject.get());
+        }
+
+        if (issuer.isPresent()) {
+            attributeQuery.setIssuer(issuer.get());
+        }
+
+        if (id.isPresent()) {
+            attributeQuery.setID(id.get());
+        }
+
+        if (signature.isPresent()) {
+            attributeQuery.setSignature(signature.get());
+            try {
+                XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(attributeQuery).marshall(attributeQuery);
+                if (shouldSign) {
+                    Signer.signObject(attributeQuery.getSignature());
+                }
+            } catch (MarshallingException | SignatureException e) {
+                throw propagate(e);
+            }
+        }
+
+        attributeQuery.getAttributes().addAll(attributes);
+
+        return attributeQuery;
+    }
+
+    public AttributeQueryBuilder withSubject(Subject subject) {
+        this.subject = Optional.fromNullable(subject);
+        return this;
+    }
+
+    public AttributeQueryBuilder withoutSigning() {
+        shouldSign = false;
+        return this;
+    }
+
+    public AttributeQueryBuilder withId(String id) {
+        this.id = Optional.fromNullable(id);
+        return this;
+    }
+
+    public AttributeQueryBuilder withIssuer(Issuer issuer) {
+        this.issuer = Optional.fromNullable(issuer);
+        return this;
+    }
+
+    public AttributeQueryBuilder withAttributes(List<Attribute> attributes){
+        this.attributes = attributes;
+        return this;
+    }
+
+    public AttributeQueryBuilder withSignature(Signature signature) {
+        this.signature = Optional.fromNullable(signature);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AttributeStatementBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AttributeStatementBuilder.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AttributeStatementBuilder {
+
+    private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private List<Attribute> attributes = new ArrayList<>();
+
+    public static AttributeStatementBuilder anAttributeStatement() {
+        return new AttributeStatementBuilder();
+    }
+
+    public AttributeStatement build() {
+        AttributeStatement attributeStatement = openSamlXmlObjectFactory.createAttributeStatement();
+
+        attributeStatement.getAttributes().addAll(attributes);
+
+        return attributeStatement;
+    }
+
+    public AttributeStatementBuilder addAttribute(Attribute attribute) {
+        this.attributes.add(attribute);
+        return this;
+    }
+
+    public AttributeStatementBuilder addAllAttributes(List<Attribute> attributes) {
+        this.attributes.addAll(attributes);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AudienceRestrictionBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AudienceRestrictionBuilder.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+
+public class AudienceRestrictionBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private String audienceId = TestEntityIds.HUB_ENTITY_ID;
+
+    public static AudienceRestrictionBuilder anAudienceRestriction() {
+        return new AudienceRestrictionBuilder();
+    }
+
+    public AudienceRestriction build() {
+        return openSamlXmlObjectFactory.createAudienceRestriction(audienceId);
+    }
+
+    public AudienceRestrictionBuilder withAudienceId(String audienceId) {
+        this.audienceId = audienceId;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AuthnContextBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AuthnContextBuilder.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.AuthnContext;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+
+public class AuthnContextBuilder {
+
+
+    private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private AuthnContextClassRef authnContextClassRef = anAuthnContextClassRef().build();
+
+    public static AuthnContextBuilder anAuthnContext() {
+        return new AuthnContextBuilder();
+    }
+
+    public AuthnContext build() {
+        AuthnContext authnContext = openSamlXmlObjectFactory.createAuthnContext();
+        authnContext.setAuthnContextClassRef(authnContextClassRef);
+        return authnContext;
+    }
+
+    public AuthnContextBuilder withAuthnContextClassRef(AuthnContextClassRef authnContextClassRef) {
+        this.authnContextClassRef = authnContextClassRef;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AuthnContextClassRefBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/AuthnContextClassRefBuilder.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
+
+public class AuthnContextClassRefBuilder {
+
+    private String value = IdaAuthnContext.LEVEL_2_AUTHN_CTX;
+
+    public static AuthnContextClassRefBuilder anAuthnContextClassRef() {
+        return new AuthnContextClassRefBuilder();
+    }
+
+    public AuthnContextClassRefBuilder withAuthnContextClasRefValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public AuthnContextClassRef build() {
+        return new OpenSamlXmlObjectFactory().createAuthnContextClassReference(value);
+    }
+
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/CertificateBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/CertificateBuilder.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import uk.gov.ida.common.shared.security.Certificate;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+
+public class CertificateBuilder {
+
+    private boolean useCertificateOfIssuerId = true;
+    private String issuerId = TestCertificateStrings.TEST_ENTITY_ID;
+    private String certificate = null;
+    private Certificate.KeyUse keyUse = Certificate.KeyUse.Signing;
+
+    public static CertificateBuilder aCertificate() {
+        return new CertificateBuilder();
+    }
+
+    public Certificate build() {
+        if (useCertificateOfIssuerId) {
+            if (keyUse == Certificate.KeyUse.Signing) {
+                certificate = TestCertificateStrings.PUBLIC_SIGNING_CERTS.get(issuerId);
+            } else {
+                certificate = TestCertificateStrings.getPrimaryPublicEncryptionCert(issuerId);
+            }
+            if (certificate == null) {
+                certificate = "Some certificate";
+            }
+        }
+        return new Certificate(issuerId, certificate, keyUse);
+    }
+
+    public CertificateBuilder withIssuerId(String issuerID) {
+        this.issuerId = issuerID;
+        return this;
+    }
+
+    public CertificateBuilder withCertificate(String certificate) {
+        useCertificateOfIssuerId = false;
+        this.certificate = certificate;
+        return this;
+    }
+
+    public CertificateBuilder withKeyUse(Certificate.KeyUse keyUse) {
+        this.keyUse = keyUse;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ConditionsBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ConditionsBuilder.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import org.opensaml.saml.saml2.core.Conditions;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static uk.gov.ida.saml.core.test.builders.AudienceRestrictionBuilder.anAudienceRestriction;
+
+public class ConditionsBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private List<AudienceRestriction> audienceRestrictions = new ArrayList<>();
+    private AudienceRestriction defaultAudienceRestriction = anAudienceRestriction().build();
+    private boolean shouldIncludeDefaultAudienceRestriction = true;
+
+    public static ConditionsBuilder aConditions() {
+        return new ConditionsBuilder();
+    }
+
+    public Conditions build() {
+        Conditions conditions = openSamlXmlObjectFactory.createConditions();
+
+        if (shouldIncludeDefaultAudienceRestriction) {
+            audienceRestrictions.add(defaultAudienceRestriction);
+        }
+        conditions.getAudienceRestrictions().addAll(audienceRestrictions);
+
+        return conditions;
+    }
+
+    public ConditionsBuilder withoutDefaultAudienceRestriction() {
+        shouldIncludeDefaultAudienceRestriction = false;
+        return this;
+    }
+
+    public ConditionsBuilder addAudienceRestriction(AudienceRestriction audienceRestriction) {
+        shouldIncludeDefaultAudienceRestriction = false;
+        audienceRestrictions.add(audienceRestriction);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ContactPersonDtoBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ContactPersonDtoBuilder.java
@@ -1,0 +1,79 @@
+package uk.gov.ida.saml.core.test.builders;
+
+
+import uk.gov.ida.saml.metadata.domain.ContactPersonDto;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContactPersonDtoBuilder {
+
+    private static final String DEFAULT_TELEPHONE_NUMBER = "0113 496 0000";
+    private static final URI DEFAULT_EMAIL_ADDRESS = URI.create("mailto:default@example.com");
+
+    private String companyName = "default-company-name";
+    private String givenName = "default-given-name";
+    private String surName = "default-sur-name";
+    private List<String> telephoneNumbers = new ArrayList<>();
+    private List<URI> emailAddresses = new ArrayList<>();
+
+    private boolean addDefaultTelephoneNumber = true;
+    private boolean addDefaultEmailAddress = true;
+
+    public static ContactPersonDtoBuilder aContactPersonDto() {
+        return new ContactPersonDtoBuilder();
+    }
+
+    public ContactPersonDto build() {
+        if (addDefaultTelephoneNumber) {
+            telephoneNumbers.add(DEFAULT_TELEPHONE_NUMBER);
+        }
+        if (addDefaultEmailAddress) {
+            emailAddresses.add(DEFAULT_EMAIL_ADDRESS);
+        }
+        return new ContactPersonDto(
+                companyName,
+                givenName,
+                surName,
+                telephoneNumbers,
+                emailAddresses);
+    }
+
+    public ContactPersonDtoBuilder withCompanyName(String companyName) {
+        this.companyName = companyName;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withGivenName(String givenName) {
+        this.givenName = givenName;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withSurName(String surName) {
+        this.surName = surName;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder addTelephoneNumber(String number) {
+        telephoneNumbers.add(number);
+        addDefaultTelephoneNumber = false;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withoutDefaultTelephoneNumber() {
+        addDefaultTelephoneNumber = false;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder addEmailAddress(URI emailAddress) {
+        emailAddresses.add(emailAddress);
+        addDefaultEmailAddress = false;
+        return this;
+    }
+
+    public ContactPersonDtoBuilder withoutDefaultEmailAddress() {
+        addDefaultEmailAddress = false;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/Cycle3DatasetBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/Cycle3DatasetBuilder.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import uk.gov.ida.saml.core.domain.Cycle3Dataset;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Cycle3DatasetBuilder {
+
+    private Map<String,String> attributes = new HashMap<>();
+
+    public static Cycle3DatasetBuilder aCycle3Dataset() {
+        return new Cycle3DatasetBuilder();
+    }
+
+    public Cycle3Dataset build() {
+        return Cycle3Dataset.createFromData(attributes);
+    }
+
+    public Cycle3DatasetBuilder addCycle3Data(String name, String value) {
+        attributes.put(name, value);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/HubAssertionBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/HubAssertionBuilder.java
@@ -1,0 +1,66 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+import uk.gov.ida.saml.core.domain.Cycle3Dataset;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static uk.gov.ida.saml.core.test.builders.AssertionRestrictionsBuilder.anAssertionRestrictions;
+
+public class HubAssertionBuilder {
+
+    private String id = "assertion-id" + UUID.randomUUID();
+    private String issuerId = "assertion issuer id";
+    private DateTime issueInstant = DateTime.now();
+    private PersistentId persistentId = new PersistentId("default-name-id");
+    private AssertionRestrictions assertionRestrictions = anAssertionRestrictions().build();
+    private Optional<Cycle3Dataset> cycle3Data = Optional.empty();
+
+    public static HubAssertionBuilder aHubAssertion() {
+        return new HubAssertionBuilder();
+    }
+
+    public HubAssertion build() {
+        return new HubAssertion(
+                id,
+                issuerId,
+                issueInstant,
+                persistentId,
+                assertionRestrictions,
+                cycle3Data);
+    }
+
+    public HubAssertionBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public HubAssertionBuilder withIssuerId(String issuerId) {
+        this.issuerId = issuerId;
+        return this;
+    }
+
+    public HubAssertionBuilder withIssueInstant(DateTime issueInstant) {
+        this.issueInstant = issueInstant;
+        return this;
+    }
+
+    public HubAssertionBuilder withPersistentId(PersistentId persistentId) {
+        this.persistentId = persistentId;
+        return this;
+    }
+
+    public HubAssertionBuilder withAssertionRestrictions(AssertionRestrictions assertionRestrictions) {
+        this.assertionRestrictions = assertionRestrictions;
+        return this;
+    }
+
+    public HubAssertionBuilder withCycle3Data(Cycle3Dataset cycle3Data) {
+        this.cycle3Data = Optional.ofNullable(cycle3Data);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/IPAddressAttributeBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/IPAddressAttributeBuilder.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.Attribute;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.IPAddress;
+
+public class IPAddressAttributeBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    private Optional<String> value = Optional.fromNullable("1.2.3.4");
+
+    public static IPAddressAttributeBuilder anIPAddress() {
+        return new IPAddressAttributeBuilder();
+    }
+
+    public Attribute build() {
+
+        Attribute ipAddressAttribute = openSamlXmlObjectFactory.createAttribute();
+        ipAddressAttribute.setFriendlyName(IdaConstants.Attributes_1_1.IPAddress.FRIENDLY_NAME);
+        ipAddressAttribute.setName(IdaConstants.Attributes_1_1.IPAddress.NAME);
+
+        IPAddress ipAddressAttributeValue = openSamlXmlObjectFactory.createIPAddressAttributeValue(value.orNull());
+
+        ipAddressAttribute.getAttributeValues().add(ipAddressAttributeValue);
+
+        return ipAddressAttribute;
+    }
+
+    public IPAddressAttributeBuilder withValue(String name) {
+        this.value = Optional.fromNullable(name);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/IdpFraudEventIdAttributeBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/IdpFraudEventIdAttributeBuilder.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import javax.xml.namespace.QName;
+
+import org.opensaml.saml.saml2.core.Attribute;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.IdpFraudEventId;
+import uk.gov.ida.saml.core.extensions.StringValueSamlObject;
+import uk.gov.ida.saml.core.extensions.impl.StringBasedMdsAttributeValueBuilder;
+
+public class IdpFraudEventIdAttributeBuilder {
+
+    private static final java.lang.String INVALID_TYPE_LOCAL_NAME = "InvalidFraudEventType";
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> value = Optional.fromNullable("default-event-id");
+
+    public static IdpFraudEventIdAttributeBuilder anIdpFraudEventIdAttribute() {
+        return new IdpFraudEventIdAttributeBuilder();
+    }
+
+    public Attribute build() {
+        Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+        attribute.setName(IdaConstants.Attributes_1_1.IdpFraudEventId.NAME);
+        if (value.isPresent()){
+            IdpFraudEventId attributeValue = openSamlXmlObjectFactory.createIdpFraudEventAttributeValue(value.get());
+            attribute.getAttributeValues().add(attributeValue);
+        }
+
+        return attribute;
+    }
+
+    public Attribute buildInvalidAttribute() {
+        Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+        attribute.setName(IdaConstants.Attributes_1_1.IdpFraudEventId.NAME);
+        if (value.isPresent()){
+            QName typeName = new QName(IdaConstants.IDA_NS, INVALID_TYPE_LOCAL_NAME, IdaConstants.IDA_PREFIX);
+            StringValueSamlObject idpFraudEventId = new StringBasedMdsAttributeValueBuilder().buildObject(IdpFraudEventId.DEFAULT_ELEMENT_NAME, typeName);
+            idpFraudEventId.setValue(value.get());
+            attribute.getAttributeValues().add(idpFraudEventId);
+        }
+
+        return attribute;
+    }
+
+    public IdpFraudEventIdAttributeBuilder withValue(String value){
+        this.value = Optional.fromNullable(value);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/IssuerBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/IssuerBuilder.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.opensaml.saml.saml2.core.Issuer;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+
+public class IssuerBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> issuerId = Optional.fromNullable(TestCertificateStrings.TEST_ENTITY_ID);
+    private String format = null;
+
+    public static IssuerBuilder anIssuer() {
+        return new IssuerBuilder();
+    }
+
+    public Issuer build() {
+
+        Issuer issuer = openSamlXmlObjectFactory.createIssuer(issuerId.orNull());
+
+        issuer.setFormat(format);
+
+        return issuer;
+    }
+
+    public IssuerBuilder withIssuerId(String issuerId) {
+        this.issuerId = Optional.fromNullable(issuerId);
+        return this;
+    }
+
+    public IssuerBuilder withFormat(String format) {
+        this.format = format;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/NameIdBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/NameIdBuilder.java
@@ -1,0 +1,60 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.NameIDType;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class NameIdBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private String value = "default-pid";
+    private Optional<String> format = Optional.fromNullable(NameIDType.PERSISTENT);
+    private Optional<String> nameQualifier = Optional.absent();
+    private Optional<String> spNameQualifier = Optional.absent();
+
+    public static NameIdBuilder aNameId() {
+        return new NameIdBuilder();
+    }
+
+    public NameID build() {
+        NameID nameId = openSamlXmlObjectFactory.createNameId(value);
+        nameId.setFormat(null);
+
+        if (format.isPresent()) {
+            nameId.setFormat(format.get());
+        }
+
+        if (nameQualifier.isPresent()) {
+            nameId.setNameQualifier(nameQualifier.get());
+        }
+
+        if (spNameQualifier.isPresent()) {
+            nameId.setSPNameQualifier(spNameQualifier.get());
+        }
+
+        return nameId;
+    }
+
+    public NameIdBuilder withValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public NameIdBuilder withFormat(String format) {
+        this.format = Optional.fromNullable(format);
+        return this;
+    }
+
+    public NameIdBuilder withNameQualifier(String nameQualifier) {
+        this.nameQualifier = Optional.fromNullable(nameQualifier);
+        return this;
+    }
+
+    public NameIdBuilder withSpNameQualifier(String spNameQualifier) {
+        this.spNameQualifier = Optional.fromNullable(spNameQualifier);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/NameIdPolicyBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/NameIdPolicyBuilder.java
@@ -1,0 +1,32 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.NameIDType;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class NameIdPolicyBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> format = Optional.fromNullable(NameIDType.PERSISTENT);
+
+    public static NameIdPolicyBuilder aNameIdPolicy() {
+        return new NameIdPolicyBuilder();
+    }
+
+    public NameIDPolicy build() {
+
+        NameIDPolicy nameIdPolicy = openSamlXmlObjectFactory.createNameIdPolicy();
+
+        if (format.isPresent()) {
+            nameIdPolicy.setFormat(format.get());
+        }
+
+        return nameIdPolicy;
+    }
+
+    public NameIdPolicyBuilder withFormat(String format) {
+        this.format = Optional.fromNullable(format);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/OrganisationDtoBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/OrganisationDtoBuilder.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.core.test.builders;
+
+
+import uk.gov.ida.saml.metadata.domain.OrganisationDto;
+
+public class OrganisationDtoBuilder {
+
+    private String organisationDisplayName = "Display Name";
+    private String organisationName = "MegaCorp";
+
+    public static OrganisationDtoBuilder anOrganisationDto() {
+        return new OrganisationDtoBuilder();
+    }
+
+    public OrganisationDto build() {
+        return new OrganisationDto(
+                organisationDisplayName,
+                organisationName,
+                "https://hub.ida.gov.uk");
+    }
+
+    public OrganisationDtoBuilder withDisplayName(String organisationDisplayName) {
+        this.organisationDisplayName = organisationDisplayName;
+        return this;
+    }
+
+    public OrganisationDtoBuilder withName(String organisationName) {
+        this.organisationName = organisationName;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/PassthroughAssertionBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/PassthroughAssertionBuilder.java
@@ -1,0 +1,81 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import java.util.Optional;
+
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.FraudDetectedDetails;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+public class PassthroughAssertionBuilder {
+
+    private PersistentId persistentId = new PersistentId("default-name-id");
+    private Optional<AuthnContext> authnContext = Optional.ofNullable(AuthnContext.LEVEL_1);
+    private String underlyingAssertion = "blob";
+    private Optional<FraudDetectedDetails> fraudDetectedDetails = Optional.empty();
+    private Optional<String> principalIpAddress = Optional.ofNullable("principal-ip-address");
+
+    public static PassthroughAssertionBuilder aPassthroughAssertion() {
+        return new PassthroughAssertionBuilder();
+    }
+
+    public PassthroughAssertion buildMatchingServiceAssertion() {
+        return new PassthroughAssertion(
+                persistentId,
+                authnContext,
+                underlyingAssertion,
+                fraudDetectedDetails,
+                Optional.empty());
+    }
+
+    public PassthroughAssertion buildAuthnStatementAssertion() {
+        return new PassthroughAssertion(
+                persistentId,
+                authnContext,
+                underlyingAssertion,
+                fraudDetectedDetails,
+                principalIpAddress);
+    }
+
+    public PassthroughAssertion buildMatchingDatasetAssertion() {
+        return new PassthroughAssertion(
+                persistentId,
+                Optional.empty(),
+                underlyingAssertion,
+                fraudDetectedDetails,
+                Optional.empty()
+        );
+    }
+
+    public PassthroughAssertionBuilder withPersistentId(PersistentId persistentId) {
+        this.persistentId = persistentId;
+        return this;
+    }
+
+    public PassthroughAssertionBuilder withUnderlyingAssertion(String underlyingAssertion) {
+        this.underlyingAssertion = underlyingAssertion;
+        return this;
+    }
+
+    public PassthroughAssertionBuilder withAuthnContext(AuthnContext authnContext) {
+        this.authnContext = Optional.ofNullable(authnContext);
+        return this;
+    }
+    public String buildMatchingDatasetAssertionAsString() {
+        return underlyingAssertion; //this is wrong (obviously) but it is sufficient to make tests that use this method pass for now
+    }
+
+    public String buildAuthnStatementAssertionAsString() {
+        return underlyingAssertion; //this is wrong (obviously) but it is sufficient to make tests that use this method pass for now
+    }
+
+    public PassthroughAssertionBuilder withFraudDetectedDetails(FraudDetectedDetails fraudDetectedDetails) {
+        this.fraudDetectedDetails = Optional.ofNullable(fraudDetectedDetails);
+        return this;
+    }
+
+    public PassthroughAssertionBuilder withPrincipalIpAddressSeenByIdp(String principalIpAddress) {
+        this.principalIpAddress = Optional.ofNullable(principalIpAddress);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ResponseForHubBuilder.java
@@ -1,0 +1,125 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.joda.time.DateTime;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.IdpIdaStatus;
+import uk.gov.ida.saml.core.domain.InboundResponseFromIdp;
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+
+public class ResponseForHubBuilder {
+
+    private String responseId = "response-id";
+    private String inResponseTo = "request-id";
+    private String issuerId = "issuer-id";
+    private DateTime issueInstant = DateTime.now();
+    private TransactionIdaStatus transactionIdpStatus = TransactionIdaStatus.Success;
+    private IdpIdaStatus idpIdaStatus = IdpIdaStatus.success();
+    private Optional<Signature> signature = null;
+    private Optional<PassthroughAssertion> authnStatementAssertion = empty();
+    private Optional<PassthroughAssertion> matchingDatasetAssertion = empty();
+    private Optional<String> matchingServiceAssertion = empty();
+
+
+    public static ResponseForHubBuilder anAuthnResponse() {
+        return new ResponseForHubBuilder();
+    }
+
+    public InboundResponseFromIdp buildInboundFromIdp() {
+        return new InboundResponseFromIdp(
+                responseId,
+                inResponseTo,
+                issuerId,
+                issueInstant,
+                idpIdaStatus,
+                signature,
+                matchingDatasetAssertion,
+                null,
+                authnStatementAssertion
+        );
+    }
+
+    public InboundResponseFromIdp buildSuccessFromIdp() {
+        return new InboundResponseFromIdp(
+                responseId,
+                inResponseTo,
+                issuerId,
+                issueInstant,
+                idpIdaStatus,
+                signature,
+                matchingDatasetAssertion,
+                null,
+                authnStatementAssertion
+        );
+    }
+
+    public OutboundResponseFromHub buildOutboundResponseFromHub() {
+        return new OutboundResponseFromHub(
+                responseId,
+                inResponseTo,
+                TestEntityIds.HUB_ENTITY_ID,
+                issueInstant,
+                transactionIdpStatus,
+                matchingServiceAssertion,
+                URI.create("blah"));
+    }
+
+
+    public ResponseForHubBuilder withResponseId(String responseId) {
+        this.responseId = responseId;
+        return this;
+    }
+
+    public ResponseForHubBuilder withInResponseTo(String inResponseTo) {
+        this.inResponseTo = inResponseTo;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIssuerId(String issuerId) {
+        this.issuerId = issuerId;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIssueInstant(DateTime issueInstant) {
+        this.issueInstant = issueInstant;
+        return this;
+    }
+
+    public ResponseForHubBuilder withIdpIdaStatus(IdpIdaStatus status) {
+        this.idpIdaStatus = status;
+        return this;
+    }
+
+    public ResponseForHubBuilder withTransactionIdaStatus(TransactionIdaStatus status) {
+        this.transactionIdpStatus = status;
+        return this;
+    }
+
+    public ResponseForHubBuilder withSignature(Signature signature) {
+        this.signature = ofNullable(signature);
+        return this;
+    }
+
+    public ResponseForHubBuilder withAuthnStatementAssertion(PassthroughAssertion authnStatementAssertion) {
+        this.authnStatementAssertion = ofNullable(authnStatementAssertion);
+        return this;
+    }
+
+    public ResponseForHubBuilder withMatchingDatasetAssertion(PassthroughAssertion matchingDatasetAssertion) {
+        this.matchingDatasetAssertion = ofNullable(matchingDatasetAssertion);
+        return this;
+    }
+
+    public ResponseForHubBuilder withMatchingServiceAssertion(String matchingServiceAssertion) {
+        this.matchingServiceAssertion = ofNullable(matchingServiceAssertion);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SamlEndpointDtoBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SamlEndpointDtoBuilder.java
@@ -1,0 +1,32 @@
+package uk.gov.ida.saml.core.test.builders;
+
+
+import uk.gov.ida.saml.metadata.domain.SamlEndpointDto;
+
+import java.net.URI;
+
+public class SamlEndpointDtoBuilder {
+
+    private SamlEndpointDto.Binding binding = SamlEndpointDto.Binding.POST;
+    private URI location = URI.create("https://hub.ida.gov.uk/blah");
+
+    public static SamlEndpointDtoBuilder aSamlEndpointDto(){
+        return new SamlEndpointDtoBuilder();
+    }
+
+    public SamlEndpointDto build() {
+        return new SamlEndpointDto(
+                binding,
+                location);
+    }
+
+    public SamlEndpointDtoBuilder withBinding(SamlEndpointDto.Binding binding) {
+        this.binding = binding;
+        return this;
+    }
+
+    public SamlEndpointDtoBuilder withLocation(URI location) {
+        this.location = location;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ScopingBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/ScopingBuilder.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.Scoping;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class ScopingBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    public static ScopingBuilder aScoping() {
+        return new ScopingBuilder();
+    }
+
+    public Scoping build() {
+        return openSamlXmlObjectFactory.createScoping();
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SimpleStringAttributeBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SimpleStringAttributeBuilder.java
@@ -1,0 +1,43 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.Attribute;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.StringBasedMdsAttributeValue;
+
+public class SimpleStringAttributeBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> name = Optional.absent();
+    private Optional<String> simpleStringValue = Optional.absent();
+
+    public static SimpleStringAttributeBuilder aSimpleStringAttribute() {
+        return new SimpleStringAttributeBuilder();
+    }
+
+    public Attribute build() {
+        Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+
+        if (name.isPresent()) {
+            attribute.setName(name.get());
+        }
+        if (simpleStringValue.isPresent()){
+            StringBasedMdsAttributeValue attributeValue = openSamlXmlObjectFactory.createSimpleMdsAttributeValue(simpleStringValue.get());
+            attribute.getAttributeValues().add(attributeValue);
+        }
+
+        return attribute;
+    }
+
+    public SimpleStringAttributeBuilder withName(String name) {
+        this.name = Optional.fromNullable(name);
+        return this;
+    }
+
+    public SimpleStringAttributeBuilder withSimpleStringValue(String value){
+        this.simpleStringValue = Optional.fromNullable(value);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SimpleStringAttributeValueBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SimpleStringAttributeValueBuilder.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.AttributeValue;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class SimpleStringAttributeValueBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    private String value;
+
+    public static SimpleStringAttributeValueBuilder aSimpleStringValue() {
+        return new SimpleStringAttributeValueBuilder();
+    }
+
+    public AttributeValue build() {
+        return openSamlXmlObjectFactory.createSimpleMdsAttributeValue(value);
+    }
+
+    public SimpleStringAttributeValueBuilder withValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/StatusBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/StatusBuilder.java
@@ -1,0 +1,43 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import com.google.common.base.Optional;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.StatusMessage;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class StatusBuilder {
+
+    private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<StatusCode> statusCode = Optional.fromNullable(StatusCodeBuilder.aStatusCode().build());
+    private Optional<StatusMessage> message = Optional.absent();
+
+
+    public static StatusBuilder aStatus() {
+        return new StatusBuilder();
+    }
+
+    public Status build() {
+        Status status = openSamlXmlObjectFactory.createStatus();
+
+        if (statusCode.isPresent()) {
+            status.setStatusCode(statusCode.get());
+        }
+
+        if (message.isPresent()) {
+            status.setStatusMessage(message.get());
+        }
+
+        return status;
+    }
+
+    public StatusBuilder withStatusCode(StatusCode statusCode) {
+        this.statusCode = Optional.fromNullable(statusCode);
+        return this;
+    }
+
+    public StatusBuilder withMessage(StatusMessage message) {
+        this.message = Optional.fromNullable(message);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/StatusCodeBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/StatusCodeBuilder.java
@@ -1,0 +1,48 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.StatusCode;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+
+public class StatusCodeBuilder {
+
+    private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> value = Optional.fromNullable(StatusCode.SUCCESS);
+    private Optional<StatusCode> subStatus = Optional.absent();
+
+    public static StatusCodeBuilder aStatusCode() {
+        return new StatusCodeBuilder();
+    }
+
+    public StatusCode build() {
+        StatusCode statusCode = openSamlXmlObjectFactory.createStatusCode();
+
+        if (value.isPresent()) {
+            statusCode.setValue(value.get());
+        }
+
+        if (subStatus.isPresent()) {
+            statusCode.setStatusCode(subStatus.get() );
+        }
+
+        return statusCode;
+    }
+
+    public StatusCodeBuilder withValue(String value) {
+        this.value = Optional.fromNullable(value);
+        return this;
+    }
+
+    public StatusCodeBuilder withSubStatusCode(StatusCode subStatusCode){
+        this.subStatus = Optional.fromNullable(subStatusCode);
+        return this;
+    }
+
+    public StatusCodeBuilder forMatchingService() {
+        this.withSubStatusCode(aStatusCode().withValue(SamlStatusCode.MATCH).build());
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/StatusMessageBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/StatusMessageBuilder.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.StatusMessage;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class StatusMessageBuilder {
+
+    private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    private String message = "default message";
+
+    public static StatusMessageBuilder aStatusMessage() {
+        return new StatusMessageBuilder();
+    }
+
+    public StatusMessage build() {
+        StatusMessage statusCode = openSamlXmlObjectFactory.createStatusMessage();
+
+        statusCode.setMessage(message);
+
+       return statusCode;
+    }
+
+    public StatusMessageBuilder withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SubjectBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SubjectBuilder.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import static uk.gov.ida.saml.core.test.builders.NameIdBuilder.aNameId;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class SubjectBuilder {
+
+    private static OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<NameID> nameIdValue = Optional.fromNullable(aNameId().build());
+    private List<SubjectConfirmation> subjectConfirmations = new ArrayList<>();
+    private boolean shouldAddDefaultSubjectConfirmation = true;
+
+    public static SubjectBuilder aSubject() {
+        return new SubjectBuilder();
+    }
+
+    public Subject build() {
+        Subject subject = openSamlXmlObjectFactory.createSubject();
+
+        if (nameIdValue.isPresent()) {
+            subject.setNameID(nameIdValue.get());
+        }
+
+        if (shouldAddDefaultSubjectConfirmation) {
+            subjectConfirmations.add(SubjectConfirmationBuilder.aSubjectConfirmation().build());
+        }
+        subject.getSubjectConfirmations().addAll(subjectConfirmations);
+
+        return subject;
+    }
+
+    public SubjectBuilder withNameId(NameID nameId) {
+        this.nameIdValue = Optional.fromNullable(nameId);
+        return this;
+    }
+
+    public SubjectBuilder withSubjectConfirmation(SubjectConfirmation subjectConfirmation) {
+        this.subjectConfirmations.add(subjectConfirmation);
+        this.shouldAddDefaultSubjectConfirmation = false;
+        return this;
+    }
+
+    public SubjectBuilder withPersistentId(String persistentId) {
+        return withNameId(aNameId().withValue(persistentId).build());
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SubjectConfirmationBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SubjectConfirmationBuilder.java
@@ -1,0 +1,43 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class SubjectConfirmationBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> method = Optional.fromNullable(SubjectConfirmation.METHOD_BEARER);
+    private Optional<SubjectConfirmationData> subjectConfirmationData = Optional.fromNullable(SubjectConfirmationDataBuilder.aSubjectConfirmationData().build());
+
+    public static SubjectConfirmationBuilder aSubjectConfirmation() {
+        return new SubjectConfirmationBuilder();
+    }
+
+    public SubjectConfirmation build() {
+        SubjectConfirmation subjectConfirmation = openSamlXmlObjectFactory.createSubjectConfirmation();
+
+        if (method.isPresent()) {
+            subjectConfirmation.setMethod(method.get());
+        }
+
+        if (subjectConfirmationData.isPresent()) {
+            subjectConfirmation.setSubjectConfirmationData(subjectConfirmationData.get());
+        }
+
+        return subjectConfirmation;
+    }
+
+    public SubjectConfirmationBuilder withMethod(String method) {
+        this.method = Optional.fromNullable(method);
+        return this;
+    }
+
+    public SubjectConfirmationBuilder withSubjectConfirmationData(SubjectConfirmationData subjectConfirmationData) {
+        this.subjectConfirmationData = Optional.fromNullable(subjectConfirmationData);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SubjectConfirmationDataBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/SubjectConfirmationDataBuilder.java
@@ -1,0 +1,96 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+
+public class SubjectConfirmationDataBuilder {
+
+    public static final int NOT_ON_OR_AFTER_DEFAULT_PERIOD = 15;
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+    private Optional<String> recipient = Optional.fromNullable(TestEntityIds.HUB_ENTITY_ID);
+    private Optional<DateTime> notOnOrAfter = Optional.fromNullable(DateTime.now().plusMinutes(NOT_ON_OR_AFTER_DEFAULT_PERIOD));
+    private Optional<DateTime> notBefore = Optional.absent();
+    private Optional<String> address = Optional.absent();
+    private Optional<String> inResponseTo = Optional.fromNullable(ResponseBuilder.DEFAULT_REQUEST_ID);
+    private List<Assertion> assertions = new ArrayList<>();
+    private List<EncryptedAssertion> encryptedAssertions = new ArrayList<>();
+
+    public static SubjectConfirmationDataBuilder aSubjectConfirmationData() {
+        return new SubjectConfirmationDataBuilder();
+    }
+
+    public SubjectConfirmationData build() {
+        SubjectConfirmationData subjectConfirmationData = openSamlXmlObjectFactory.createSubjectConfirmationData();
+
+        if (recipient.isPresent()) {
+            subjectConfirmationData.setRecipient(recipient.get());
+        }
+        if (notOnOrAfter.isPresent()) {
+            subjectConfirmationData.setNotOnOrAfter(notOnOrAfter.get());
+        }
+        if (notBefore.isPresent()) {
+            subjectConfirmationData.setNotBefore(notBefore.get());
+        }
+        if (inResponseTo.isPresent()) {
+            subjectConfirmationData.setInResponseTo(inResponseTo.get());
+        }
+        if (address.isPresent()) {
+            subjectConfirmationData.setAddress(address.get());
+        }
+        subjectConfirmationData.getUnknownXMLObjects().addAll(assertions);
+        subjectConfirmationData.getUnknownXMLObjects().addAll(encryptedAssertions);
+
+        return subjectConfirmationData;
+    }
+
+    public SubjectConfirmationDataBuilder withRecipient(String recipient) {
+        this.recipient = Optional.fromNullable(recipient);
+        return this;
+    }
+
+    public SubjectConfirmationDataBuilder withNotOnOrAfter(DateTime notOnOrAfter) {
+        this.notOnOrAfter = Optional.fromNullable(notOnOrAfter);
+        return this;
+    }
+
+    public SubjectConfirmationDataBuilder withNotBefore(DateTime notBefore) {
+        this.notBefore = Optional.fromNullable(notBefore);
+        return this;
+    }
+
+    public SubjectConfirmationDataBuilder withAddress(String address) {
+        this.address = Optional.fromNullable(address);
+        return this;
+    }
+
+    public SubjectConfirmationDataBuilder withInResponseTo(String inResponseTo) {
+        this.inResponseTo = Optional.fromNullable(inResponseTo);
+        return this;
+    }
+
+    public SubjectConfirmationDataBuilder addAssertion(Assertion assertion) {
+        this.assertions.add(assertion);
+        return this;
+    }
+
+    public SubjectConfirmationDataBuilder addAssertions(List<Assertion> assertions) {
+        this.assertions.addAll(assertions);
+        return this;
+    }
+
+    public SubjectConfirmationDataBuilder addAssertion(final EncryptedAssertion assertion) {
+        this.encryptedAssertions.add(assertion);
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/VerifiedAttributeValueBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/VerifiedAttributeValueBuilder.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.saml.core.test.builders;
+
+import org.opensaml.saml.saml2.core.AttributeValue;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class VerifiedAttributeValueBuilder {
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    private boolean value;
+
+    public static VerifiedAttributeValueBuilder aVerifiedValue() {
+        return new VerifiedAttributeValueBuilder();
+    }
+
+    public AttributeValue build() {
+        return openSamlXmlObjectFactory.createVerifiedAttributeValue(value);
+    }
+
+    public VerifiedAttributeValueBuilder withValue(boolean value) {
+        this.value = value;
+        return this;
+    }
+
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/metadata/AssertionConsumerServiceEndpointDtoBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/metadata/AssertionConsumerServiceEndpointDtoBuilder.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.saml.core.test.builders.metadata;
+
+import uk.gov.ida.saml.metadata.domain.AssertionConsumerServiceEndpointDto;
+
+import java.net.URI;
+
+public class AssertionConsumerServiceEndpointDtoBuilder {
+
+    private URI location = URI.create("https://hub.ida.gov.uk/blah");
+    private boolean isDefault = false;
+    private int index = 0;
+
+    public static AssertionConsumerServiceEndpointDtoBuilder anAssertionConsumerServiceEndpointDto() {
+        return new AssertionConsumerServiceEndpointDtoBuilder();
+    }
+
+    public AssertionConsumerServiceEndpointDto build() {
+        return new AssertionConsumerServiceEndpointDto(
+                location,
+                isDefault,
+                index);
+    }
+
+    public AssertionConsumerServiceEndpointDtoBuilder withLocation(URI location) {
+        this.location = location;
+        return this;
+    }
+
+    public AssertionConsumerServiceEndpointDtoBuilder isDefault() {
+        isDefault = true;
+        return this;
+    }
+
+    public AssertionConsumerServiceEndpointDtoBuilder withIndex(int index) {
+        this.index = index;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/metadata/IdentityProviderMetadataDtoBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/builders/metadata/IdentityProviderMetadataDtoBuilder.java
@@ -1,0 +1,111 @@
+package uk.gov.ida.saml.core.test.builders.metadata;
+
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import uk.gov.ida.common.shared.security.Certificate;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.test.builders.CertificateBuilder;
+import uk.gov.ida.saml.core.test.builders.ContactPersonDtoBuilder;
+import uk.gov.ida.saml.core.test.builders.OrganisationDtoBuilder;
+import uk.gov.ida.saml.metadata.domain.ContactPersonDto;
+import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
+import uk.gov.ida.saml.metadata.domain.OrganisationDto;
+import uk.gov.ida.saml.metadata.domain.SamlEndpointDto;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class IdentityProviderMetadataDtoBuilder {
+
+    private List<SamlEndpointDto> singleSignOnServiceEndpoints = new ArrayList<>();
+    private String entityId = TestEntityIds.HUB_ENTITY_ID;
+    private OrganisationDto organisation = OrganisationDtoBuilder.anOrganisationDto().build();
+    private List<ContactPersonDto> contactPersons = new ArrayList<>();
+    private List<Certificate> signingCertificates = null;
+    private DateTime validUntil = DateTime.now().plus(Duration.standardDays(365));
+    private List<Certificate> idpSigningCertificates = new ArrayList<>();
+    private Certificate encryptionCertificate = null;
+
+    private boolean useDefaultSingleSignOnServiceEndpoints = true;
+    private boolean useDefaultContactPerson = true;
+
+    public static IdentityProviderMetadataDtoBuilder anIdentityProviderMetadataDto() {
+        return new IdentityProviderMetadataDtoBuilder();
+    }
+
+    public HubIdentityProviderMetadataDto build() {
+        populateListsWithDefaults();
+
+        return new HubIdentityProviderMetadataDto(
+                singleSignOnServiceEndpoints,
+                entityId,
+                organisation,
+                contactPersons,
+                idpSigningCertificates,
+                validUntil,
+                signingCertificates,
+                encryptionCertificate);
+    }
+
+    private void populateListsWithDefaults() {
+        if (useDefaultSingleSignOnServiceEndpoints) {
+            this.singleSignOnServiceEndpoints.add(SamlEndpointDto.createPostBinding(URI.create("https://hub.ida.gov.uk/SAML2/SSO/POST")));
+        }
+        if (useDefaultContactPerson) {
+            this.contactPersons.add(ContactPersonDtoBuilder.aContactPersonDto().build());
+        }
+        if (signingCertificates == null && entityId != null) {
+            this.withSigningCertificate(CertificateBuilder.aCertificate().withKeyUse(Certificate.KeyUse.Signing).withIssuerId(entityId).build());
+        }
+        if (idpSigningCertificates.isEmpty()) {
+            this.idpSigningCertificates.add(CertificateBuilder.aCertificate().build());
+        }
+        if (encryptionCertificate == null && entityId != null) {
+            this.encryptionCertificate = CertificateBuilder.aCertificate().withKeyUse(Certificate.KeyUse.Encryption).withIssuerId(entityId).build();
+        }
+    }
+
+    public IdentityProviderMetadataDtoBuilder addSingleSignOnServiceEndpoint(SamlEndpointDto samlEndpoint) {
+        this.singleSignOnServiceEndpoints.add(samlEndpoint);
+        this.useDefaultSingleSignOnServiceEndpoints = false;
+        return this;
+    }
+
+    public IdentityProviderMetadataDtoBuilder withEntityId(String entityId) {
+        this.entityId = entityId;
+        return this;
+    }
+
+    public IdentityProviderMetadataDtoBuilder addContactPerson(ContactPersonDto contactPerson) {
+        this.contactPersons.add(contactPerson);
+        this.useDefaultContactPerson = false;
+        return this;
+    }
+
+    public IdentityProviderMetadataDtoBuilder withSigningCertificate(Certificate certificate) {
+        this.signingCertificates = ImmutableList.of(certificate);
+        return this;
+    }
+
+    public IdentityProviderMetadataDtoBuilder withSigningCertificates(List<Certificate> signingCertificates) {
+        this.signingCertificates = signingCertificates;
+        return this;
+    }
+
+    public IdentityProviderMetadataDtoBuilder withValidUntil(DateTime validUntil) {
+        this.validUntil = validUntil;
+        return this;
+    }
+
+    public IdentityProviderMetadataDtoBuilder addIdpSigningCertificate(Certificate certificate) {
+        this.idpSigningCertificates.add(certificate);
+        return this;
+    }
+
+    public IdentityProviderMetadataDtoBuilder withHubEncryptionCertificate(Certificate certificate) {
+        this.encryptionCertificate = certificate;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/matchers/SignableSAMLObjectBaseMatcher.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/matchers/SignableSAMLObjectBaseMatcher.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.core.test.matchers;
+
+import org.assertj.core.api.Condition;
+import org.opensaml.saml.common.SignableSAMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.validators.SingleCertificateSignatureValidator;
+import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
+import uk.gov.ida.saml.security.SignatureValidator;
+
+public class SignableSAMLObjectBaseMatcher extends Condition<SignableSAMLObject> {
+
+    private final SamlMessageSignatureValidator samlMessageSignatureValidator;
+
+    public SignableSAMLObjectBaseMatcher(SamlMessageSignatureValidator samlMessageSignatureValidator) {
+        this.samlMessageSignatureValidator = samlMessageSignatureValidator;
+    }
+
+    public static SignableSAMLObjectBaseMatcher signedBy(String publicCert, String privateKey) {
+        final SignatureValidator signatureValidator = new SingleCertificateSignatureValidator(
+                new TestCredentialFactory(publicCert, privateKey).getSigningCredential()
+        );
+        return new SignableSAMLObjectBaseMatcher(new SamlMessageSignatureValidator(signatureValidator));
+    }
+
+    @Override
+    public boolean matches(SignableSAMLObject value) {
+        if (value instanceof Response) {
+            return samlMessageSignatureValidator.validate((Response) value, IDPSSODescriptor.DEFAULT_ELEMENT_NAME).isOK();
+        }
+        else if (value instanceof RequestAbstractType) {
+            return samlMessageSignatureValidator.validate((RequestAbstractType) value, SPSSODescriptor.DEFAULT_ELEMENT_NAME).isOK();
+        }
+        else if (value instanceof Assertion) {
+            return samlMessageSignatureValidator.validate((Assertion) value, IDPSSODescriptor.DEFAULT_ELEMENT_NAME).isOK();
+        }
+        else {
+            throw new IllegalArgumentException("Don't know how to validate signature of a " + value.getClass());
+        }
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/validators/SingleCertificateSignatureValidator.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/core/test/validators/SingleCertificateSignatureValidator.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.core.test.validators;
+
+import net.shibboleth.utilities.java.support.resolver.Criterion;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.CredentialResolver;
+import org.opensaml.security.credential.impl.StaticCredentialResolver;
+import org.opensaml.security.trust.TrustEngine;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.saml.security.SignatureValidator;
+
+import javax.xml.namespace.QName;
+import java.util.Collections;
+import java.util.List;
+
+public class SingleCertificateSignatureValidator extends SignatureValidator {
+    private final Credential credential;
+
+    public SingleCertificateSignatureValidator(Credential credential) {
+        this.credential = credential;
+    }
+
+    @Override
+    protected TrustEngine<Signature> getTrustEngine(String entityId) {
+        CredentialResolver credResolver = new StaticCredentialResolver(credential);
+        KeyInfoCredentialResolver kiResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
+        return new ExplicitKeySignatureTrustEngine(credResolver, kiResolver);
+    }
+
+    @Override
+    protected List<Criterion> getAdditionalCriteria(String entityId, QName role) {
+        return Collections.emptyList();
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/hub/test/builders/EidasAuthnRequestBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/hub/test/builders/EidasAuthnRequestBuilder.java
@@ -1,0 +1,57 @@
+package uk.gov.ida.saml.hub.test.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.hub.domain.EidasAuthnRequestFromHub;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+public class EidasAuthnRequestBuilder {
+    private String id = UUID.randomUUID().toString();
+    private String issuer = "issuer_id";
+    private DateTime issueInstant = DateTime.now();
+    private String destination;
+    private String providerName;
+    private List<AuthnContext> authnContextList;
+
+    public static EidasAuthnRequestBuilder anEidasAuthnRequest() {
+        return new EidasAuthnRequestBuilder();
+    }
+
+    public EidasAuthnRequestFromHub buildFromHub() {
+        return new EidasAuthnRequestFromHub(
+            id,
+            issuer,
+            issueInstant,
+            authnContextList,
+            URI.create("http://eidas/ssoLocation"),
+            providerName);
+    }
+
+    public EidasAuthnRequestBuilder withLevelsOfAssurance(List<AuthnContext> authnContextList) {
+        this.authnContextList = authnContextList;
+        return this;
+    }
+
+    public EidasAuthnRequestBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public EidasAuthnRequestBuilder withDestination(String destination) {
+        this.destination = destination;
+        return this;
+    }
+
+    public EidasAuthnRequestBuilder withProviderName(String providerName) {
+        this.providerName = providerName;
+        return this;
+    }
+
+    public EidasAuthnRequestBuilder withIssuer(String issuerEntityId) {
+        this.issuer = issuerEntityId;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/hub/test/builders/HubAttributeQueryRequestBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/hub/test/builders/HubAttributeQueryRequestBuilder.java
@@ -1,0 +1,105 @@
+package uk.gov.ida.saml.hub.test.builders;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+import uk.gov.ida.saml.hub.domain.HubAttributeQueryRequest;
+import uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Optional.absent;
+import static com.google.common.base.Optional.fromNullable;
+
+public class HubAttributeQueryRequestBuilder {
+
+    private String id = "id";
+    private PersistentId persistentId = new PersistentId("default-name-id");
+    private String authnStatementAssertion = "aPassthroughAssertion().buildAuthnStatementAssertion()";
+    private Optional<HubAssertion> cycle3AttributeAssertion = absent();
+    private Optional<List<UserAccountCreationAttribute>> userAccountCreationAttributes = absent();
+    private URI assertionConsumerServiceUrl = URI.create("http://transaction.com");
+    private String authnRequestIssuerEntityId = "issuer-id";
+    private AuthnContext authnContext = AuthnContext.LEVEL_1;
+    private String encryptedMathcingDatasetAssertion = "aPassthroughAssertion().buildEncryptedMatchingDatasetAssertion()";
+    private String hubEntityId = "hubEntityId";
+
+    public static HubAttributeQueryRequestBuilder aHubAttributeQueryRequest() {
+        return new HubAttributeQueryRequestBuilder();
+    }
+
+    public HubAttributeQueryRequest build() {
+        return new HubAttributeQueryRequest(
+                id,
+                persistentId,
+                encryptedMathcingDatasetAssertion,
+                authnStatementAssertion,
+                cycle3AttributeAssertion,
+                userAccountCreationAttributes,
+                DateTime.now(),
+                assertionConsumerServiceUrl,
+                authnRequestIssuerEntityId,
+                authnContext,
+                hubEntityId
+        );
+    }
+
+    public HubAttributeQueryRequestBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withPersistentId(PersistentId persistentId) {
+        this.persistentId = persistentId;
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withEncryptedMatchingDatasetAssertion(String assertion) {
+        this.encryptedMathcingDatasetAssertion = assertion;
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withAuthnStatementAssertion(String authnStatementAssertion) {
+        this.authnStatementAssertion = authnStatementAssertion;
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withCycle3DataAssertion(HubAssertion cycle3DataAssertion) {
+        this.cycle3AttributeAssertion = fromNullable(cycle3DataAssertion);
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withAssertionConsumerServiceUrl(URI assertionConsumerServiceUrl) {
+        this.assertionConsumerServiceUrl = assertionConsumerServiceUrl;
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withAuthnRequestIssuerEntityId(String requestIssuer) {
+        this.authnRequestIssuerEntityId = requestIssuer;
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withAuthnContext(AuthnContext authnContext) {
+        this.authnContext = authnContext;
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder addUserAccountCreationAttribute(final UserAccountCreationAttribute userAccountCreationAttribute) {
+        if(!userAccountCreationAttributes.isPresent()){
+           List<UserAccountCreationAttribute> userAccountCreationAttributeList = new ArrayList<>();
+
+           userAccountCreationAttributes = Optional.fromNullable(userAccountCreationAttributeList);
+        }
+        this.userAccountCreationAttributes.get().add(userAccountCreationAttribute);
+        return this;
+    }
+
+    public HubAttributeQueryRequestBuilder withoutUserAccountCreationAttributes() {
+        userAccountCreationAttributes = absent();
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/hub/test/builders/IdaAuthnRequestBuilder.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/hub/test/builders/IdaAuthnRequestBuilder.java
@@ -1,0 +1,124 @@
+package uk.gov.ida.saml.hub.test.builders;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.hub.domain.AuthnRequestFromTransaction;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
+
+
+public class IdaAuthnRequestBuilder {
+
+    private String id = UUID.randomUUID().toString();
+    private String issuer = "issuer_id";
+    private DateTime issueInstant = DateTime.now();
+    private List<AuthnContext> levelsOfAssurance = Collections.singletonList(AuthnContext.LEVEL_1);
+    private Optional<Boolean> forceAuthentication = empty();
+    private Optional<Integer> assertionConsumerServiceIndex = empty();
+    private Optional<Signature> signature = empty();
+    private URI destination = URI.create("http://thehub");
+    private Optional<DateTime> sessionExpiry = empty();
+    private Optional<URI> assertionConsumerServiceUrl = empty();
+    private AuthnContextComparisonTypeEnumeration comparisonType = AuthnContextComparisonTypeEnumeration.EXACT;
+
+    public static IdaAuthnRequestBuilder anIdaAuthnRequest() {
+        return new IdaAuthnRequestBuilder();
+    }
+
+    public IdaAuthnRequestFromHub buildFromHub() {
+        return new IdaAuthnRequestFromHub(
+                id,
+                issuer,
+                issueInstant,
+                levelsOfAssurance,
+                forceAuthentication,
+                sessionExpiry.orElse(DateTime.now().plusHours(20)),
+                URI.create("/location"),
+                comparisonType);
+    }
+
+    public AuthnRequestFromTransaction buildFromTransaction() {
+        if (sessionExpiry.isPresent()) {
+            throw new IllegalStateException("sessionExpiry can only be set on an authn request from hub");
+        }
+        return new AuthnRequestFromTransaction(
+                id,
+                issuer,
+                issueInstant,
+                forceAuthentication,
+                assertionConsumerServiceUrl,
+                assertionConsumerServiceIndex,
+                signature,
+                destination);
+    }
+
+    public IdaAuthnRequestBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withIssuer(String issuer) {
+        this.issuer = issuer;
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withIssueInstant(DateTime issueInstant) {
+        this.issueInstant = issueInstant;
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withLevelsOfAssurance(List<AuthnContext> levelsOfAssurance) {
+        this.levelsOfAssurance = levelsOfAssurance;
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withForceAuthentication(Optional<Boolean> forceAuthentication) {
+        this.forceAuthentication = forceAuthentication;
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withAssertionConsumerServiceIndex(int index) {
+        this.assertionConsumerServiceIndex = ofNullable(index);
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withAssertionConsumerServiceUrl(URI url) {
+        this.assertionConsumerServiceUrl = ofNullable(url);
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withoutAssertionConsumerServiceIndex() {
+        this.assertionConsumerServiceIndex = empty();
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withDestination(URI destination) {
+        this.destination = destination;
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withSessionExpiryTimestamp(DateTime sessionExpiryTimestamp) {
+        this.sessionExpiry = ofNullable(sessionExpiryTimestamp);
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withSignature(Signature signature) {
+        this.signature = ofNullable(signature);
+        return this;
+    }
+
+    public IdaAuthnRequestBuilder withComparisonType(AuthnContextComparisonTypeEnumeration comparisonType) {
+        this.comparisonType = comparisonType;
+        return this;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/api/MsaTransformersFactory.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/api/MsaTransformersFactory.java
@@ -1,0 +1,68 @@
+package uk.gov.ida.saml.msa.test.api;
+
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import org.w3c.dom.Element;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EncryptionCredentialFactory;
+import uk.gov.ida.saml.security.EncryptionKeyStore;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+import uk.gov.ida.saml.security.SignatureFactory;
+import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseSignatureCreator;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlResponseAssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.hub.transformers.outbound.MatchingServiceIdaStatusMarshaller;
+import uk.gov.ida.saml.msa.test.outbound.HealthCheckResponseFromMatchingService;
+import uk.gov.ida.saml.msa.test.outbound.transformers.HealthCheckResponseFromMatchingServiceTransformer;
+import uk.gov.ida.saml.msa.test.transformers.ResponseToElementTransformer;
+import java.util.function.Function;
+
+public class MsaTransformersFactory {
+
+    public ResponseToElementTransformer getResponseToElementTransformer(
+            EncryptionKeyStore encryptionKeyStore,
+            IdaKeyStore keyStore,
+            EntityToEncryptForLocator entityToEncryptForLocator,
+            SignatureAlgorithm signatureAlgorithm,
+            DigestAlgorithm digestAlgorithm
+    ) {
+        SignatureFactory signatureFactory = new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm);
+        SamlResponseAssertionEncrypter assertionEncrypter = new SamlResponseAssertionEncrypter(
+                new EncryptionCredentialFactory(encryptionKeyStore),
+                new EncrypterFactory(),
+                entityToEncryptForLocator);
+        return new ResponseToElementTransformer(
+                new XmlObjectToElementTransformer<Response>(),
+                new SamlSignatureSigner<Response>(),
+                assertionEncrypter,
+                new ResponseAssertionSigner(signatureFactory),
+                new ResponseSignatureCreator(signatureFactory)
+        );
+    }
+
+    public HealthCheckResponseFromMatchingServiceTransformer getHealthCheckResponseFromMatchingServiceToResponseTransformer() {
+        return new HealthCheckResponseFromMatchingServiceTransformer(
+                new OpenSamlXmlObjectFactory(),
+                new MatchingServiceIdaStatusMarshaller(new OpenSamlXmlObjectFactory())
+        );
+    }
+
+    public Function<HealthCheckResponseFromMatchingService, Element> getHealthcheckResponseFromMatchingServiceToElementTransformer(
+            final EncryptionKeyStore encryptionKeyStore,
+            final IdaKeyStore keyStore,
+            final EntityToEncryptForLocator entityToEncryptForLocator,
+            final SignatureAlgorithm signatureAlgorithm,
+            final DigestAlgorithm digestAlgorithm
+    ){
+        Function<Response, Element> responseToElementTransformer = getResponseToElementTransformer(encryptionKeyStore, keyStore, entityToEncryptForLocator, signatureAlgorithm, digestAlgorithm);
+
+        return responseToElementTransformer.compose(getHealthCheckResponseFromMatchingServiceToResponseTransformer());
+    }
+
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/domain/MatchingServiceAssertion.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/domain/MatchingServiceAssertion.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.msa.test.domain;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.domain.AssertionRestrictions;
+import uk.gov.ida.saml.core.domain.MatchingServiceAuthnStatement;
+import uk.gov.ida.saml.core.domain.OutboundAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.util.List;
+
+public class MatchingServiceAssertion extends OutboundAssertion {
+    private MatchingServiceAuthnStatement authnStatement;
+    private String audience;
+    private List<Attribute> userAttributesForAccountCreation;
+
+    public MatchingServiceAssertion(
+            String id,
+            String issuerId,
+            DateTime issueInstant,
+            PersistentId persistentId,
+            AssertionRestrictions assertionRestrictions,
+            MatchingServiceAuthnStatement authnStatement,
+            String audience,
+            List<Attribute> userAttributesForAccountCreation) {
+
+        super(id, issuerId, issueInstant, persistentId, assertionRestrictions);
+
+        this.authnStatement = authnStatement;
+        this.audience = audience;
+        this.userAttributesForAccountCreation = userAttributesForAccountCreation;
+    }
+
+    public MatchingServiceAuthnStatement getAuthnStatement(){
+        return authnStatement;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public List<Attribute> getUserAttributesForAccountCreation() {
+        return userAttributesForAccountCreation;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/domain/UnknownUserCreationIdaStatus.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/domain/UnknownUserCreationIdaStatus.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.saml.msa.test.domain;
+
+import uk.gov.ida.saml.core.domain.IdaStatus;
+
+public enum UnknownUserCreationIdaStatus implements IdaStatus {
+    Success,
+    CreateFailure,
+    NoAttributeFailure,
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/HealthCheckResponseFromMatchingService.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/HealthCheckResponseFromMatchingService.java
@@ -1,0 +1,11 @@
+package uk.gov.ida.saml.msa.test.outbound;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
+
+public class HealthCheckResponseFromMatchingService extends IdaMatchingServiceResponse {
+    public HealthCheckResponseFromMatchingService(String entityId, String healthCheckReqeustId) {
+        super("healthcheck-response-id", healthCheckReqeustId, entityId, DateTime.now());
+    }
+}
+

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/OutboundResponseFromMatchingService.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/OutboundResponseFromMatchingService.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.msa.test.outbound;
+
+import org.joda.time.DateTime;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
+import uk.gov.ida.saml.core.domain.MatchingServiceIdaStatus;
+import uk.gov.ida.saml.msa.test.domain.MatchingServiceAssertion;
+
+public class OutboundResponseFromMatchingService extends IdaMatchingServiceResponse {
+    private Optional<MatchingServiceAssertion> matchingServiceAssertion;
+    private MatchingServiceIdaStatus status;
+
+    public OutboundResponseFromMatchingService(
+            String responseId,
+            String inResponseTo,
+            String issuer,
+            DateTime issueInstant,
+            MatchingServiceIdaStatus status,
+            Optional<MatchingServiceAssertion> matchingServiceAssertion) {
+
+        super(responseId, inResponseTo, issuer, issueInstant);
+
+        this.matchingServiceAssertion = matchingServiceAssertion;
+        this.status = status;
+    }
+
+    public Optional<MatchingServiceAssertion> getMatchingServiceAssertion() {
+        return matchingServiceAssertion;
+    }
+
+    public MatchingServiceIdaStatus getStatus() {
+        return status;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/OutboundResponseFromUnknownUserCreationService.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/OutboundResponseFromUnknownUserCreationService.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.saml.msa.test.outbound;
+
+import org.joda.time.DateTime;
+
+import com.google.common.base.Optional;
+
+import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
+import uk.gov.ida.saml.msa.test.domain.MatchingServiceAssertion;
+import uk.gov.ida.saml.msa.test.domain.UnknownUserCreationIdaStatus;
+
+public class OutboundResponseFromUnknownUserCreationService extends IdaMatchingServiceResponse {
+    private final UnknownUserCreationIdaStatus status;
+    private final Optional<MatchingServiceAssertion> matchingServiceAssertion;
+
+    public OutboundResponseFromUnknownUserCreationService(
+            String responseId,
+            String inResponseTo,
+            String issuer,
+            DateTime issueInstant,
+            UnknownUserCreationIdaStatus status,
+            Optional<MatchingServiceAssertion> matchingServiceAssertion) {
+        super(responseId, inResponseTo, issuer, issueInstant);
+        this.status = status;
+        this.matchingServiceAssertion = matchingServiceAssertion;
+    }
+
+    public Optional<MatchingServiceAssertion> getMatchingServiceAssertion() {
+        return matchingServiceAssertion;
+    }
+
+    public UnknownUserCreationIdaStatus getStatus() {
+        return status;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/UnknownUserCreationIdaStatusMarshaller.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/UnknownUserCreationIdaStatusMarshaller.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.saml.msa.test.outbound;
+
+import com.google.common.collect.ImmutableMap;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+import uk.gov.ida.saml.msa.test.domain.UnknownUserCreationIdaStatus;
+
+public class UnknownUserCreationIdaStatusMarshaller extends IdaStatusMarshaller<UnknownUserCreationIdaStatus> {
+
+    private static final ImmutableMap<UnknownUserCreationIdaStatus, DetailedStatusCode> REST_TO_SAML_CODES =
+            ImmutableMap.<UnknownUserCreationIdaStatus, DetailedStatusCode>builder()
+                    .put(UnknownUserCreationIdaStatus.CreateFailure, DetailedStatusCode.UnknownUserCreateFailure)
+                    .put(UnknownUserCreationIdaStatus.Success, DetailedStatusCode.UnknownUserCreateSuccess)
+                    .put(UnknownUserCreationIdaStatus.NoAttributeFailure, DetailedStatusCode.UnknownUserNoAttributeFailure)
+                    .build();
+
+    public UnknownUserCreationIdaStatusMarshaller(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+
+    @Override
+    protected DetailedStatusCode getDetailedStatusCode(UnknownUserCreationIdaStatus originalStatus) {
+        return REST_TO_SAML_CODES.get(originalStatus);
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/HealthCheckResponseFromMatchingServiceTransformer.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/HealthCheckResponseFromMatchingServiceTransformer.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.saml.msa.test.outbound.transformers;
+
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.MatchingServiceIdaStatus;
+import uk.gov.ida.saml.core.transformers.outbound.IdaResponseToSamlResponseTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.MatchingServiceIdaStatusMarshaller;
+import uk.gov.ida.saml.msa.test.outbound.HealthCheckResponseFromMatchingService;
+
+public class HealthCheckResponseFromMatchingServiceTransformer extends IdaResponseToSamlResponseTransformer<HealthCheckResponseFromMatchingService> {
+
+    private final MatchingServiceIdaStatusMarshaller statusMarshaller;
+
+    public HealthCheckResponseFromMatchingServiceTransformer(OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+                                                             MatchingServiceIdaStatusMarshaller statusMarshaller) {
+        super(openSamlXmlObjectFactory);
+        this.statusMarshaller = statusMarshaller;
+    }
+
+    @Override
+    protected void transformAssertions(HealthCheckResponseFromMatchingService originalResponse, Response transformedResponse) {
+        // healthcheck has no assertions
+    }
+
+    @Override
+    protected Status transformStatus(HealthCheckResponseFromMatchingService originalResponse) {
+        return statusMarshaller.toSamlStatus(MatchingServiceIdaStatus.Healthy);
+    }
+
+    @Override
+    protected void transformDestination(HealthCheckResponseFromMatchingService originalResponse, Response transformedResponse) {
+        // healthcheck does not require transformation
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/MatchingServiceAssertionToAssertionTransformer.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/MatchingServiceAssertionToAssertionTransformer.java
@@ -1,0 +1,78 @@
+package uk.gov.ida.saml.msa.test.outbound.transformers;
+
+import com.google.inject.Inject;
+import org.opensaml.core.xml.XMLObjectBuilderFactory;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.AudienceRestriction;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.impl.AttributeStatementBuilder;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.MatchingServiceAuthnStatement;
+import uk.gov.ida.saml.core.transformers.outbound.OutboundAssertionToSubjectTransformer;
+import uk.gov.ida.saml.msa.test.domain.MatchingServiceAssertion;
+
+import java.util.List;
+
+public class MatchingServiceAssertionToAssertionTransformer {
+
+    private final OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+    private final MatchingServiceAuthnStatementToAuthnStatementTransformer matchingServiceAuthnStatementToAuthnStatementTransformer;
+    private final OutboundAssertionToSubjectTransformer outboundAssertionToSubjectTransformer;
+    private XMLObjectBuilderFactory builderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+
+    @Inject
+    public MatchingServiceAssertionToAssertionTransformer(
+            OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+            MatchingServiceAuthnStatementToAuthnStatementTransformer matchingServiceAuthnStatementToAuthnStatementTransformer,
+            OutboundAssertionToSubjectTransformer outboundAssertionToSubjectTransformer) {
+
+        this.openSamlXmlObjectFactory = openSamlXmlObjectFactory;
+        this.matchingServiceAuthnStatementToAuthnStatementTransformer = matchingServiceAuthnStatementToAuthnStatementTransformer;
+        this.outboundAssertionToSubjectTransformer = outboundAssertionToSubjectTransformer;
+    }
+
+    public Assertion transform(MatchingServiceAssertion originalAssertion) {
+
+        Assertion transformedAssertion = openSamlXmlObjectFactory.createAssertion();
+        transformedAssertion.setIssueInstant(originalAssertion.getIssueInstant());
+
+        Issuer transformedIssuer = openSamlXmlObjectFactory.createIssuer(originalAssertion.getIssuerId());
+        transformedAssertion.setIssuer(transformedIssuer);
+        transformedAssertion.setID(originalAssertion.getId());
+
+        Subject subject = outboundAssertionToSubjectTransformer.transform(originalAssertion);
+        transformedAssertion.setSubject(subject);
+
+        MatchingServiceAuthnStatement authnStatement = originalAssertion.getAuthnStatement();
+
+        transformedAssertion.getAuthnStatements().add(matchingServiceAuthnStatementToAuthnStatementTransformer.transform(authnStatement));
+
+        Conditions conditions = openSamlXmlObjectFactory.createConditions();
+        AudienceRestriction audienceRestriction = openSamlXmlObjectFactory.createAudienceRestriction(originalAssertion.getAudience());
+        conditions.getAudienceRestrictions().add(audienceRestriction);
+        transformedAssertion.setConditions(conditions);
+
+        List<Attribute> userAttributesForAccountCreation = originalAssertion.getUserAttributesForAccountCreation();
+        if (!userAttributesForAccountCreation.isEmpty()) {
+            addAttributes(transformedAssertion, userAttributesForAccountCreation);
+        }
+
+
+        return transformedAssertion;
+    }
+
+    private void addAttributes(final Assertion transformedAssertion, final List<Attribute> userAttributesForAccountCreation) {
+        AttributeStatementBuilder attributeStatementBuilder =
+                (AttributeStatementBuilder) builderFactory.getBuilder(AttributeStatement.DEFAULT_ELEMENT_NAME);
+        AttributeStatement attributeStatement = attributeStatementBuilder.buildObject();
+        attributeStatement.getAttributes().addAll(userAttributesForAccountCreation);
+
+        transformedAssertion.getAttributeStatements().add(attributeStatement);
+    }
+
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/MatchingServiceAuthnStatementToAuthnStatementTransformer.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/MatchingServiceAuthnStatementToAuthnStatementTransformer.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.msa.test.outbound.transformers;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.AuthnContext;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.MatchingServiceAuthnStatement;
+
+public class MatchingServiceAuthnStatementToAuthnStatementTransformer {
+
+    @Inject
+    public MatchingServiceAuthnStatementToAuthnStatementTransformer(
+            final OpenSamlXmlObjectFactory openSamlXmlObjectFactory) {
+
+        this.openSamlXmlObjectFactory = openSamlXmlObjectFactory;
+    }
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+
+    public AuthnStatement transform(MatchingServiceAuthnStatement idaAuthnStatement) {
+        AuthnStatement authnStatement = openSamlXmlObjectFactory.createAuthnStatement();
+        AuthnContext authnContext = openSamlXmlObjectFactory.createAuthnContext();
+        authnContext.setAuthnContextClassRef(openSamlXmlObjectFactory.createAuthnContextClassReference(idaAuthnStatement.getAuthnContext().getUri()));
+        authnStatement.setAuthnContext(authnContext);
+        authnStatement.setAuthnInstant(DateTime.now());
+        return authnStatement;
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/OutboundResponseFromMatchingServiceToSamlResponseTransformer.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/OutboundResponseFromMatchingServiceToSamlResponseTransformer.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.msa.test.outbound.transformers;
+
+import com.google.common.base.Optional;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.transformers.outbound.IdaResponseToSamlResponseTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.MatchingServiceIdaStatusMarshaller;
+import uk.gov.ida.saml.msa.test.domain.MatchingServiceAssertion;
+import uk.gov.ida.saml.msa.test.outbound.OutboundResponseFromMatchingService;
+
+public class OutboundResponseFromMatchingServiceToSamlResponseTransformer extends IdaResponseToSamlResponseTransformer<OutboundResponseFromMatchingService> {
+
+    private final MatchingServiceIdaStatusMarshaller statusMarshaller;
+    private final MatchingServiceAssertionToAssertionTransformer assertionTransformer;
+
+    public OutboundResponseFromMatchingServiceToSamlResponseTransformer(
+            MatchingServiceIdaStatusMarshaller statusMarshaller,
+            OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+            MatchingServiceAssertionToAssertionTransformer assertionTransformer) {
+        super(openSamlXmlObjectFactory);
+        this.statusMarshaller = statusMarshaller;
+        this.assertionTransformer = assertionTransformer;
+    }
+
+    @Override
+    protected void transformAssertions(OutboundResponseFromMatchingService originalResponse, Response transformedResponse) {
+        Optional<MatchingServiceAssertion> assertion = originalResponse.getMatchingServiceAssertion();
+        if (assertion.isPresent()) {
+            Assertion transformedAssertion = assertionTransformer.transform(assertion.get());
+            transformedResponse.getAssertions().add(transformedAssertion);
+        }
+    }
+
+    @Override
+    protected Status transformStatus(OutboundResponseFromMatchingService originalResponse) {
+        return statusMarshaller.toSamlStatus(originalResponse.getStatus());
+    }
+
+    @Override
+    protected void transformDestination(OutboundResponseFromMatchingService originalResponse, Response transformedResponse) {
+
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/OutboundResponseFromUnknownUserCreationServiceToSamlResponseTransformer.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/transformers/OutboundResponseFromUnknownUserCreationServiceToSamlResponseTransformer.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.msa.test.outbound.transformers;
+
+import com.google.common.base.Optional;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.transformers.outbound.IdaResponseToSamlResponseTransformer;
+import uk.gov.ida.saml.msa.test.outbound.UnknownUserCreationIdaStatusMarshaller;
+import uk.gov.ida.saml.msa.test.domain.MatchingServiceAssertion;
+import uk.gov.ida.saml.msa.test.outbound.OutboundResponseFromUnknownUserCreationService;
+
+public class OutboundResponseFromUnknownUserCreationServiceToSamlResponseTransformer extends IdaResponseToSamlResponseTransformer<OutboundResponseFromUnknownUserCreationService> {
+
+    private final UnknownUserCreationIdaStatusMarshaller statusMarshaller;
+    private final MatchingServiceAssertionToAssertionTransformer assertionTransformer;
+
+    public OutboundResponseFromUnknownUserCreationServiceToSamlResponseTransformer(
+            OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+            UnknownUserCreationIdaStatusMarshaller statusMarshaller,
+            MatchingServiceAssertionToAssertionTransformer assertionTransformer) {
+        super(openSamlXmlObjectFactory);
+        this.statusMarshaller = statusMarshaller;
+        this.assertionTransformer = assertionTransformer;
+    }
+
+    @Override
+    protected void transformAssertions(OutboundResponseFromUnknownUserCreationService originalResponse, Response transformedResponse) {
+        Optional<MatchingServiceAssertion> assertion = originalResponse.getMatchingServiceAssertion();
+        if (assertion.isPresent()) {
+            Assertion transformedAssertion = assertionTransformer.transform(assertion.get());
+            transformedResponse.getAssertions().add(transformedAssertion);
+        }
+    }
+
+    @Override
+    protected Status transformStatus(OutboundResponseFromUnknownUserCreationService originalResponse) {
+        return statusMarshaller.toSamlStatus(originalResponse.getStatus());
+    }
+
+    @Override
+    protected void transformDestination(OutboundResponseFromUnknownUserCreationService originalResponse, Response transformedResponse) {
+
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/transformers/MatchingDatasetUnmarshaller.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/transformers/MatchingDatasetUnmarshaller.java
@@ -1,0 +1,166 @@
+package uk.gov.ida.saml.msa.test.transformers;
+
+import org.joda.time.LocalDate;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.extensions.StringBasedMdsAttributeValue;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.AddressFactory;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+import uk.gov.ida.saml.core.domain.SimpleMdsValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.*;
+import static java.text.MessageFormat.*;
+
+public class MatchingDatasetUnmarshaller {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MatchingDatasetUnmarshaller.class);
+    private final AddressFactory addressFactory;
+
+    public MatchingDatasetUnmarshaller(AddressFactory addressFactory) {
+        this.addressFactory = addressFactory;
+    }
+
+    public MatchingDataset fromAssertion(Assertion assertion) {
+        List<AttributeStatement> attributeStatements = assertion.getAttributeStatements();
+        if (attributeStatements.isEmpty()) {
+            // this returns null, and the consumer would wrap it with fromNullable.  Not awesome but it works.
+            return null;
+        }
+
+        List<Attribute> attributes = attributeStatements.get(0).getAttributes();
+        MatchingDatasetBuilder datasetBuilder = new MatchingDatasetBuilder();
+        for (Attribute attribute : attributes) {
+            transformAttribute(attribute, datasetBuilder);
+        }
+
+        return datasetBuilder.build();
+    }
+
+    private void transformAttribute(Attribute attribute, MatchingDatasetBuilder datasetBuilder) {
+        switch (attribute.getName()) {
+            case IdaConstants.Attributes_1_1.Firstname.NAME:
+                datasetBuilder.firstname(transformPersonNameAttribute(attribute));
+                break;
+
+            case IdaConstants.Attributes_1_1.Middlename.NAME:
+                datasetBuilder.middlenames(transformPersonNameAttribute(attribute));
+                break;
+
+            case IdaConstants.Attributes_1_1.Surname.NAME:
+                datasetBuilder.addSurnames(transformPersonNameAttribute(attribute));
+                break;
+
+            case IdaConstants.Attributes_1_1.Gender.NAME:
+                uk.gov.ida.saml.core.extensions.Gender gender = (uk.gov.ida.saml.core.extensions.Gender) attribute.getAttributeValues().get(0);
+                datasetBuilder.gender(new SimpleMdsValue<>(Gender.fromString(gender.getValue()), gender.getFrom(), gender.getTo(), gender.getVerified()));
+                break;
+
+            case IdaConstants.Attributes_1_1.DateOfBirth.NAME:
+                datasetBuilder.dateOfBirth(getBirthdates(attribute));
+                break;
+
+            case IdaConstants.Attributes_1_1.CurrentAddress.NAME:
+                List<Address> transformedCurrentAddresses = addressFactory.create(attribute);
+                datasetBuilder.addCurrentAddresses(transformedCurrentAddresses);
+                break;
+
+            case IdaConstants.Attributes_1_1.PreviousAddress.NAME:
+                List<Address> transformedPreviousAddresses = addressFactory.create(attribute);
+                datasetBuilder.addPreviousAddresses(transformedPreviousAddresses);
+                break;
+
+            default:
+                String errorMessage = format("Attribute {0} is not a supported Matching Dataset attribute.", attribute.getName());
+                LOG.warn(errorMessage);
+                throw new IllegalArgumentException(errorMessage);
+        }
+    }
+
+    private List<SimpleMdsValue<LocalDate>> getBirthdates(Attribute attribute) {
+        List<SimpleMdsValue<LocalDate>> birthDates = new ArrayList<>();
+
+        for (XMLObject xmlObject : attribute.getAttributeValues()) {
+            StringBasedMdsAttributeValue stringBasedMdsAttributeValue = (StringBasedMdsAttributeValue) xmlObject;
+            String dateOfBirthString = stringBasedMdsAttributeValue.getValue();
+            birthDates.add(new SimpleMdsValue<>(
+                    LocalDate.parse(dateOfBirthString),
+                    stringBasedMdsAttributeValue.getFrom(),
+                    stringBasedMdsAttributeValue.getTo(),
+                    stringBasedMdsAttributeValue.getVerified()));
+        }
+
+        return birthDates;
+    }
+
+    private List<SimpleMdsValue<String>> transformPersonNameAttribute(Attribute attribute) {
+        List<SimpleMdsValue<String>> personNames = new ArrayList<>();
+
+        for (XMLObject xmlObject : attribute.getAttributeValues()) {
+            PersonName personName = (PersonName) xmlObject;
+            personNames.add(new SimpleMdsValue<>(personName.getValue(), personName.getFrom(), personName.getTo(), personName.getVerified()));
+        }
+
+        return personNames;
+    }
+
+    private static class MatchingDatasetBuilder {
+        private List<SimpleMdsValue<String>> firstnames = new ArrayList<>();
+        private List<SimpleMdsValue<String>> middlenames = new ArrayList<>();
+        private List<SimpleMdsValue<String>> surnames = new ArrayList<>();
+        private Optional<SimpleMdsValue<Gender>> gender = Optional.empty();
+        private List<SimpleMdsValue<LocalDate>> dateOfBirths = new ArrayList<>();
+        private List<Address> currentAddresses = newArrayList();
+        private List<Address> previousAddresses = newArrayList();
+
+        public MatchingDatasetBuilder firstname(List<SimpleMdsValue<String>> firstnames) {
+            this.firstnames.addAll(firstnames);
+            return this;
+        }
+
+        public MatchingDatasetBuilder middlenames(List<SimpleMdsValue<String>> middlenames) {
+            this.middlenames.addAll(middlenames);
+            return this;
+        }
+
+        public MatchingDatasetBuilder addSurnames(List<SimpleMdsValue<String>> surnames) {
+            this.surnames.addAll(surnames);
+            return this;
+        }
+
+        public MatchingDatasetBuilder gender(SimpleMdsValue<Gender> gender) {
+            this.gender = Optional.ofNullable(gender);
+            return this;
+        }
+
+        public MatchingDatasetBuilder dateOfBirth(List<SimpleMdsValue<LocalDate>> dateOfBirths) {
+            this.dateOfBirths.addAll(dateOfBirths);
+            return this;
+        }
+
+        public MatchingDatasetBuilder addCurrentAddresses(List<Address> currentAddresses) {
+            this.currentAddresses.addAll(currentAddresses);
+            return this;
+        }
+
+        public MatchingDatasetBuilder addPreviousAddresses(List<Address> previousAddresses) {
+            this.previousAddresses.addAll(previousAddresses);
+            return this;
+        }
+
+        public MatchingDataset build() {
+            return new MatchingDataset(firstnames, middlenames, surnames, gender, dateOfBirths, currentAddresses, previousAddresses);
+        }
+    }
+}

--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/transformers/ResponseToElementTransformer.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/transformers/ResponseToElementTransformer.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.msa.test.transformers;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.Response;
+import org.w3c.dom.Element;
+import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseSignatureCreator;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlResponseAssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import java.util.function.Function;
+
+public class ResponseToElementTransformer implements Function<Response, Element> {
+
+    private final XmlObjectToElementTransformer<Response> xmlObjectToElementTransformer;
+    private final SamlSignatureSigner<Response> samlSignatureSigner;
+    private final SamlResponseAssertionEncrypter samlResponseAssertionEncrypter;
+    private final ResponseAssertionSigner responseAssertionSigner;
+    private final ResponseSignatureCreator responseSignatureCreator;
+
+    @Inject
+    public ResponseToElementTransformer(
+            final XmlObjectToElementTransformer<Response> xmlObjectToElementTransformer, SamlSignatureSigner<Response> samlSignatureSigner,
+            final SamlResponseAssertionEncrypter samlResponseAssertionEncrypter,
+            final ResponseAssertionSigner responseAssertionSigner,
+            final ResponseSignatureCreator responseSignatureCreator) {
+
+        this.xmlObjectToElementTransformer = xmlObjectToElementTransformer;
+        this.samlSignatureSigner = samlSignatureSigner;
+        this.samlResponseAssertionEncrypter = samlResponseAssertionEncrypter;
+        this.responseAssertionSigner = responseAssertionSigner;
+        this.responseSignatureCreator = responseSignatureCreator;
+    }
+
+    @Override
+    public Element apply(final Response response) {
+        final Response responseWithSignature = responseSignatureCreator.addUnsignedSignatureTo(response);
+        final Response responseWithSignedAssertions = responseAssertionSigner.signAssertions(responseWithSignature);
+        final Response responseWithEncryptedAssertions = samlResponseAssertionEncrypter.encryptAssertions(responseWithSignedAssertions);
+        final Response signedResponse = samlSignatureSigner.sign(responseWithEncryptedAssertions);
+        return xmlObjectToElementTransformer.apply(signedResponse);
+    }
+
+}

--- a/hub-saml-test-utils/src/test/java/uk/gov/ida/saml/msa/test/transformers/MatchingDatasetUnmarshallerTest.java
+++ b/hub-saml-test-utils/src/test/java/uk/gov/ida/saml/msa/test/transformers/MatchingDatasetUnmarshallerTest.java
@@ -1,0 +1,265 @@
+package uk.gov.ida.saml.msa.test.transformers;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.extensions.Address;
+import uk.gov.ida.saml.core.extensions.Gender;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.domain.AddressFactory;
+import uk.gov.ida.saml.core.domain.MatchingDataset;
+
+import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.*;
+import static uk.gov.ida.saml.core.test.builders.AddressAttributeBuilder_1_1.*;
+import static uk.gov.ida.saml.core.test.builders.AddressAttributeValueBuilder_1_1.*;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.*;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.*;
+import static uk.gov.ida.saml.core.test.builders.DateAttributeBuilder_1_1.*;
+import static uk.gov.ida.saml.core.test.builders.DateAttributeValueBuilder.*;
+import static uk.gov.ida.saml.core.test.builders.GenderAttributeBuilder_1_1.*;
+import static uk.gov.ida.saml.core.test.builders.PersonNameAttributeBuilder_1_1.*;
+import static uk.gov.ida.saml.core.test.builders.PersonNameAttributeValueBuilder.*;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class MatchingDatasetUnmarshallerTest {
+
+    private MatchingDatasetUnmarshaller unmarshaller;
+
+    @Before
+    public void setUp() {
+        this.unmarshaller = new MatchingDatasetUnmarshaller(new AddressFactory());
+    }
+
+    @Test
+    public void transform_shouldTransformAnAssertionIntoAMatchingDataset_1_1() throws Exception {
+        Attribute firstname = aPersonName_1_1().addValue(aPersonNameValue().withValue("Bob").withFrom(DateTime.parse("2000-03-5")).withTo(DateTime.parse("2001-02-6")).withVerified(true).build()).buildAsFirstname();
+        Attribute middlenames = aPersonName_1_1().addValue(aPersonNameValue().withValue("foo").withFrom(DateTime.parse("2000-03-5")).withTo(DateTime.parse("2001-02-6")).withVerified(true).build()).buildAsMiddlename();
+        Attribute surname = aPersonName_1_1().addValue(aPersonNameValue().withValue("Bobbins").withFrom(DateTime.parse("2000-03-5")).withTo(DateTime.parse("2001-02-6")).withVerified(true).build()).buildAsSurname();
+        Attribute gender = aGender_1_1().withValue("Male").withFrom(DateTime.parse("2000-03-5")).withTo(DateTime.parse("2001-02-6")).withVerified(true).build();
+        Attribute dateOfBirth = aDate_1_1().addValue(aDateValue().withValue("1986-12-05").withFrom(DateTime.parse("2001-09-08")).withTo(DateTime.parse("2002-03-05")).withVerified(false).build()).buildAsDateOfBirth();
+        Address address = anAddressAttributeValue().addLines(asList("address-line-1")).withFrom(DateTime.parse("2012-08-08")).withTo(DateTime.parse("2012-09-09")).build();
+        Attribute currentAddress = anAddressAttribute().addAddress(address).buildCurrentAddress();
+
+        Address previousAddress1 = anAddressAttributeValue().addLines(asList("address-line-2")).withFrom(DateTime.parse("2011-08-08")).withTo(DateTime.parse("2012-08-07")).build();
+        Address previousAddress2 = anAddressAttributeValue().addLines(asList("address-line-3")).withFrom(DateTime.parse("2010-08-08")).withTo(DateTime.parse("2011-08-07")).build();
+        Attribute previousAddresses = anAddressAttribute().addAddress(previousAddress1).addAddress(previousAddress2).buildPreviousAddress();
+
+        Assertion originalAssertion = aMatchingDatasetAssertion(firstname, middlenames, surname, gender, dateOfBirth, currentAddress, previousAddresses).buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(originalAssertion);
+
+        final PersonName firstNameAttributeValue = (PersonName) firstname.getAttributeValues().get(0);
+        final PersonName middleNameAttributeValue = (PersonName) middlenames.getAttributeValues().get(0);
+        final PersonName surnameAttributeValue = (PersonName) surname.getAttributeValues().get(0);
+        final Gender genderAttributeValue = (Gender) gender.getAttributeValues().get(0);
+        final uk.gov.ida.saml.core.extensions.Date dateOfBirthAttributeValue = (uk.gov.ida.saml.core.extensions.Date) dateOfBirth.getAttributeValues().get(0);
+        final Address currentAddressAttributeValue = (Address) currentAddress.getAttributeValues().get(0);
+        assertThat(matchingDataset.getFirstNames().get(0).getValue()).isEqualTo(firstNameAttributeValue.getValue());
+        assertThat(matchingDataset.getFirstNames().get(0).getFrom()).isEqualTo(firstNameAttributeValue.getFrom());
+        assertThat(matchingDataset.getFirstNames().get(0).getTo()).isEqualTo(firstNameAttributeValue.getTo());
+        assertThat(matchingDataset.getMiddleNames().get(0).getValue()).isEqualTo(middleNameAttributeValue.getValue());
+        assertThat(matchingDataset.getMiddleNames().get(0).getFrom()).isEqualTo(middleNameAttributeValue.getFrom());
+        assertThat(matchingDataset.getMiddleNames().get(0).getTo()).isEqualTo(middleNameAttributeValue.getTo());
+        assertThat(matchingDataset.getSurnames().get(0).getValue()).isEqualTo(surnameAttributeValue.getValue());
+        assertThat(matchingDataset.getSurnames().get(0).getFrom()).isEqualTo(surnameAttributeValue.getFrom());
+        assertThat(matchingDataset.getSurnames().get(0).getTo()).isEqualTo(surnameAttributeValue.getTo());
+
+        assertThat(matchingDataset.getGender().get().getValue().getValue()).isEqualTo(genderAttributeValue.getValue());
+        assertThat(matchingDataset.getGender().get().getFrom()).isEqualTo(genderAttributeValue.getFrom());
+        assertThat(matchingDataset.getGender().get().getTo()).isEqualTo(genderAttributeValue.getTo());
+
+        assertThat(matchingDataset.getDateOfBirths().get(0).getValue()).isEqualTo(LocalDate.parse(dateOfBirthAttributeValue.getValue()));
+        assertThat(matchingDataset.getDateOfBirths().get(0).getFrom()).isEqualTo(dateOfBirthAttributeValue.getFrom());
+        assertThat(matchingDataset.getDateOfBirths().get(0).getTo()).isEqualTo(dateOfBirthAttributeValue.getTo());
+
+        assertThat(matchingDataset.getAddresses().size()).isEqualTo(3);
+
+        uk.gov.ida.saml.core.domain.Address transformedCurrentAddress = matchingDataset.getAddresses().get(0);
+        assertThat(transformedCurrentAddress.getLines().get(0)).isEqualTo(currentAddressAttributeValue.getLines().get(0).getValue());
+        assertThat(transformedCurrentAddress.getPostCode().get()).isEqualTo(currentAddressAttributeValue.getPostCode().getValue());
+        assertThat(transformedCurrentAddress.getInternationalPostCode().get()).isEqualTo(currentAddressAttributeValue.getInternationalPostCode().getValue());
+        assertThat(transformedCurrentAddress.getUPRN().get()).isEqualTo(currentAddressAttributeValue.getUPRN().getValue());
+        assertThat(transformedCurrentAddress.getFrom()).isEqualTo(currentAddressAttributeValue.getFrom());
+        assertThat(transformedCurrentAddress.getTo().get()).isEqualTo(currentAddressAttributeValue.getTo());
+
+        uk.gov.ida.saml.core.domain.Address transformedPreviousAddress1 = matchingDataset.getAddresses().get(1);
+        assertThat(transformedPreviousAddress1.getLines().get(0)).isEqualTo(previousAddress1.getLines().get(0).getValue());
+        uk.gov.ida.saml.core.domain.Address transformedPreviousAddress2 = matchingDataset.getAddresses().get(2);
+        assertThat(transformedPreviousAddress2.getLines().get(0)).isEqualTo(previousAddress2.getLines().get(0).getValue());
+
+    }
+
+    @Test
+    public void transform_shoulHandleWhenMatchingDatasetIsPresentAndToDateIsMissingFromCurrentAddress() throws Exception {
+        Attribute currentAddress = anAddressAttribute().addAddress(anAddressAttributeValue().withTo(null).build()).buildCurrentAddress();
+        Assertion assertion = aMatchingDatasetAssertion(
+                aPersonName_1_1().buildAsFirstname(),
+                aPersonName_1_1().buildAsMiddlename(),
+                aPersonName_1_1().buildAsSurname(),
+                aGender_1_1().build(),
+                aDate_1_1().buildAsDateOfBirth(),
+                currentAddress,
+                anAddressAttribute().addAddress(anAddressAttributeValue().build()).buildPreviousAddress()).buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(assertion);
+
+        assertThat(matchingDataset).isNotNull();
+    }
+
+    @Test
+    public void transform_shoulHandleWhenMatchingDatasetIsPresentAndToDateIsMissingFromPreviousAddress() throws Exception {
+        Assertion assertion = aMatchingDatasetAssertion(
+                aPersonName_1_1().buildAsFirstname(),
+                aPersonName_1_1().buildAsMiddlename(),
+                aPersonName_1_1().buildAsSurname(),
+                aGender_1_1().build(),
+                aDate_1_1().buildAsDateOfBirth(),
+                anAddressAttribute().addAddress(anAddressAttributeValue().build()).buildCurrentAddress(),
+                anAddressAttribute().addAddress(anAddressAttributeValue().withTo(null).build()).buildPreviousAddress()).buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(assertion);
+
+        assertThat(matchingDataset).isNotNull();
+    }
+
+    @Test
+    public void transform_shoulHandleWhenMatchingDatasetIsPresentAndToDateIsMissingFromFirstName() throws Exception {
+        Attribute firstName = aPersonName_1_1().addValue(aPersonNameValue().withTo(null).build()).buildAsFirstname();
+        Assertion assertion = aMatchingDatasetAssertion(
+                firstName,
+                aPersonName_1_1().buildAsMiddlename(),
+                aPersonName_1_1().buildAsSurname(),
+                aGender_1_1().build(),
+                aDate_1_1().buildAsDateOfBirth(),
+                anAddressAttribute().addAddress(anAddressAttributeValue().build()).buildCurrentAddress(),
+                anAddressAttribute().addAddress(anAddressAttributeValue().build()).buildPreviousAddress()).buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(assertion);
+
+        assertThat(matchingDataset).isNotNull();
+    }
+
+    @Test
+    public void transform_shoulHandleWhenMatchingDatasetIsPresentAndToDateIsPresentInFirstName() throws Exception {
+        Attribute firstName = aPersonName_1_1().addValue(aPersonNameValue().withTo(DateTime.parse("1066-01-05")).build()).buildAsFirstname();
+        Assertion assertion = aMatchingDatasetAssertion(
+                firstName,
+                aPersonName_1_1().buildAsMiddlename(),
+                aPersonName_1_1().buildAsSurname(),
+                aGender_1_1().build(),
+                aDate_1_1().buildAsDateOfBirth(),
+                anAddressAttribute().addAddress(anAddressAttributeValue().build()).buildCurrentAddress(),
+                anAddressAttribute().addAddress(anAddressAttributeValue().build()).buildPreviousAddress()).buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(assertion);
+
+        assertThat(matchingDataset).isNotNull();
+    }
+
+    @Test
+    public void transform_shouldMapMultipleFirstNames() throws Exception {
+        Attribute firstName = aPersonName_1_1()
+                .addValue(aPersonNameValue().withValue("name1").build())
+                .addValue(aPersonNameValue().withValue("name2").build())
+                .buildAsFirstname();
+
+        AttributeStatement attributeStatementBuilder = anAttributeStatement().addAttribute(firstName).build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatementBuilder)
+                .buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(matchingDatasetAssertion);
+
+        assertThat(matchingDataset).isNotNull();
+        assertThat(matchingDataset.getFirstNames().size()).isEqualTo(2);
+    }
+    @Test
+    public void transform_shouldMapMultipleSurnames() throws Exception {
+        Attribute surName = aPersonName_1_1()
+                .addValue(aPersonNameValue().withValue("name1").build())
+                .addValue(aPersonNameValue().withValue("name2").build())
+                .buildAsSurname();
+
+        AttributeStatement attributeStatementBuilder = anAttributeStatement().addAttribute(surName).build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatementBuilder)
+                .buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(matchingDatasetAssertion);
+
+        assertThat(matchingDataset).isNotNull();
+        assertThat(matchingDataset.getSurnames().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void transform_shouldMapMultipleMiddleNames() throws Exception {
+        Attribute middleName = aPersonName_1_1()
+                .addValue(aPersonNameValue().withValue("name1").build())
+                .addValue(aPersonNameValue().withValue("name2").build())
+                .buildAsMiddlename();
+
+        AttributeStatement attributeStatementBuilder = anAttributeStatement().addAttribute(middleName).build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatementBuilder)
+                .buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(matchingDatasetAssertion);
+
+        assertThat(matchingDataset).isNotNull();
+        assertThat(matchingDataset.getMiddleNames().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void transform_shouldMapMultipleBirthdates() throws Exception {
+        Attribute attribute = aDate_1_1().addValue(aDateValue().withValue("2012-12-12").build()).addValue(aDateValue().withValue("2011-12-12").build()).buildAsDateOfBirth();
+
+        AttributeStatement attributeStatementBuilder = anAttributeStatement().addAttribute(attribute).build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatementBuilder)
+                .buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(matchingDatasetAssertion);
+
+        assertThat(matchingDataset).isNotNull();
+        assertThat(matchingDataset.getDateOfBirths().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void transform_shouldMapMultipleCurrentAddresses() throws Exception {
+        Attribute attribute = anAddressAttribute().addAddress(anAddressAttributeValue().build()).addAddress(anAddressAttributeValue().build()).buildCurrentAddress();
+
+        AttributeStatement attributeStatementBuilder = anAttributeStatement().addAttribute(attribute).build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatementBuilder)
+                .buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(matchingDatasetAssertion);
+
+        assertThat(matchingDataset).isNotNull();
+        assertThat(matchingDataset.getAddresses().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void transform_shouldMapMultiplePreviousAddresses() throws Exception {
+        Attribute attribute = anAddressAttribute().addAddress(anAddressAttributeValue().build()).addAddress(anAddressAttributeValue().build()).buildPreviousAddress();
+
+        AttributeStatement attributeStatementBuilder = anAttributeStatement().addAttribute(attribute).build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatementBuilder)
+                .buildUnencrypted();
+
+        MatchingDataset matchingDataset = unmarshaller.fromAssertion(matchingDatasetAssertion);
+
+        assertThat(matchingDataset).isNotNull();
+        assertThat(matchingDataset.getAddresses().size()).isEqualTo(2);
+    }
+
+
+}

--- a/hub-saml/Readme.md
+++ b/hub-saml/Readme.md
@@ -1,0 +1,38 @@
+# Verify Hub SAML
+
+Responsible for SAML behaviours which are specific to the domain of the hub. At a high level:
+
+* Handling requests from RPs
+* Generating requests for IDPs
+* Handling responses from IDPs
+* Generating requests for MSAs
+* Handling responses from MSAs
+* Generating responses for RPs
+
+At a lower level this includes:
+
+* Converting OpenSAML objects to Hub domain objects
+* Converting Hub domain objects to OpenSAML objects
+* Validating assertions from IDP responses
+* Validating assertions from MSA responses
+* Generating Attribute Query Requests
+* Generating Cycle 3 Dataset Assertions
+* Hashing PIDs
+
+Common tasks (e.g. validating signatures) are handled by dependencies such as [saml-security](https://github.com/alphagov/verify-saml-security) and [saml-serializers](https://github.com/alphagov/verify-saml-serializers).
+
+# Hub SAML Test Utils
+
+`hub-saml-test-utils` is provided for services which require hub-like behaviour to set up state for their tests.
+For example: in order to test stub-idp we need to generate an example AuthnRequest. `hub-saml-test-utils` provides
+helpful builders for situations like this.
+
+### Building the project
+
+`./gradlew clean build`
+
+## Licence
+
+[MIT Licence](LICENCE)
+
+This code is provided for informational purposes only and is not yet intended for use outside GOV.UK Verify

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    compile configurations.common,
+            configurations.saml_libs,
+            configurations.ida_utils
+
+    testCompile configurations.test_deps_compile,
+            configurations.dev_pki,
+            project(':hub-saml-test-utils')
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/InternalPublicKeyStore.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/InternalPublicKeyStore.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.saml.core;
+
+import java.security.PublicKey;
+import java.util.List;
+
+public interface InternalPublicKeyStore {
+    List<PublicKey> getVerifyingKeysForEntity();
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/IdaMatchingServiceResponse.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/IdaMatchingServiceResponse.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.core.domain;
+
+import org.joda.time.DateTime;
+
+public abstract class IdaMatchingServiceResponse extends IdaMessage implements IdaResponse {
+
+    private String inResponseTo;
+
+    protected IdaMatchingServiceResponse() {
+    }
+
+    public IdaMatchingServiceResponse(String responseId, String inResponseTo, String issuer, DateTime issueInstant) {
+        super(responseId, issuer, issueInstant);
+        this.inResponseTo = inResponseTo;
+    }
+
+    public String getInResponseTo() {
+        return inResponseTo;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/InboundResponseFromIdpData.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/InboundResponseFromIdpData.java
@@ -1,0 +1,83 @@
+package uk.gov.ida.saml.core.domain;
+
+import java.util.Optional;
+
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+
+public class InboundResponseFromIdpData {
+    private IdpIdaStatus.Status status;
+    private String issuer;
+    private Optional<String> persistentId;
+    private Optional<String> statusMessage;
+    private Optional<String> authnStatementAssertionBlob;
+    private Optional<String> encryptedMatchingDatasetAssertion;
+    private Optional<String> principalIpAddressAsSeenByIdp;
+    private String levelOfAssurance;
+    private Optional<String> idpFraudEventId;
+    private Optional<String> fraudIndicator;
+
+    public InboundResponseFromIdpData(
+            IdpIdaStatus.Status status,
+            Optional<String> statusMessage,
+            String issuer,
+            Optional<String> authnStatementAssertionBlob,
+            Optional<String> encryptedMatchingDatasetAssertion,
+            Optional<String> persistentId,
+            Optional<String> principalIpAddressAsSeenByIdp,
+            String levelOfAssurance,
+            Optional<String> idpFraudEventId,
+            Optional<String> fraudIndicator) {
+        this.status = status;
+        this.statusMessage = statusMessage;
+        this.issuer = issuer;
+        this.authnStatementAssertionBlob = authnStatementAssertionBlob;
+        this.encryptedMatchingDatasetAssertion = encryptedMatchingDatasetAssertion;
+        this.principalIpAddressAsSeenByIdp = principalIpAddressAsSeenByIdp;
+        this.persistentId = persistentId;
+        this.levelOfAssurance = levelOfAssurance;
+        this.idpFraudEventId = idpFraudEventId;
+        this.fraudIndicator = fraudIndicator;
+    }
+
+    protected InboundResponseFromIdpData() {}
+
+    public Optional<String> getAuthnStatementAssertionBlob() {
+        return authnStatementAssertionBlob;
+    }
+
+    public IdpIdaStatus.Status getStatus() {
+        return status;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public Optional<String> getStatusMessage() {
+        return statusMessage;
+    }
+
+    public Optional<String> getPrincipalIpAddressAsSeenByIdp() {
+        return principalIpAddressAsSeenByIdp;
+    }
+
+    public Optional<String> getPersistentId() {
+        return persistentId;
+    }
+
+    public String getLevelOfAssurance() {
+        return levelOfAssurance;
+    }
+
+    public Optional<String> getIdpFraudEventId() {
+        return idpFraudEventId;
+    }
+
+    public Optional<String> getFraudIndicator() {
+        return fraudIndicator;
+    }
+
+    public Optional<String> getEncryptedMatchingDatasetAssertion() {
+        return encryptedMatchingDatasetAssertion;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/MatchingServiceAuthnStatement.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/MatchingServiceAuthnStatement.java
@@ -1,0 +1,23 @@
+package uk.gov.ida.saml.core.domain;
+
+public final class MatchingServiceAuthnStatement {
+
+    private AuthnContext authnContext;
+
+    private MatchingServiceAuthnStatement() {
+    }
+
+    private MatchingServiceAuthnStatement(AuthnContext authnContext) {
+        this.authnContext = authnContext;
+    }
+
+    public AuthnContext getAuthnContext() {
+        return authnContext;
+    }
+
+    public static MatchingServiceAuthnStatement createIdaAuthnStatement(
+            AuthnContext authnContext) {
+
+        return new MatchingServiceAuthnStatement(authnContext);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/errors/SamlTransformationErrorFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/errors/SamlTransformationErrorFactory.java
@@ -1,0 +1,366 @@
+package uk.gov.ida.saml.core.errors;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationWarning;
+import uk.gov.ida.saml.core.validation.errors.*;
+
+import javax.xml.namespace.QName;
+import java.net.URI;
+
+import static java.text.MessageFormat.format;
+import static uk.gov.ida.saml.core.validation.errors.ResponseProcessingValidationSpecification.ATTRIBUTE_STATEMENT_EMPTY;
+
+public final class SamlTransformationErrorFactory {
+
+    private SamlTransformationErrorFactory() {
+    }
+
+    public static SamlValidationSpecificationFailure duplicateRequestId(String requestId, String issuerId) {
+        return new DuplicateRequestIdValidationSpecificationFailure(DuplicateRequestIdValidationSpecificationFailure.DUPLICATE_REQUEST_ID, requestId, issuerId);
+    }
+
+    public static SamlValidationSpecificationFailure authnContextMissingError() {
+        return new AuthnContextMissingError(AuthnContextMissingError.MISSING_AUTHN_CONTEXT, false);
+    }
+
+    public static SamlValidationSpecificationFailure scopingNotAllowed() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.SCOPE_NOT_ALLOWED);
+    }
+
+    public static SamlValidationSpecificationFailure illegalProtocolBindingError(final String protocolBinding, final String expectedProtocolBinding) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.PROTOCOL_BINDING, protocolBinding, expectedProtocolBinding);
+    }
+
+    public static SamlValidationSpecificationFailure unrecognisedBinding(final String binding) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.UNRECOGNISED_BINDING, binding);
+    }
+
+    public static SamlValidationSpecificationFailure isPassiveNotAllowed() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.PASSIVE_NOT_ALLOWED);
+    }
+
+    public static SamlValidationSpecificationFailure missingNameIDPolicy() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_NAME_ID_POLICY);
+    }
+
+    public static SamlValidationSpecificationFailure illegalNameIDPolicy(final String policy) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.ILLEGAL_NAME_ID_POLICY, policy);
+    }
+
+    public static SamlValidationSpecificationFailure attributeStatementEmpty(final String assertionId) {
+        return new ResponseProcessingValidationSpecification(ATTRIBUTE_STATEMENT_EMPTY, assertionId);
+    }
+
+    public static SamlValidationSpecificationFailure missingInResponseTo() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_INRESPONSE_TO);
+    }
+
+    public static SamlValidationSpecificationFailure emptyInResponseTo() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.EMPTY_INRESPONSE_TO);
+    }
+
+    public static SamlValidationSpecificationFailure authnContextClassRefMissing() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_AUTHN_CONTEXT_CLASS_REF, false);
+    }
+
+    public static SamlValidationSpecificationFailure authnContextClassRefValueMissing() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_AUTHN_CONTEXT_CLASS_REF_VALUE, false);
+    }
+
+    public static SamlValidationSpecificationFailure authnInstantMissing() {
+        return new ResponseProcessingValidationSpecification("AuthnStatement is missing 'AuthnInstant'"); //TODO: need to update saml-extensions to constantise this string
+    }
+
+    public static SamlValidationSpecificationFailure missingAuthnStatement() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_AUTHN_STATEMENT, false);
+    }
+
+    public static SamlValidationSpecificationFailure multipleAuthnStatements() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MULTIPLE_AUTHN_STATEMENTS, false);
+    }
+
+    public static SamlValidationSpecificationFailure authnStatementAlreadyReceived(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.AUTHN_STATEMENT_ALREADY_RECEIVED, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingAssertionSubject(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUBJECT, id);
+    }
+
+    public static SamlValidationSpecificationFailure assertionSubjectHasNoNameID(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.SUBJECT_HAS_NO_NAME_ID, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingAssertionSubjectNameIDFormat(final String id) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUBJECT_NAME_ID_FORMAT, id);
+    }
+
+    public static SamlValidationSpecificationFailure illegalAssertionSubjectNameIDFormat(final String id, final String format) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.ILLEGAL_SUBJECT_NAME_ID_FORMAT, id, format);
+    }
+
+    public static SamlValidationSpecificationFailure unencryptedAssertion() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.UNENCRYPTED_ASSERTIONS);
+    }
+
+    public static SamlValidationSpecificationFailure missingSuccessUnEncryptedAssertions() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUCCESS_UNENCRYPTED);
+    }
+
+    public static SamlValidationSpecificationFailure nonSuccessHasUnEncryptedAssertions() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.NON_SUCCESS_HAS_UNENCRYPTED);
+    }
+
+    public static SamlValidationSpecificationFailure missingMatchingMds() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_MDS);
+    }
+
+    public static SamlValidationSpecificationFailure emptyIssuer() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_ISSUER);
+    }
+
+    public static SamlValidationSpecificationFailure illegalIssuerFormat(final String providedFormat, final String expectedFormat) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ILLEGAL_ISSUER_FORMAT, providedFormat, expectedFormat);
+    }
+
+    public static SamlValidationSpecificationFailure destinationMissing(final URI expectedUri) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_DESTINATION, expectedUri);
+    }
+
+    public static SamlValidationSpecificationFailure destinationEmpty(final URI expectedUri, final String destination) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_DESTINATION, expectedUri, destination);
+    }
+
+    public static SamlValidationSpecificationFailure destinationInvalid(URI uri, String endpoint) {
+        return new GenericHubProfileValidationSpecification("Destination is incorrect. Received: {0}{1}{2}", uri.getScheme(), uri.getPath(), endpoint);
+    }
+
+    public static SamlValidationSpecificationFailure assertionNotSigned(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ASSERTION_SIGNATURE_NOT_SIGNED, id);
+    }
+
+    public static SamlValidationSpecificationFailure assertionSignatureMissing(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ASSERTION_SIGNATURE, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingIssueInstant(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ISSUE_INSTANT, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingVersion(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_VERSION, id);
+    }
+
+    public static SamlValidationSpecificationFailure illegalVersion(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ILLEGAL_VERSION, id);
+    }
+
+    public static SamlValidationSpecificationFailure noSubjectConfirmationWithBearerMethod(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.NO_SUBJECT_CONF_WITH_BEARER_METHOD, id);
+    }
+
+    public static SamlValidationSpecificationFailure emptyIPAddress(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_IP_ADDRESS, id);
+    }
+
+    public static SamlValidationSpecificationFailure missingIPAddress(final String id) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_IP_ADDRESS, id);
+    }
+
+    public static SamlValidationSpecificationFailure duplicateMatchingDataset(final String id, final String responseIssuerId) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.DUPLICATE_MATCHING_DATASET, id, responseIssuerId);
+    }
+
+    public static SamlValidationSpecificationFailure mdsStatementMissing() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MDS_STATEMENT_MISSING);
+    }
+
+    public static SamlValidationSpecificationFailure mdsMultipleStatements() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MDS_MULTIPLE_STATEMENTS);
+    }
+
+    public static SamlValidationSpecificationFailure mdsAttributeNotRecognised(final String attributeName) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MDS_ATTRIBUTE_NOT_RECOGNISED, attributeName);
+    }
+
+    public static SamlValidationSpecificationFailure emptyAttribute(final String attributeName) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_ATTRIBUTE, attributeName);
+    }
+
+    public static SamlValidationSpecificationFailure attributeWithIncorrectType(final String attributeName, final QName expected, final QName received) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.ATTRIBUTE_HAS_INCORRECT_TYPE, attributeName, expected, received);
+    }
+
+    public static SamlValidationSpecificationFailure illegalRequestVersionNumber() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.INCORRECT_VERSION);
+    }
+
+    public static SamlValidationSpecificationFailure requestTooOld(String requestId, DateTime issueInstant, DateTime currentTime) {
+        return new RequestFreshnessValidationSpecification(RequestFreshnessValidationSpecification.REQUEST_TOO_OLD, requestId, issueInstant, currentTime);
+    }
+
+    public static SamlValidationSpecificationFailure missingRequestId() {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_ID);
+    }
+
+    public static SamlValidationSpecificationFailure missingRequestIssueInstant(final String requestId) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_ISSUE_INSTANT, requestId);
+    }
+
+    public static SamlValidationSpecificationFailure missingRequestVersion(final String requestId) {
+        return new AuthnRequestFromTransactionValidationSpecification(AuthnRequestFromTransactionValidationSpecification.MISSING_VERSION, requestId);
+    }
+
+    public static SamlValidationSpecificationFailure nestedSubStatusCodesBreached(int subStatusCodeLimit) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.SUB_STATUS_CODE_LIMIT_EXCEEDED, subStatusCodeLimit);
+    }
+
+    public static SamlValidationSpecificationFailure invalidStatusCode(final String statusCode) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.INVALID_STATUS_CODE, statusCode);
+    }
+
+    public static SamlValidationSpecificationFailure invalidSubStatusCode(final String subStatusCode, final String statusCode) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.INVALID_SUB_STATUS_CODE, subStatusCode, statusCode);
+    }
+
+    public static SamlValidationSpecificationFailure subStatusMustBeOneOf(final String subStatus, final String code1, final String code2, final String code3) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.STATUS_CODE_MUST_BE_ONE_OF, subStatus, code1, code2, code3);
+    }
+
+    public static SamlValidationSpecificationFailure missingSubStatus() {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.MISSING_SUB_STATUS);
+    }
+
+    public static SamlValidationSpecificationFailure unexpectedNumberOfAssertions(int expected, int actual) {
+        return new ResponseProcessingValidationSpecification(ResponseProcessingValidationSpecification.UNEXPECTED_NUMBER_OF_ASSERTIONS, expected, actual);
+    }
+
+    public static SamlValidationSpecificationFailure notMatchInResponseTo(final String inResponseTo, final String requestId) {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.IN_RESPONSE_TO_DOES_NOT_MATCH, inResponseTo, requestId);
+    }
+
+    public static SamlValidationSpecificationFailure incorrectRecipientFormat(String recipient, String expectedRecipient) {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.INCORRECT_RECIPIENT_FORMAT, recipient, expectedRecipient);
+    }
+
+    public static SamlValidationSpecificationFailure missingSubjectConfirmationData() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.MISSING_SUBJECT_CONFIRMATION_DATA);
+    }
+
+    public static SamlValidationSpecificationFailure missingBearerInResponseTo() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NO_INRESPONSETO_VALUE);
+    }
+
+    public static SamlValidationSpecificationFailure missingBearerRecipient() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NO_RECIPIENT);
+    }
+
+    public static SamlValidationSpecificationFailure missingNotOnOrAfter() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NO_NOT_ON_OR_AFTER);
+    }
+
+    public static SamlValidationSpecificationFailure exceededNotOnOrAfter(DateTime expiredTime) {
+        return new BearerSubjectConfirmationValidationSpecification(format(BearerSubjectConfirmationValidationSpecification.EXCEEDED_NOT_ON_OR_AFTER, expiredTime));
+    }
+
+    public static SamlValidationSpecificationFailure notBeforeExists() {
+        return new BearerSubjectConfirmationValidationSpecification(BearerSubjectConfirmationValidationSpecification.NOT_BEFORE_ATTRIBUTE_EXISTS);
+    }
+
+    public static SamlValidationSpecificationFailure missingOrEmptyEntityID() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_OR_EMPTY_ENTITY_ID);
+    }
+
+    public static SamlValidationSpecificationFailure missingCacheDurationAndValidUntil() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_CACHEDUR_VALIDUNTIL);
+    }
+
+    public static SamlValidationSpecificationFailure missingRoleDescriptor() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ROLE_DESCRIPTOR);
+    }
+
+    public static SamlValidationSpecificationFailure missingKeyDescriptor() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_KEY_DESCRIPTOR);
+    }
+
+    public static SamlValidationSpecificationFailure missingKeyInfo() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_KEY_INFO);
+    }
+
+    public static SamlValidationSpecificationFailure missingX509Data() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_X509DATA);
+    }
+
+    public static SamlValidationSpecificationFailure missingX509Certificate() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_X509CERT);
+    }
+
+    public static SamlValidationSpecificationFailure emptyX509Certificiate() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.EMPTY_X509CERT);
+    }
+
+    public static SamlValidationSpecificationFailure missingOrganization() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ORGANIZATION);
+    }
+
+    public static SamlValidationSpecificationFailure missingDisplayName() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_DISPLAY_NAME);
+    }
+
+    public static SamlValidationSpecificationFailure missingSignature() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_SIGNATURE);
+    }
+
+    public static SamlValidationSpecificationFailure signatureNotSigned() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.SIGNATURE_NOT_SIGNED);
+    }
+
+    public static SamlValidationSpecificationFailure missingIssuer() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ISSUER);
+    }
+
+    public static SamlValidationSpecificationFailure missingId() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_ID);
+    }
+
+    public static SamlValidationSpecificationFailure missingKey(final String key, final String entity) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISSING_KEY, key, entity);
+    }
+
+    public static SamlValidationSpecificationFailure unsupportedKey(final String key) {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.UNSUPPORTED_KEY, key);
+    }
+
+    public static SamlValidationSpecificationFailure invalidRequestID() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.INVALID_REQUEST_ID);
+    }
+
+    public static SamlValidationSpecificationFailure invalidRelayState(String relayState) {
+        return new RelayStateValidationSpecification(RelayStateValidationSpecification.INVALID_RELAY_STATE, relayState);
+    }
+
+    public static SamlValidationSpecificationFailure relayStateContainsInvalidCharacter(String invalidCharacter, String relayState) {
+        return new RelayStateValidationSpecification(RelayStateValidationSpecification.INVALID_RELAY_STATE_CHARACTER, invalidCharacter, relayState);
+    }
+
+    public static SamlValidationSpecificationFailure invalidAttributeLanguageInAssertion(final String name, final String language) {
+        return new InvalidAttributeLanguageInAssertion(name, language);
+    }
+
+    public static SamlValidationSpecificationFailure invalidFraudAttribute(String message) {
+        return new SamlValidationSpecification(SamlValidationSpecification.DESERIALIZATION_ERROR, message);
+    }
+
+    public static SamlValidationSpecificationWarning invalidAttributeNameFormat(final String nameFormat) {
+        return new InvalidAttributeNameFormat(nameFormat);
+    }
+
+    public static SamlValidationSpecificationFailure mismatchedPersistentIdentifiers() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISMATCHED_PIDS);
+    }
+
+    public static SamlValidationSpecificationFailure mismatchedIssuers() {
+        return new GenericHubProfileValidationSpecification(GenericHubProfileValidationSpecification.MISMATCHED_ISSUERS);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/security/RelayStateValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/security/RelayStateValidator.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.core.security;
+
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+public class RelayStateValidator {
+
+    private static final int MAXIMUM_NUMBER_OF_CHARACTERS = 80;
+    private static final String[] INVALID_CHARACTERS = new String[]{"<", ">", "'", ";", "\"","%", "&"};
+
+    public void validate(String relayState) {
+        if (relayState == null){
+            return;
+        }
+
+        if (relayState.length() > MAXIMUM_NUMBER_OF_CHARACTERS) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.invalidRelayState(relayState);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        for (String invalidCharacter : INVALID_CHARACTERS) {
+            if (relayState.contains(invalidCharacter)) {
+                SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.relayStateContainsInvalidCharacter(invalidCharacter, relayState);
+                throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+            }
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/AssertionBlobEncrypter.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/AssertionBlobEncrypter.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.saml.core.transformers.outbound.decorators;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+public class AssertionBlobEncrypter {
+    private final StringToOpenSamlObjectTransformer<Assertion> stringToAssertionTransformer;
+    private final XmlObjectToBase64EncodedStringTransformer<Assertion> assertionToBase64EncodedStringTransformer;
+    private AssertionEncrypter assertionEncrypter;
+
+    @Inject
+    public AssertionBlobEncrypter(StringToOpenSamlObjectTransformer<Assertion> stringToAssertionTransformer,
+                                  XmlObjectToBase64EncodedStringTransformer<Assertion> assertionToBase64EncodedStringTransformer,
+                                  AssertionEncrypter assertionEncrypter)
+    {
+        this.stringToAssertionTransformer = stringToAssertionTransformer;
+        this.assertionToBase64EncodedStringTransformer = assertionToBase64EncodedStringTransformer;
+        this.assertionEncrypter = assertionEncrypter;
+    }
+
+
+    public String encryptAssertionBlob(String entityId, String matchingDatasetAssertionBlob) {
+        return Optional
+                .ofNullable(matchingDatasetAssertionBlob)
+                .map(stringToAssertionTransformer::apply)
+                .map(assertion -> assertionEncrypter.encrypt(assertion, entityId))
+                .map(assertionToBase64EncodedStringTransformer::apply)
+                .get();
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionEncrypter.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionEncrypter.java
@@ -1,0 +1,52 @@
+package uk.gov.ida.saml.core.transformers.outbound.decorators;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EncryptionCredentialFactory;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+
+import java.util.List;
+
+public class SamlAttributeQueryAssertionEncrypter extends AbstractAssertionEncrypter<AttributeQuery> {
+
+    @Inject
+    public SamlAttributeQueryAssertionEncrypter(
+            final EncryptionCredentialFactory credentialFactory,
+            final EncrypterFactory encrypterFactory,
+            final EntityToEncryptForLocator entityToEncryptForLocator) {
+
+        super(encrypterFactory, entityToEncryptForLocator, credentialFactory);
+    }
+
+    @Override
+    protected String getRequestId(final AttributeQuery attributeQuery) {
+        return attributeQuery.getID();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected List<EncryptedAssertion> getEncryptedAssertions(final AttributeQuery attributeQuery) {
+        final SubjectConfirmationData subjectConfirmationData = attributeQuery.getSubject()
+                .getSubjectConfirmations()
+                .get(0)
+                .getSubjectConfirmationData();
+
+        return (List<EncryptedAssertion>) (List<?>)
+                subjectConfirmationData.getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected List<Assertion> getAssertions(final AttributeQuery attributeQuery) {
+        final SubjectConfirmationData subjectConfirmationData = attributeQuery.getSubject()
+                .getSubjectConfirmations()
+                .get(0)
+                .getSubjectConfirmationData();
+        return (List<Assertion>) (List<?>)
+                subjectConfirmationData.getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/DestinationValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/DestinationValidator.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.core.validators;
+
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.destinationEmpty;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.destinationMissing;
+
+public class DestinationValidator {
+
+    private final URI expectedUri;
+
+    public DestinationValidator(URI expectedDestinationHost, String expectedEndpoint) {
+        expectedUri = uriWithoutPort(expectedDestinationHost, expectedEndpoint);
+    }
+
+    /*
+    Validate that the destination sent to us matches the configured host & the given path
+
+    Path is added because we have to do validation on both Responses & Requests
+     */
+    public void validate(String destination) {
+        if(destination == null) throw new SamlValidationException(destinationMissing(expectedUri));
+
+        URI destinationURI = URI.create(destination);
+
+        URI destinationURIWithoutPort;
+        destinationURIWithoutPort = uriWithoutPort(destinationURI, destinationURI.getPath());
+
+        if (!expectedUri.equals(destinationURIWithoutPort))
+            throw new SamlValidationException(destinationEmpty(expectedUri, destination));
+    }
+
+    private URI uriWithoutPort(URI destinationURI, String endpoint) {
+        try {
+            return new URI(destinationURI.getScheme(), destinationURI.getHost(), endpoint, null);
+        } catch (URISyntaxException e) {
+            throw new SamlValidationException(SamlTransformationErrorFactory.destinationInvalid(destinationURI, endpoint));
+        }
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/SamlValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/SamlValidator.java
@@ -1,0 +1,11 @@
+package uk.gov.ida.saml.core.validators;
+
+
+import org.opensaml.saml.common.SAMLObject;
+
+public interface SamlValidator<T extends SAMLObject> {
+    void validate(T itemToValidate);
+}
+
+
+

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/AssertionAttributeStatementValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/AssertionAttributeStatementValidator.java
@@ -1,0 +1,72 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.IdpFraudEventId;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidAttributeLanguageInAssertion;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidFraudAttribute;
+
+public class AssertionAttributeStatementValidator {
+
+    public static final String INVALID_FRAUD_EVENT_TYPE = "Invalid fraud event type";
+    private static final String INVALID_FRAUD_EVENT_NAME = "Invalid fraud event name";
+    private static final String INVALID_NUMBER_OF_FRAUD_EVENT_ATTRIBUTE_STATEMENTS = "Invalid number of fraud event attribute statements";
+
+    public void validate(Assertion assertion) {
+        for (AttributeStatement attributeStatement : assertion.getAttributeStatements()) {
+            for (Attribute attribute : attributeStatement.getAttributes()) {
+                for (XMLObject attributeValue : attribute.getAttributeValues()) {
+                    if (attributeValue instanceof PersonName) {
+                        PersonName personName = (PersonName) attributeValue;
+                        String language = personName.getLanguage();
+                        if (language != null && !IdaConstants.IDA_LANGUAGE.equals(language)) {
+                            SamlValidationSpecificationFailure failure = invalidAttributeLanguageInAssertion(attribute.getName(), language);
+                            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void validateFraudEvent(Assertion assertion) {
+        if(assertion.getAttributeStatements().size() != 1){
+            SamlValidationSpecificationFailure failure = invalidFraudAttribute(INVALID_NUMBER_OF_FRAUD_EVENT_ATTRIBUTE_STATEMENTS);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        else {
+            AttributeStatement attributeStatement = assertion.getAttributeStatements().get(0);
+            validateFraudEvent(attributeStatement);
+        }
+    }
+
+    private void validateFraudEvent(AttributeStatement attributeStatement) {
+        Attribute fraudEventAttribute = Iterables.find(attributeStatement.getAttributes(), new Predicate<Attribute>() {
+            @Override
+            public boolean apply(Attribute input) {
+                return input.getName().equals(IdaConstants.Attributes_1_1.IdpFraudEventId.NAME);
+            }
+        }, null);
+        if(fraudEventAttribute == null){
+            SamlValidationSpecificationFailure failure = invalidFraudAttribute(INVALID_FRAUD_EVENT_NAME);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        } else {
+            boolean didNotDeserializeCorrectlyIntoFraudEventType = !(fraudEventAttribute.getAttributeValues().get(0) instanceof IdpFraudEventId);
+            if (didNotDeserializeCorrectlyIntoFraudEventType) {
+                SamlValidationSpecificationFailure failure = invalidFraudAttribute(INVALID_FRAUD_EVENT_TYPE);
+                throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+            }
+        }
+    }
+
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidator.java
@@ -1,0 +1,77 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.BasicAssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil;
+
+public class AssertionValidator {
+
+    private final IssuerValidator issuerValidator;
+    private final AssertionSubjectValidator subjectValidator;
+    protected final AssertionAttributeStatementValidator assertionAttributeStatementValidator;
+    private final BasicAssertionSubjectConfirmationValidator basicAssertionSubjectConfirmationValidator;
+
+    public AssertionValidator(
+            IssuerValidator issuerValidator,
+            AssertionSubjectValidator subjectValidator,
+            AssertionAttributeStatementValidator assertionAttributeStatementValidator,
+            BasicAssertionSubjectConfirmationValidator basicAssertionSubjectConfirmationValidator) {
+
+        this.issuerValidator = issuerValidator;
+        this.subjectValidator = subjectValidator;
+        this.assertionAttributeStatementValidator = assertionAttributeStatementValidator;
+        this.basicAssertionSubjectConfirmationValidator = basicAssertionSubjectConfirmationValidator;
+    }
+
+    public void validate(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        Signature signature = assertion.getSignature();
+        if (assertion.getID() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingId();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (signature == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionSignatureMissing(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionNotSigned(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (assertion.getIssueInstant() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingIssueInstant(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (assertion.getVersion() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingVersion(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (!assertion.getVersion().equals(SAMLVersion.VERSION_20)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.illegalVersion(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        issuerValidator.validate(assertion.getIssuer());
+        assertionAttributeStatementValidator.validate(assertion);
+
+        validateSubject(assertion, requestId, expectedRecipientId);
+        basicAssertionSubjectConfirmationValidator.validate(assertion.getSubject().getSubjectConfirmations().get(0));
+    }
+
+    protected void validateSubject(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        subjectValidator.validate(assertion.getSubject(), assertion.getID());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/AuthnStatementAssertionValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/AuthnStatementAssertionValidator.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnContextClassRefMissing;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnContextClassRefValueMissing;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnContextMissingError;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnInstantMissing;
+
+public class AuthnStatementAssertionValidator {
+    private final DuplicateAssertionValidator duplicateAssertionValidator;
+
+    public AuthnStatementAssertionValidator(DuplicateAssertionValidator duplicateAssertionValidator) {
+        this.duplicateAssertionValidator = duplicateAssertionValidator;
+    }
+
+    public void validate(Assertion assertion) {
+        validateAuthnStatement(assertion.getAuthnStatements().get(0));
+        duplicateAssertionValidator.validateAuthnStatementAssertion(assertion);
+    }
+
+    private void validateAuthnStatement(AuthnStatement authnStatement) {
+        if (authnStatement.getAuthnContext() == null)
+            throw new SamlValidationException(authnContextMissingError());
+        if (authnStatement.getAuthnContext().getAuthnContextClassRef() == null)
+            throw new SamlValidationException(authnContextClassRefMissing());
+        if (authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef() == null)
+            throw new SamlValidationException(authnContextClassRefValueMissing());
+        if (authnStatement.getAuthnInstant() == null)
+            throw new SamlValidationException(authnInstantMissing());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidator.java
@@ -1,0 +1,41 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+
+import java.util.concurrent.ConcurrentMap;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnStatementAlreadyReceived;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.duplicateMatchingDataset;
+
+public class DuplicateAssertionValidator {
+
+    private final ConcurrentMap<String, DateTime> duplicateIds;
+
+    @Inject
+    public DuplicateAssertionValidator(ConcurrentMap<String, DateTime> duplicateIds) {
+        this.duplicateIds = duplicateIds;
+    }
+
+    public void validateAuthnStatementAssertion(Assertion assertion) {
+        if (!valid(assertion)) throw new SamlValidationException(authnStatementAlreadyReceived(assertion.getID()));
+    }
+
+    public void validateMatchingDataSetAssertion(Assertion assertion, String responseIssuerId) {
+        if (!valid(assertion)) throw new SamlValidationException(duplicateMatchingDataset(assertion.getID(), responseIssuerId));
+    }
+
+    private boolean valid(Assertion assertion) {
+        if (isDuplicateNonExpired(assertion)) return false;
+
+        DateTime expire = assertion.getSubject().getSubjectConfirmations().get(0).getSubjectConfirmationData().getNotOnOrAfter();
+        duplicateIds.put(assertion.getID(), expire);
+        return true;
+    }
+
+    private boolean isDuplicateNonExpired(Assertion assertion) {
+        return duplicateIds.containsKey(assertion.getID()) && duplicateIds.get(assertion.getID()).isAfter(DateTime.now());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/IPAddressValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/IPAddressValidator.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import com.google.common.base.Strings;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.IPAddress;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+public class IPAddressValidator {
+    public void validate(Assertion assertion) {
+        for (AttributeStatement attributeStatement : assertion.getAttributeStatements()) {
+            for (Attribute attribute : attributeStatement.getAttributes()) {
+                if (attribute.getName().equals(IdaConstants.Attributes_1_1.IPAddress.NAME)) {
+                    IPAddress ipAddressAttributeValue = (IPAddress) attribute.getAttributeValues().get(0);
+                    String addressValue = ipAddressAttributeValue.getValue();
+                    if (!Strings.isNullOrEmpty(addressValue)) {
+                        return;
+                    }
+
+                    SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.emptyIPAddress(assertion.getID());
+                    throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+                }
+            }
+        }
+        SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingIPAddress(assertion.getID());
+        throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/IdentityProviderAssertionValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/IdentityProviderAssertionValidator.java
@@ -1,0 +1,116 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.AssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IdentityProviderAssertionValidator extends AssertionValidator {
+
+    private final AssertionSubjectConfirmationValidator subjectConfirmationValidator;
+
+    public IdentityProviderAssertionValidator(
+            IssuerValidator issuerValidator,
+            AssertionSubjectValidator subjectValidator,
+            AssertionAttributeStatementValidator assertionAttributeStatementValidator,
+            AssertionSubjectConfirmationValidator subjectConfirmationValidator) {
+
+        super(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+
+        this.subjectConfirmationValidator = subjectConfirmationValidator;
+    }
+
+    public void validateConsistency(Assertion authnStatementAssertion, Assertion matchingDatasetAssertion) {
+        validateConsistency(Arrays.asList(authnStatementAssertion, matchingDatasetAssertion));
+    }
+
+    public void validateConsistency(List<Assertion> assertions) {
+        ensurePidsMatch(assertions);
+
+        ensureIssuersMatch(assertions);
+    }
+
+    private void ensurePidsMatch(List<Assertion> assertions) {
+        boolean pidsDoNotMatch = assertions.stream()
+            .map(assertion -> assertion.getSubject().getNameID().getValue())
+            .distinct()
+            .count() > 1;
+
+        if (pidsDoNotMatch) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.mismatchedPersistentIdentifiers();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void ensureIssuersMatch(List<Assertion> assertions) {
+        boolean issuerValuesDoNotMatch = assertions.stream()
+            .map(assertion -> assertion.getIssuer().getValue())
+            .distinct()
+            .count() > 1;
+
+        if (issuerValuesDoNotMatch) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.mismatchedIssuers();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    @Override
+    protected void validateSubject(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        super.validateSubject(assertion, requestId, expectedRecipientId);
+
+        ensurePresenceOfBearerSubjectConfirmation(assertion);
+
+        validateAllBearerSubjectConfirmations(assertion, requestId, expectedRecipientId);
+
+        validateFraudAttribute(assertion);
+    }
+
+    private void validateAllBearerSubjectConfirmations(
+            Assertion assertion,
+            String requestId,
+            String expectedRecipientId) {
+
+        for (SubjectConfirmation subjectConfirmation : assertion.getSubject().getSubjectConfirmations()) {
+            if (SubjectConfirmation.METHOD_BEARER.equals(subjectConfirmation.getMethod())) {
+                subjectConfirmationValidator.validate(subjectConfirmation, requestId, expectedRecipientId);
+            }
+        }
+    }
+
+    private void ensurePresenceOfBearerSubjectConfirmation(Assertion assertion) {
+        boolean hasSubjectConfirmationWithBearerMethod = false;
+        for (SubjectConfirmation subjectConfirmation : assertion.getSubject().getSubjectConfirmations()) {
+            if (SubjectConfirmation.METHOD_BEARER.equals(subjectConfirmation.getMethod())) {
+                hasSubjectConfirmationWithBearerMethod = true;
+            }
+        }
+
+        if (!hasSubjectConfirmationWithBearerMethod) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.noSubjectConfirmationWithBearerMethod(assertion.getID());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void validateFraudAttribute(Assertion assertion) {
+        if (assertion.getAuthnStatements().size() == 1){
+            AuthnStatement authnStatement = assertion.getAuthnStatements().get(0);
+            boolean isFraudResponse = authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef().equals(AuthnContext.LEVEL_X.getUri());
+            if (isFraudResponse)
+            {
+                assertionAttributeStatementValidator.validateFraudEvent(assertion);
+            }
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/MatchingDatasetAssertionValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/MatchingDatasetAssertionValidator.java
@@ -1,0 +1,94 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.Address;
+import uk.gov.ida.saml.core.extensions.Date;
+import uk.gov.ida.saml.core.extensions.Gender;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+
+import javax.xml.namespace.QName;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.attributeStatementEmpty;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.attributeWithIncorrectType;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.emptyAttribute;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidAttributeNameFormat;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.mdsAttributeNotRecognised;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.mdsMultipleStatements;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.mdsStatementMissing;
+import static uk.gov.ida.saml.core.validation.SamlTransformationErrorManager.warn;
+
+public class MatchingDatasetAssertionValidator {
+
+    private final DuplicateAssertionValidator duplicateAssertionValidator;
+
+    public MatchingDatasetAssertionValidator(DuplicateAssertionValidator duplicateAssertionValidator) {
+        this.duplicateAssertionValidator = duplicateAssertionValidator;
+    }
+
+    private static final Set<String> VALID_ATTRIBUTE_NAMES_1_1 = ImmutableSet.of(
+        IdaConstants.Attributes_1_1.Firstname.NAME,
+        IdaConstants.Attributes_1_1.Middlename.NAME,
+        IdaConstants.Attributes_1_1.Surname.NAME,
+        IdaConstants.Attributes_1_1.Gender.NAME,
+        IdaConstants.Attributes_1_1.DateOfBirth.NAME,
+        IdaConstants.Attributes_1_1.CurrentAddress.NAME,
+        IdaConstants.Attributes_1_1.PreviousAddress.NAME
+    );
+
+    private static final Set<String> VALID_ATTRIBUTE_NAME_FORMATS = ImmutableSet.of(
+        Attribute.UNSPECIFIED
+    );
+
+    private static final Map<String, QName> VALID_TYPE_FOR_ATTRIBUTE = ImmutableMap.<String, QName>builder()
+        .put(IdaConstants.Attributes_1_1.Firstname.NAME, PersonName.TYPE_NAME)
+        .put(IdaConstants.Attributes_1_1.Middlename.NAME, PersonName.TYPE_NAME)
+        .put(IdaConstants.Attributes_1_1.Surname.NAME, PersonName.TYPE_NAME)
+        .put(IdaConstants.Attributes_1_1.Gender.NAME, Gender.TYPE_NAME)
+        .put(IdaConstants.Attributes_1_1.DateOfBirth.NAME, Date.TYPE_NAME)
+        .put(IdaConstants.Attributes_1_1.CurrentAddress.NAME, Address.TYPE_NAME)
+        .put(IdaConstants.Attributes_1_1.PreviousAddress.NAME, Address.TYPE_NAME)
+        .build();
+
+    public void validate(Assertion assertion, String responseIssuerId) {
+        duplicateAssertionValidator.validateMatchingDataSetAssertion(assertion, responseIssuerId);
+        validateAttributes(assertion);
+    }
+
+    private void validateAttributes(Assertion assertion) {
+        final List<AttributeStatement> attributeStatements = assertion.getAttributeStatements();
+        if (attributeStatements.isEmpty()) throw new SamlValidationException(mdsStatementMissing());
+        if (attributeStatements.size() > 1) throw new SamlValidationException(mdsMultipleStatements());
+
+        final List<Attribute> attributes = attributeStatements.get(0).getAttributes();
+        if (attributes.isEmpty()) throw new SamlValidationException(attributeStatementEmpty(assertion.getID()));
+
+        attributes.forEach(this::validateAttribute);
+    }
+
+    private void validateAttribute(Attribute attribute) {
+        String attributeName = attribute.getName();
+        if (!VALID_ATTRIBUTE_NAMES_1_1.contains(attributeName))
+            throw new SamlValidationException(mdsAttributeNotRecognised(attributeName));
+
+        List<XMLObject> attributeValues = attribute.getAttributeValues();
+        if(attributeValues.isEmpty())
+            throw new SamlValidationException(emptyAttribute(attributeName));
+
+        QName schemaType = attributeValues.get(0).getSchemaType();
+        if(!VALID_TYPE_FOR_ATTRIBUTE.get(attributeName).equals(schemaType))
+            throw new SamlValidationException(attributeWithIncorrectType(attributeName, VALID_TYPE_FOR_ATTRIBUTE.get(attributeName), schemaType));
+
+        if(!VALID_ATTRIBUTE_NAME_FORMATS.contains(attribute.getNameFormat()))
+            warn(invalidAttributeNameFormat(attribute.getNameFormat()));
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidator.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.saml.core.validators.subject;
+
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Subject;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+public class AssertionSubjectValidator {
+
+    public void validate(
+            Subject subject,
+            String assertionId) {
+
+        if (subject == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingAssertionSubject(assertionId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (subject.getNameID() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.assertionSubjectHasNoNameID(assertionId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (subject.getNameID().getFormat() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingAssertionSubjectNameIDFormat(assertionId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (!NameIDType.PERSISTENT.equals(subject.getNameID().getFormat())) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.illegalAssertionSubjectNameIDFormat(assertionId, subject.getNameID().getFormat());
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subjectconfirmation/AssertionSubjectConfirmationValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subjectconfirmation/AssertionSubjectConfirmationValidator.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.saml.core.validators.subjectconfirmation;
+
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+public class AssertionSubjectConfirmationValidator extends BasicAssertionSubjectConfirmationValidator {
+
+    public void validate(
+            SubjectConfirmation subjectConfirmation,
+            String requestId,
+            String expectedRecipientId) {
+
+        super.validate(subjectConfirmation);
+
+        SubjectConfirmationData subjectConfirmationData = subjectConfirmation.getSubjectConfirmationData();
+
+        if (!subjectConfirmationData.getInResponseTo().equals(requestId)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.notMatchInResponseTo(subjectConfirmationData.getInResponseTo(), requestId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (!subjectConfirmationData.getRecipient().equals(expectedRecipientId)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.incorrectRecipientFormat(subjectConfirmationData.getRecipient(), expectedRecipientId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+ }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subjectconfirmation/BasicAssertionSubjectConfirmationValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subjectconfirmation/BasicAssertionSubjectConfirmationValidator.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.core.validators.subjectconfirmation;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+public class BasicAssertionSubjectConfirmationValidator {
+
+    public void validate(SubjectConfirmation subjectConfirmation) {
+
+        final SubjectConfirmationData subjectConfirmationData = subjectConfirmation.getSubjectConfirmationData();
+
+        if (subjectConfirmationData == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingSubjectConfirmationData();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (subjectConfirmationData.getInResponseTo() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingBearerInResponseTo();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (subjectConfirmationData.getRecipient() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingBearerRecipient();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        final DateTime notOnOrAfter = subjectConfirmationData.getNotOnOrAfter();
+        if (notOnOrAfter == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingNotOnOrAfter();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        final DateTime now = DateTime.now();
+        if (notOnOrAfter.isEqual(now) || notOnOrAfter.isBefore(now)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.exceededNotOnOrAfter(notOnOrAfter);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (subjectConfirmationData.getNotBefore() != null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.notBeforeExists();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/HubConstants.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/HubConstants.java
@@ -1,0 +1,6 @@
+package uk.gov.ida.saml.hub;
+
+public interface HubConstants {
+    String SP_NAME_QUALIFIER = "https://hub.gov.uk";
+    String VERIFY_FEDERATION = "VERIFY-FEDERATION";
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
@@ -1,0 +1,593 @@
+package uk.gov.ida.saml.hub.api;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import org.w3c.dom.Element;
+import uk.gov.ida.common.shared.security.IdGenerator;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.api.CoreTransformersFactory;
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
+import uk.gov.ida.saml.core.transformers.outbound.OutboundAssertionToSubjectTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlAttributeQueryAssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.core.validators.DestinationValidator;
+import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
+import uk.gov.ida.saml.core.validators.assertion.AssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.AuthnStatementAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.DuplicateAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.IPAddressValidator;
+import uk.gov.ida.saml.core.validators.assertion.IdentityProviderAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.MatchingDatasetAssertionValidator;
+import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.AssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.BasicAssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.hub.configuration.SamlAuthnRequestValidityDurationConfiguration;
+import uk.gov.ida.saml.hub.configuration.SamlDuplicateRequestValidationConfiguration;
+import uk.gov.ida.saml.hub.domain.AuthnRequestFromRelyingParty;
+import uk.gov.ida.saml.hub.domain.EidasAuthnRequestFromHub;
+import uk.gov.ida.saml.hub.domain.Endpoints;
+import uk.gov.ida.saml.hub.domain.HubAttributeQueryRequest;
+import uk.gov.ida.saml.hub.domain.HubEidasAttributeQueryRequest;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromMatchingService;
+import uk.gov.ida.saml.hub.domain.MatchingServiceHealthCheckRequest;
+import uk.gov.ida.saml.hub.factories.AttributeFactory_1_1;
+import uk.gov.ida.saml.hub.factories.AttributeQueryAttributeFactory;
+import uk.gov.ida.saml.hub.transformers.inbound.AuthnRequestFromRelyingPartyUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.AuthnRequestToIdaRequestFromRelyingPartyTransformer;
+import uk.gov.ida.saml.hub.transformers.inbound.IdaResponseFromIdpUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.IdpIdaStatusUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.InboundHealthCheckResponseFromMatchingServiceUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.InboundResponseFromMatchingServiceUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatusUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.PassthroughAssertionUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
+import uk.gov.ida.saml.hub.transformers.inbound.decorators.AuthnRequestSizeValidator;
+import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer;
+import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer;
+import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.AssertionFromIdpToAssertionTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.AttributeQueryToElementTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.EidasAuthnRequestFromHubToAuthnRequestTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.EncryptedAssertionUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.outbound.HubAssertionMarshaller;
+import uk.gov.ida.saml.hub.transformers.outbound.HubAttributeQueryRequestToSamlAttributeQueryTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.IdaAuthnRequestFromHubToAuthnRequestTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.MatchingServiceHealthCheckRequestToSamlAttributeQueryTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundResponseFromHubToSamlResponseTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.RequestAbstractTypeToStringTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.SamlProfileTransactionIdaStatusMarshaller;
+import uk.gov.ida.saml.hub.transformers.outbound.TransactionIdaStatusMarshaller;
+import uk.gov.ida.saml.hub.transformers.outbound.decorators.NoOpSamlAttributeQueryAssertionEncrypter;
+import uk.gov.ida.saml.hub.transformers.outbound.decorators.SamlAttributeQueryAssertionSignatureSigner;
+import uk.gov.ida.saml.hub.transformers.outbound.decorators.SigningRequestAbstractTypeSignatureCreator;
+import uk.gov.ida.saml.hub.validators.StringSizeValidator;
+import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestFromTransactionValidator;
+import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestIdKey;
+import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestIssueInstantValidator;
+import uk.gov.ida.saml.hub.validators.authnrequest.DuplicateAuthnRequestValidator;
+import uk.gov.ida.saml.hub.validators.response.common.AssertionSizeValidator;
+import uk.gov.ida.saml.hub.validators.response.common.ResponseSizeValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.IdpResponseValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.EncryptedResponseFromMatchingServiceValidator;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.HealthCheckResponseFromMatchingServiceValidator;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.ResponseAssertionsFromMatchingServiceValidator;
+import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
+import uk.gov.ida.saml.metadata.transformers.HubIdentityProviderMetadataDtoToEntityDescriptorTransformer;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.DecrypterFactory;
+import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EncryptionCredentialFactory;
+import uk.gov.ida.saml.security.EncryptionKeyStore;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
+import uk.gov.ida.saml.security.SignatureFactory;
+import uk.gov.ida.saml.security.SignatureValidator;
+import uk.gov.ida.saml.security.SigningCredentialFactory;
+import uk.gov.ida.saml.security.SigningKeyStore;
+import uk.gov.ida.saml.security.validators.encryptedelementtype.EncryptionAlgorithmValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
+
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+@SuppressWarnings("unused")
+public class HubTransformersFactory {
+
+    private final CoreTransformersFactory coreTransformersFactory;
+
+    public HubTransformersFactory() {
+        coreTransformersFactory = new CoreTransformersFactory();
+    }
+
+    public Function<OutboundResponseFromHub, String> getOutboundResponseFromHubToStringTransformer(
+            final EncryptionKeyStore encryptionKeyStore,
+            final IdaKeyStore keyStore,
+            final EntityToEncryptForLocator entityToEncryptForLocator,
+            final SignatureAlgorithm signatureAlgorithm,
+            final DigestAlgorithm digestAlgorithm) {
+        Function<OutboundResponseFromHub, Response> outboundToResponseTransformer = getOutboundResponseFromHubToSamlResponseTransformer();
+        Function<Response, String> responseStringTransformer = coreTransformersFactory.getResponseStringTransformer(
+                encryptionKeyStore,
+                keyStore,
+                entityToEncryptForLocator,
+                signatureAlgorithm,
+                digestAlgorithm);
+
+        return responseStringTransformer.compose(outboundToResponseTransformer);
+    }
+
+    public Function<OutboundResponseFromHub, String> getOutboundResponseFromHubToStringTransformer(
+            final EncryptionKeyStore encryptionKeyStore,
+            final IdaKeyStore keystore,
+            final EntityToEncryptForLocator entityToEncryptForLocator,
+            final ResponseAssertionSigner responseAssertionSigner,
+            final SignatureAlgorithm signatureAlgorithm,
+            final DigestAlgorithm digestAlgorithm) {
+        Function<OutboundResponseFromHub, Response> outboundToResponseTransformer = getOutboundResponseFromHubToSamlResponseTransformer();
+        Function<Response, String> responseStringTransformer = coreTransformersFactory.getResponseStringTransformer(
+                encryptionKeyStore,
+                keystore,
+                entityToEncryptForLocator,
+                responseAssertionSigner,
+                signatureAlgorithm,
+                digestAlgorithm
+        );
+
+        return responseStringTransformer.compose(outboundToResponseTransformer);
+    }
+
+    public Function<OutboundResponseFromHub, String> getSamlProfileOutboundResponseFromHubToStringTransformer(
+            final EncryptionKeyStore encryptionKeyStore,
+            final IdaKeyStore keystore,
+            final EntityToEncryptForLocator entityToEncryptForLocator,
+            final ResponseAssertionSigner responseAssertionSigner,
+            final SignatureAlgorithm signatureAlgorithm,
+            final DigestAlgorithm digestAlgorithm) {
+        Function<OutboundResponseFromHub, Response> outboundToResponseTransformer = getSamlProfileOutboundResponseFromHubToSamlResponseTransformer();
+        Function<Response, String> responseStringTransformer = coreTransformersFactory.getResponseStringTransformer(
+                encryptionKeyStore,
+                keystore,
+                entityToEncryptForLocator,
+                responseAssertionSigner,
+                signatureAlgorithm,
+                digestAlgorithm
+        );
+
+        return responseStringTransformer.compose(outboundToResponseTransformer);
+    }
+
+    public Function<HubIdentityProviderMetadataDto, Element> getHubIdentityProviderMetadataDtoToElementTransformer() {
+        return
+                coreTransformersFactory.<EntityDescriptor>getXmlObjectToElementTransformer().compose(getHubIdentityProviderMetadataDtoToEntityDescriptorTransformer());
+    }
+
+    public Function<IdaAuthnRequestFromHub, String> getIdaAuthnRequestFromHubToStringTransformer(IdaKeyStore keyStore, SignatureAlgorithm signatureAlgorithm, DigestAlgorithm digestAlgorithm) {
+        return getAuthnRequestToStringTransformer(false, keyStore, signatureAlgorithm, digestAlgorithm).compose(getIdaAuthnRequestFromHubToAuthnRequestTransformer());
+    }
+
+    public Function<EidasAuthnRequestFromHub, String> getEidasAuthnRequestFromHubToStringTransformer(IdaKeyStore keyStore, SignatureAlgorithm signatureAlgorithm, DigestAlgorithm digestAlgorithm) {
+        return getAuthnRequestToStringTransformer(true, keyStore, signatureAlgorithm, digestAlgorithm).compose(getEidasAuthnRequestFromHubToAuthnRequestTransformer());
+    }
+
+    public Function<String, AuthnRequestFromRelyingParty> getStringToIdaAuthnRequestTransformer(
+            URI expectedDestinationHost,
+            SigningKeyStore signingKeyStore,
+            IdaKeyStore decryptionKeyStore,
+            ConcurrentMap<AuthnRequestIdKey, DateTime> duplicateIds,
+            SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration,
+            SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration
+    ) {
+        Function<String, AuthnRequest> stringToAuthnRequestTransformer = getStringToAuthnRequestTransformer();
+        Function<AuthnRequest, AuthnRequestFromRelyingParty> authnRequestToIdaRequestFromTransactionTransformer =
+            getAuthnRequestToAuthnRequestFromTransactionTransformer(
+                expectedDestinationHost,
+                signingKeyStore,
+                decryptionKeyStore,
+                duplicateIds,
+                samlDuplicateRequestValidationConfiguration,
+                samlAuthnRequestValidityDurationConfiguration
+            );
+
+        return authnRequestToIdaRequestFromTransactionTransformer.compose(stringToAuthnRequestTransformer);
+    }
+
+    public StringToOpenSamlObjectTransformer<AuthnRequest> getStringToAuthnRequestTransformer() {
+        return coreTransformersFactory.getStringtoOpenSamlObjectTransformer(
+                new AuthnRequestSizeValidator(new StringSizeValidator())
+        );
+    }
+
+    public StringToOpenSamlObjectTransformer<Response> getStringToResponseTransformer() {
+        return coreTransformersFactory.getStringtoOpenSamlObjectTransformer(
+                new ResponseSizeValidator(new StringSizeValidator())
+        );
+    }
+
+    public StringToOpenSamlObjectTransformer<Response> getStringToResponseTransformer(ResponseSizeValidator validator) {
+        return coreTransformersFactory.getStringtoOpenSamlObjectTransformer(
+                validator
+        );
+    }
+
+    public StringToOpenSamlObjectTransformer<Assertion> getStringToAssertionTransformer() {
+        return coreTransformersFactory.getStringtoOpenSamlObjectTransformer(
+                new AssertionSizeValidator()
+        );
+    }
+
+    public PassthroughAssertionUnmarshaller getAssertionToPassthroughAssertionTransformer() {
+        return new PassthroughAssertionUnmarshaller(
+                new XmlObjectToBase64EncodedStringTransformer<>(),
+                new AuthnContextFactory()
+        );
+    }
+
+    public AssertionFromIdpToAssertionTransformer getAssertionFromIdpToAssertionTransformer() {
+        return new AssertionFromIdpToAssertionTransformer(getStringToAssertionTransformer());
+    }
+
+    public Function<HubAttributeQueryRequest, Element> getMatchingServiceRequestToElementTransformer(
+            IdaKeyStore keyStore,
+            EncryptionKeyStore encryptionKeyStore,
+            EntityToEncryptForLocator entity,
+            SignatureAlgorithm signatureAlgorithm,
+            DigestAlgorithm digestAlgorithm, String hubEntityId) {
+        Function<HubAttributeQueryRequest, AttributeQuery> t1 = getHubAttributeQueryRequestToSamlAttributeQueryTransformer();
+        Function<AttributeQuery, Element> t2 = getAttributeQueryToElementTransformer(keyStore, encryptionKeyStore, Optional.fromNullable(entity), signatureAlgorithm, digestAlgorithm, hubEntityId);
+
+        return t2.compose(t1);
+    }
+
+    public Function<HubEidasAttributeQueryRequest, Element> getEidasMatchingServiceRequestToElementTransformer(
+        IdaKeyStore keyStore,
+        EncryptionKeyStore encryptionKeyStore,
+        EntityToEncryptForLocator entity,
+        SignatureAlgorithm signatureAlgorithm,
+        DigestAlgorithm digestAlgorithm,
+        String hubEntityId) {
+
+        Function<HubEidasAttributeQueryRequest, AttributeQuery> t1 = getHubEidasAttributeQueryRequestToSamlAttributeQueryTransformer();
+        Function<AttributeQuery, Element> t2 = getAttributeQueryToElementTransformer(keyStore, encryptionKeyStore, Optional.fromNullable(entity), signatureAlgorithm, digestAlgorithm, hubEntityId);
+
+        return t2.compose(t1);
+    }
+
+    public Function<MatchingServiceHealthCheckRequest, Element> getMatchingServiceHealthCheckRequestToElementTransformer(
+            IdaKeyStore keyStore,
+            EncryptionKeyStore encryptionKeyStore,
+            EntityToEncryptForLocator entity,
+            SignatureAlgorithm signatureAlgorithm,
+            DigestAlgorithm digestAlgorithm, String hubEntityId) {
+        Function<MatchingServiceHealthCheckRequest, AttributeQuery> t1
+                = new MatchingServiceHealthCheckRequestToSamlAttributeQueryTransformer(new OpenSamlXmlObjectFactory());
+        Function<AttributeQuery, Element> attributeQueryToElementTransformer = getAttributeQueryToElementTransformer(keyStore, encryptionKeyStore, Optional.fromNullable(entity), signatureAlgorithm, digestAlgorithm, hubEntityId);
+        return attributeQueryToElementTransformer.compose(t1);
+    }
+
+    public <T extends RequestAbstractType> RequestAbstractTypeToStringTransformer<T> getRequestAbstractTypeToStringTransformer(
+            boolean includeKeyInfo,
+            IdaKeyStore keyStore,
+            SignatureAlgorithm signatureAlgorithm,
+            DigestAlgorithm digestAlgorithm) {
+        return new RequestAbstractTypeToStringTransformer<>(
+                new SigningRequestAbstractTypeSignatureCreator<T>(new SignatureFactory(includeKeyInfo, new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm)),
+                new SamlSignatureSigner<T>(),
+                new XmlObjectToBase64EncodedStringTransformer<>()
+        );
+    }
+
+    public RequestAbstractTypeToStringTransformer<AuthnRequest> getAuthnRequestToStringTransformer(
+            boolean includeKeyInfo,
+            IdaKeyStore keyStore,
+            SignatureAlgorithm signatureAlgorithm,
+            DigestAlgorithm digestAlgorithm) {
+        return getRequestAbstractTypeToStringTransformer(includeKeyInfo, keyStore, signatureAlgorithm, digestAlgorithm);
+    }
+
+    public DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer getResponseToInboundResponseFromMatchingServiceTransformer(
+            SigningKeyStore signingKeyStore,
+            IdaKeyStore keyStore, String hubEntityId) {
+        return new DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer(
+                new InboundResponseFromMatchingServiceUnmarshaller(
+                        getAssertionToPassthroughAssertionTransformer(),
+                        new MatchingServiceIdaStatusUnmarshaller()
+                ),
+                getSamlResponseSignatureValidator(getSignatureValidator(signingKeyStore)),
+                this.<InboundResponseFromMatchingService>getSamlResponseAssertionDecrypter(keyStore),
+                getSamlAssertionsSignatureValidator(getSignatureValidator(signingKeyStore)),
+                new EncryptedResponseFromMatchingServiceValidator(),
+                new ResponseAssertionsFromMatchingServiceValidator(
+                        new AssertionValidator(
+                                new IssuerValidator(),
+                                new AssertionSubjectValidator(),
+                                new AssertionAttributeStatementValidator(),
+                                new BasicAssertionSubjectConfirmationValidator()
+                        ),
+                        hubEntityId
+                )
+        );
+    }
+
+    /**
+     * Compliance Tool should implement this method
+     *
+     * @deprecated Compliance Tool should implement this method
+     */
+    @Deprecated
+    public Function<String, InboundResponseFromIdp> getStringToIdaResponseIssuedByIdpTransformer(
+            SigningKeyStore signingKeyStore,
+            IdaKeyStore keyStore,
+            URI expectedDestinationHost,
+            String expectedEndpoint,
+            ConcurrentMap<String, DateTime> assertionIdCache,
+            String hubEntityId) {
+        // not sure if we need to allow an extra ResponseSizeValidator here.
+        Function<String, Response> t1 = getStringToResponseTransformer();
+        Function<Response, InboundResponseFromIdp> t2 = getDecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
+                signingKeyStore,
+                keyStore,
+                expectedDestinationHost,
+                expectedEndpoint,
+                assertionIdCache,
+                hubEntityId
+        );
+        return  t2.compose(t1);
+    }
+
+    public Function<String, InboundResponseFromIdp> getStringToIdaResponseIssuedByIdpTransformer(
+            SignatureValidator idpSignatureValidator,
+            IdaKeyStore keyStore,
+            URI expectedDestinationHost,
+            String expectedEndpoint,
+            ConcurrentMap<String, DateTime> assertionIdCache,
+            String hubEntityId) {
+
+        // not sure if we need to allow an extra ResponseSizeValidator here.
+        Function<String, Response> t1 = getStringToResponseTransformer();
+        Function<Response, InboundResponseFromIdp> t2 = getDecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
+                idpSignatureValidator,
+                keyStore,
+                expectedDestinationHost,
+                expectedEndpoint,
+                assertionIdCache,
+                hubEntityId
+        );
+        return  t2.compose(t1);
+    }
+
+    /**
+     * Compliance Tool should implement this method
+     *
+     * @deprecated Compliance Tool should implement this method
+     */
+    @Deprecated
+    public DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer getDecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
+            SigningKeyStore signingKeyStore,
+            IdaKeyStore keyStore,
+            URI expectedDestinationHost,
+            String expectedEndpoint,
+            ConcurrentMap<String, DateTime> assertionIdCache,
+            String hubEntityId) {
+        return getDecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
+                getSignatureValidator(signingKeyStore),
+                keyStore,
+                expectedDestinationHost,
+                expectedEndpoint,
+                assertionIdCache,
+                hubEntityId
+        );
+    }
+
+    public DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer getDecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
+            SignatureValidator idpSignatureValidator,
+            IdaKeyStore keyStore,
+            URI expectedDestinationHost,
+            String expectedEndpoint,
+            ConcurrentMap<String, DateTime> assertionIdCache,
+            String hubEntityId) {
+        IdpResponseValidator validator = new IdpResponseValidator(this.<InboundResponseFromIdp>getSamlResponseSignatureValidator(idpSignatureValidator),
+            this.<InboundResponseFromIdp>getSamlResponseAssertionDecrypter(keyStore),
+                getSamlAssertionsSignatureValidator(idpSignatureValidator),
+            new EncryptedResponseFromIdpValidator(new SamlStatusToIdpIdaStatusMappingsFactory()),
+            new DestinationValidator(expectedDestinationHost, expectedEndpoint),
+            getResponseAssertionsFromIdpValidator(assertionIdCache, hubEntityId));
+
+        return new DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
+            validator,
+            new IdaResponseFromIdpUnmarshaller(
+                new IdpIdaStatusUnmarshaller(new IdpIdaStatus.IdpIdaStatusFactory(), new SamlStatusToIdpIdaStatusMappingsFactory()),
+                getAssertionToPassthroughAssertionTransformer()
+            )
+        );
+    }
+
+    public AuthnRequestToIdaRequestFromRelyingPartyTransformer getAuthnRequestToAuthnRequestFromTransactionTransformer(
+        final URI expectedDestinationHost,
+        final SigningKeyStore signingKeyStore,
+        final IdaKeyStore decryptionKeyStore,
+        final ConcurrentMap<AuthnRequestIdKey, DateTime> duplicateIds,
+        final SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration,
+        final SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration
+    ) {
+        List<Credential> credential = new IdaKeyStoreCredentialRetriever(decryptionKeyStore).getDecryptingCredentials();
+        Decrypter decrypter = new DecrypterFactory().createDecrypter(credential);
+
+        return new AuthnRequestToIdaRequestFromRelyingPartyTransformer(
+            new AuthnRequestFromRelyingPartyUnmarshaller(decrypter),
+            coreTransformersFactory.<AuthnRequest>getSamlRequestSignatureValidator(signingKeyStore),
+            new DestinationValidator(expectedDestinationHost, Endpoints.SSO_REQUEST_ENDPOINT),
+            new AuthnRequestFromTransactionValidator(
+                new IssuerValidator(),
+                new DuplicateAuthnRequestValidator(duplicateIds, samlDuplicateRequestValidationConfiguration),
+                new AuthnRequestIssueInstantValidator(samlAuthnRequestValidityDurationConfiguration)
+            )
+        );
+    }
+
+    private OutboundResponseFromHubToSamlResponseTransformer getOutboundResponseFromHubToSamlResponseTransformer() {
+        return new OutboundResponseFromHubToSamlResponseTransformer(
+                new TransactionIdaStatusMarshaller(new OpenSamlXmlObjectFactory()),
+                new OpenSamlXmlObjectFactory(),
+                new AssertionFromIdpToAssertionTransformer(getStringToAssertionTransformer())
+        );
+    }
+
+    private OutboundResponseFromHubToSamlResponseTransformer getSamlProfileOutboundResponseFromHubToSamlResponseTransformer() {
+        return new OutboundResponseFromHubToSamlResponseTransformer(
+                new SamlProfileTransactionIdaStatusMarshaller(new OpenSamlXmlObjectFactory()),
+                new OpenSamlXmlObjectFactory(),
+                new AssertionFromIdpToAssertionTransformer(getStringToAssertionTransformer())
+        );
+    }
+
+    private HubIdentityProviderMetadataDtoToEntityDescriptorTransformer getHubIdentityProviderMetadataDtoToEntityDescriptorTransformer() {
+        OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+        return new HubIdentityProviderMetadataDtoToEntityDescriptorTransformer(
+                openSamlXmlObjectFactory,
+                coreTransformersFactory.getCertificatesToKeyDescriptorsTransformer(),
+                new IdGenerator()
+        );
+    }
+
+    private IdaAuthnRequestFromHubToAuthnRequestTransformer getIdaAuthnRequestFromHubToAuthnRequestTransformer() {
+        return new IdaAuthnRequestFromHubToAuthnRequestTransformer(new OpenSamlXmlObjectFactory());
+    }
+
+    private EidasAuthnRequestFromHubToAuthnRequestTransformer getEidasAuthnRequestFromHubToAuthnRequestTransformer() {
+        return new EidasAuthnRequestFromHubToAuthnRequestTransformer(new OpenSamlXmlObjectFactory());
+    }
+
+    private HubAttributeQueryRequestToSamlAttributeQueryTransformer getHubAttributeQueryRequestToSamlAttributeQueryTransformer() {
+        return new HubAttributeQueryRequestToSamlAttributeQueryTransformer(
+                new OpenSamlXmlObjectFactory(),
+                new HubAssertionMarshaller(
+                        new OpenSamlXmlObjectFactory(),
+                        new AttributeFactory_1_1(new OpenSamlXmlObjectFactory()),
+                        new OutboundAssertionToSubjectTransformer(new OpenSamlXmlObjectFactory())),
+                new AssertionFromIdpToAssertionTransformer(
+                        getStringToAssertionTransformer()
+                ),
+                new AttributeQueryAttributeFactory(new OpenSamlXmlObjectFactory()),
+                new EncryptedAssertionUnmarshaller(getStringToEncryptedAssertionTransformer()));
+    }
+
+    private HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer getHubEidasAttributeQueryRequestToSamlAttributeQueryTransformer() {
+        return new HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer(
+                new OpenSamlXmlObjectFactory(),
+                new HubAssertionMarshaller(
+                        new OpenSamlXmlObjectFactory(),
+                        new AttributeFactory_1_1(new OpenSamlXmlObjectFactory()),
+                        new OutboundAssertionToSubjectTransformer(new OpenSamlXmlObjectFactory())),
+                new AssertionFromIdpToAssertionTransformer(
+                        getStringToAssertionTransformer()
+                ),
+                new AttributeQueryAttributeFactory(new OpenSamlXmlObjectFactory()),
+                new EncryptedAssertionUnmarshaller(getStringToEncryptedAssertionTransformer()));
+    }
+
+    private StringToOpenSamlObjectTransformer<EncryptedAssertion> getStringToEncryptedAssertionTransformer() {
+        return coreTransformersFactory.getStringtoOpenSamlObjectTransformer(
+                new AssertionSizeValidator()
+        );
+    }
+
+    private AttributeQueryToElementTransformer getAttributeQueryToElementTransformer(
+            IdaKeyStore keyStore,
+            EncryptionKeyStore encryptionKeyStore,
+            Optional<EntityToEncryptForLocator> entity,
+            SignatureAlgorithm signatureAlgorithm,
+            DigestAlgorithm digestAlgorithm,
+            String hubEntityId) {
+        return new AttributeQueryToElementTransformer(
+                new SigningRequestAbstractTypeSignatureCreator<>(new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm)),
+                new SamlAttributeQueryAssertionSignatureSigner(new IdaKeyStoreCredentialRetriever(keyStore), new OpenSamlXmlObjectFactory(), hubEntityId),
+                new SamlSignatureSigner<AttributeQuery>(),
+                new XmlObjectToElementTransformer<>(),
+                getSamlAttributeQueryAssertionEncrypter(encryptionKeyStore, entity)
+        );
+    }
+
+    private SamlAttributeQueryAssertionEncrypter getSamlAttributeQueryAssertionEncrypter(EncryptionKeyStore encryptionKeyStore, Optional<EntityToEncryptForLocator> entity) {
+        if (entity.isPresent()) {
+            return new SamlAttributeQueryAssertionEncrypter(new EncryptionCredentialFactory(encryptionKeyStore), new EncrypterFactory(), entity.get());
+        } else {
+            return new NoOpSamlAttributeQueryAssertionEncrypter();
+        }
+    }
+
+    private ResponseAssertionsFromIdpValidator getResponseAssertionsFromIdpValidator(final ConcurrentMap<String, DateTime> assertionIdCache, String hubEntityId) {
+        return new ResponseAssertionsFromIdpValidator(
+                new IdentityProviderAssertionValidator(
+                        new IssuerValidator(),
+                        new AssertionSubjectValidator(),
+                        new AssertionAttributeStatementValidator(),
+                        new AssertionSubjectConfirmationValidator()
+                ),
+                new MatchingDatasetAssertionValidator(new DuplicateAssertionValidator(assertionIdCache)),
+                new AuthnStatementAssertionValidator(
+                        new DuplicateAssertionValidator(assertionIdCache)
+                ),
+                new IPAddressValidator(),
+                hubEntityId
+        );
+    }
+
+    public DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer getResponseInboundHealthCheckResponseFromMatchingServiceTransformer(SigningKeyStore signingKeyStore) {
+
+        return new DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer(
+            new InboundHealthCheckResponseFromMatchingServiceUnmarshaller(
+                new MatchingServiceIdaStatusUnmarshaller()
+            ),
+            getSamlResponseSignatureValidator(getSignatureValidator(signingKeyStore)),
+            new HealthCheckResponseFromMatchingServiceValidator(
+            )
+        );
+    }
+
+    private AssertionDecrypter getSamlResponseAssertionDecrypter(IdaKeyStore keyStore) {
+        IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
+        DecrypterFactory decrypterFactory = new DecrypterFactory();
+        Decrypter decrypter = decrypterFactory.createDecrypter(idaKeyStoreCredentialRetriever.getDecryptingCredentials());
+        return new AssertionDecrypter(new EncryptionAlgorithmValidator(), decrypter);
+    }
+
+    private SignatureValidator getSignatureValidator(SigningKeyStore signingKeyStore) {
+        SigningCredentialFactory signingCredentialFactory = new SigningCredentialFactory(signingKeyStore);
+        return coreTransformersFactory.getSignatureValidator(signingCredentialFactory);
+    }
+    private SamlResponseSignatureValidator getSamlResponseSignatureValidator(SignatureValidator signatureValidator) {
+        return new SamlResponseSignatureValidator(new SamlMessageSignatureValidator(signatureValidator));
+    }
+
+    private SamlAssertionsSignatureValidator getSamlAssertionsSignatureValidator(SignatureValidator signatureValidator) {
+        return new SamlAssertionsSignatureValidator(new SamlMessageSignatureValidator(signatureValidator));
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/configuration/SamlAuthnRequestValidityDurationConfiguration.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/configuration/SamlAuthnRequestValidityDurationConfiguration.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.saml.hub.configuration;
+
+import io.dropwizard.util.Duration;
+
+public interface SamlAuthnRequestValidityDurationConfiguration {
+    Duration getAuthnRequestValidityDuration();
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/configuration/SamlDuplicateRequestValidationConfiguration.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/configuration/SamlDuplicateRequestValidationConfiguration.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.saml.hub.configuration;
+
+import io.dropwizard.util.Duration;
+
+public interface SamlDuplicateRequestValidationConfiguration {
+    Duration getAuthnRequestIdExpirationDuration();
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/AuthnRequestFromRelyingParty.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/AuthnRequestFromRelyingParty.java
@@ -1,0 +1,96 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+import org.opensaml.xmlsec.signature.Signature;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class AuthnRequestFromRelyingParty extends VerifySamlMessage {
+
+    private Optional<Boolean> forceAuthentication;
+    private Optional<URI> assertionConsumerServiceUrl;
+    private Optional<Integer> assertionConsumerServiceIndex;
+    private Optional<Signature> signature;
+    private Optional<String> verifyServiceProviderVersion;
+
+    protected AuthnRequestFromRelyingParty() {
+    }
+
+    public AuthnRequestFromRelyingParty(
+        String id,
+        String issuer,
+        DateTime issueInstant,
+        URI destination,
+        Optional<Boolean> forceAuthentication,
+        Optional<URI> assertionConsumerServiceUrl,
+        Optional<Integer> assertionConsumerServiceIndex,
+        Optional<Signature> signature,
+        Optional<String> verifyServiceProviderVersion
+    ) {
+        super(id, issuer, issueInstant, destination);
+        this.forceAuthentication = forceAuthentication;
+        this.assertionConsumerServiceUrl = assertionConsumerServiceUrl;
+        this.assertionConsumerServiceIndex = assertionConsumerServiceIndex;
+        this.signature = signature;
+        this.verifyServiceProviderVersion = verifyServiceProviderVersion;
+    }
+
+    public Optional<Boolean> getForceAuthentication() {
+        return forceAuthentication;
+    }
+
+    public Optional<Integer> getAssertionConsumerServiceIndex() {
+        return assertionConsumerServiceIndex;
+    }
+
+    public Optional<Signature> getSignature() {
+        return signature;
+    }
+
+    public Optional<URI> getAssertionConsumerServiceUrl() {
+        return assertionConsumerServiceUrl;
+    }
+
+    public Optional<String> getVerifyServiceProviderVersion() {
+        return verifyServiceProviderVersion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AuthnRequestFromRelyingParty)) return false;
+
+        AuthnRequestFromRelyingParty that = (AuthnRequestFromRelyingParty) o;
+
+        if (forceAuthentication != null ? !forceAuthentication.equals(that.forceAuthentication) : that.forceAuthentication != null)
+            return false;
+        if (assertionConsumerServiceUrl != null ? !assertionConsumerServiceUrl.equals(that.assertionConsumerServiceUrl) : that.assertionConsumerServiceUrl != null)
+            return false;
+        if (assertionConsumerServiceIndex != null ? !assertionConsumerServiceIndex.equals(that.assertionConsumerServiceIndex) : that.assertionConsumerServiceIndex != null)
+            return false;
+        if (signature != null ? !signature.equals(that.signature) : that.signature != null) return false;
+        return verifyServiceProviderVersion != null ? verifyServiceProviderVersion.equals(that.verifyServiceProviderVersion) : that.verifyServiceProviderVersion == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = forceAuthentication != null ? forceAuthentication.hashCode() : 0;
+        result = 31 * result + (assertionConsumerServiceUrl != null ? assertionConsumerServiceUrl.hashCode() : 0);
+        result = 31 * result + (assertionConsumerServiceIndex != null ? assertionConsumerServiceIndex.hashCode() : 0);
+        result = 31 * result + (signature != null ? signature.hashCode() : 0);
+        result = 31 * result + (verifyServiceProviderVersion != null ? verifyServiceProviderVersion.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthnRequestFromRelyingParty{" +
+            "forceAuthentication=" + forceAuthentication +
+            ", assertionConsumerServiceUrl=" + assertionConsumerServiceUrl +
+            ", assertionConsumerServiceIndex=" + assertionConsumerServiceIndex +
+            ", signature=" + signature +
+            ", verifyServiceProviderVersion=" + verifyServiceProviderVersion +
+            '}';
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/AuthnRequestFromTransaction.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/AuthnRequestFromTransaction.java
@@ -1,0 +1,94 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.common.shared.security.IdGenerator;
+import uk.gov.ida.saml.core.domain.IdaSamlMessage;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class AuthnRequestFromTransaction extends IdaSamlMessage {
+    private Optional<Boolean> forceAuthentication;
+    private Optional<URI> assertionConsumerServiceUrl;
+    private Optional<Integer> assertionConsumerServiceIndex;
+    private Optional<Signature> signature;
+
+    protected AuthnRequestFromTransaction() {
+    }
+
+    public AuthnRequestFromTransaction(
+            String id,
+            String issuer,
+            DateTime issueInstant,
+            Optional<Boolean> forceAuthentication,
+            Optional<URI> assertionConsumerServiceUrl,
+            Optional<Integer> assertionConsumerServiceIndex,
+            Optional<Signature> signature,
+            URI destination) {
+
+        super(id, issuer, issueInstant, destination);
+
+        this.forceAuthentication = forceAuthentication;
+        this.assertionConsumerServiceUrl = assertionConsumerServiceUrl;
+        this.assertionConsumerServiceIndex = assertionConsumerServiceIndex;
+        this.signature = signature;
+    }
+
+    public static AuthnRequestFromTransaction createRequestReceivedFromTransaction(
+        String id,
+        String issuerId,
+        DateTime issueInstant,
+        boolean forceAuthentication,
+        Optional<URI> assertionConsumerServiceUrl,
+        Optional<Integer> assertionConsumerServiceIndex,
+        Optional<Signature> signature,
+        URI destination) {
+
+        return new AuthnRequestFromTransaction(
+                id,
+                issuerId,
+                issueInstant,
+                Optional.ofNullable(forceAuthentication),
+                assertionConsumerServiceUrl,
+                assertionConsumerServiceIndex,
+                signature,
+                destination);
+    }
+
+    // NOTE: this method is only used for the fake relying parties we use
+    public static AuthnRequestFromTransaction createRequestToSendToHub(
+        String issuerId,
+        boolean forceAuthentication,
+        Optional<URI> assertionConsumerServiceUrl,
+        Optional<Integer> assertionConsumerServiceIndex,
+        Optional<Signature> signature,
+        URI destination) {
+
+        return createRequestReceivedFromTransaction(
+                new IdGenerator().getId(),
+                issuerId,
+                DateTime.now(),
+                forceAuthentication,
+                assertionConsumerServiceUrl,
+                assertionConsumerServiceIndex,
+                signature,
+                destination);
+    }
+
+    public Optional<Boolean> getForceAuthentication() {
+        return forceAuthentication;
+    }
+
+    public Optional<Integer> getAssertionConsumerServiceIndex() {
+        return assertionConsumerServiceIndex;
+    }
+
+    public Optional<Signature> getSignature() {
+        return signature;
+    }
+
+    public Optional<URI> getAssertionConsumerServiceUrl() {
+        return assertionConsumerServiceUrl;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/BaseHubAttributeQueryRequest.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/BaseHubAttributeQueryRequest.java
@@ -1,0 +1,40 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.IdaSamlMessage;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.net.URI;
+
+public class BaseHubAttributeQueryRequest extends IdaSamlMessage {
+    protected PersistentId persistentId;
+    protected URI assertionConsumerServiceUrl;
+    protected String authnRequestIssuerEntityId;
+
+    public BaseHubAttributeQueryRequest(String id,
+                                        String issuer,
+                                        DateTime issueInstant,
+                                        URI destination,
+                                        PersistentId persistentId,
+                                        URI assertionConsumerServiceUrl,
+                                        String authnRequestIssuerEntityId) {
+        super(id, issuer, issueInstant, destination);
+        this.persistentId = persistentId;
+        this.assertionConsumerServiceUrl = assertionConsumerServiceUrl;
+        this.authnRequestIssuerEntityId = authnRequestIssuerEntityId;
+    }
+
+    public PersistentId getPersistentId() {
+        return persistentId;
+    }
+
+    public URI getAssertionConsumerServiceUrl() {
+        return assertionConsumerServiceUrl;
+    }
+
+    public String getAuthnRequestIssuerEntityId() {
+        return authnRequestIssuerEntityId;
+    }
+
+}
+

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/Endpoints.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/Endpoints.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.saml.hub.domain;
+
+public class Endpoints {
+    private Endpoints() {}
+    public static final String SSO_RESPONSE_ENDPOINT = "/SAML2/SSO/Response/POST";
+    public static final String SSO_REQUEST_ENDPOINT = "/SAML2/SSO";
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/HubAttributeQueryRequest.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/HubAttributeQueryRequest.java
@@ -1,0 +1,61 @@
+package uk.gov.ida.saml.hub.domain;
+
+import com.google.common.base.Optional;
+import javax.validation.constraints.NotNull;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.net.URI;
+import java.util.List;
+
+public class HubAttributeQueryRequest extends BaseHubAttributeQueryRequest {
+    private String authnStatementAssertion;
+    private Optional<HubAssertion> cycle3AttributeAssertion;
+    private Optional<List<UserAccountCreationAttribute>> userAccountCreationAttributes;
+    private AuthnContext authnContext;
+    @NotNull
+    private String encryptedMatchingDatasetAssertion;
+
+    public HubAttributeQueryRequest(
+            String id,
+            PersistentId persistentId,
+            String encryptedMatchingDatasetAssertion,
+            String authnStatementAssertion,
+            Optional<HubAssertion> cycle3AttributeAssertion,
+            Optional<List<UserAccountCreationAttribute>> userAccountCreationAttributes,
+            DateTime issueInstant,
+            URI assertionConsumerServiceUrl,
+            String authnRequestIssuerEntityId,
+            AuthnContext authnContext,
+            String hubEntityId) {
+        super(id, hubEntityId, issueInstant, null, persistentId, assertionConsumerServiceUrl, authnRequestIssuerEntityId);
+        this.authnStatementAssertion = authnStatementAssertion;
+        this.cycle3AttributeAssertion = cycle3AttributeAssertion;
+        this.userAccountCreationAttributes = userAccountCreationAttributes;
+        this.authnContext = authnContext;
+        this.encryptedMatchingDatasetAssertion = encryptedMatchingDatasetAssertion;
+    }
+
+
+    public Optional<HubAssertion> getCycle3AttributeAssertion() {
+        return cycle3AttributeAssertion;
+    }
+
+    public Optional<List<UserAccountCreationAttribute>> getUserAccountCreationAttributes() {
+        return userAccountCreationAttributes;
+    }
+
+    public String getAuthnStatementAssertion() {
+        return authnStatementAssertion;
+    }
+
+    public AuthnContext getAuthnContext() {
+        return authnContext;
+    }
+
+    public String getEncryptedMatchingDatasetAssertion() {
+        return encryptedMatchingDatasetAssertion;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/HubEidasAttributeQueryRequest.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/HubEidasAttributeQueryRequest.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+public class HubEidasAttributeQueryRequest extends BaseHubAttributeQueryRequest {
+
+    private final String encryptedIdentityAssertion;
+    private final AuthnContext authnContext;
+    private final Optional<HubAssertion> cycle3AttributeAssertion;
+    private final Optional<List<UserAccountCreationAttribute>> userAccountCreationAttributes;
+
+    public HubEidasAttributeQueryRequest(
+        String requestId,
+        String issuer,
+        DateTime issueInstant,
+        PersistentId persistentId, // FIXME - change to use new PersistenceId with equal and hashcode at both places
+        URI assertionConsumerServiceUrl,
+        String authnRequestIssuerEntityId,
+        String encryptedIdentityAssertion,
+        AuthnContext authnContext,
+        Optional<HubAssertion> cycle3AttributeAssertion,
+        Optional<List<UserAccountCreationAttribute>> userAccountCreationAttributes) {
+
+        super(requestId, issuer, issueInstant, null, persistentId, assertionConsumerServiceUrl, authnRequestIssuerEntityId);
+        this.encryptedIdentityAssertion = encryptedIdentityAssertion;
+        this.authnContext = authnContext;
+        this.cycle3AttributeAssertion = cycle3AttributeAssertion;
+        this.userAccountCreationAttributes = userAccountCreationAttributes;
+    }
+
+    public String getEncryptedIdentityAssertion() {
+        return encryptedIdentityAssertion;
+    }
+
+    public AuthnContext getAuthnContext() {
+        return authnContext;
+    }
+
+    public Optional<HubAssertion> getCycle3AttributeAssertion() {
+        return cycle3AttributeAssertion;
+    }
+
+    public Optional<List<UserAccountCreationAttribute>> getUserAccountCreationAttributes() {
+        return userAccountCreationAttributes;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/IdpIdaStatus.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/IdpIdaStatus.java
@@ -1,0 +1,94 @@
+package uk.gov.ida.saml.hub.domain;
+
+import uk.gov.ida.saml.core.domain.IdaStatus;
+
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+
+public final class IdpIdaStatus implements IdaStatus {
+
+    public enum Status {
+        Success,
+        NoAuthenticationContext,
+        RequesterError,
+        AuthenticationFailed,
+        AuthenticationCancelled,
+        AuthenticationPending,
+        UpliftFailed
+    }
+    public static IdpIdaStatus success() { return new IdpIdaStatus(Status.Success);}
+
+    public static IdpIdaStatus authenticationFailed() { return new IdpIdaStatus(Status.AuthenticationFailed);}
+    public static IdpIdaStatus noAuthenticationContext() { return new IdpIdaStatus(Status.NoAuthenticationContext);}
+    public static IdpIdaStatus requesterError() { return new IdpIdaStatus(Status.RequesterError);}
+    public static IdpIdaStatus requesterError(Optional<String> errorMessage) { return new IdpIdaStatus(Status.RequesterError, errorMessage);}
+    public static IdpIdaStatus authenticationCancelled() {
+        return new IdpIdaStatus(Status.AuthenticationCancelled);
+    }
+    public static IdpIdaStatus authenticationPending() { return new IdpIdaStatus(Status.AuthenticationPending); }
+    public static IdpIdaStatus upliftFailed() { return new IdpIdaStatus(Status.UpliftFailed); }
+
+    private Status status;
+    private Optional<String> message = empty();
+
+    private IdpIdaStatus() {
+    }
+
+    private IdpIdaStatus(Status status) {
+        this(status, Optional.<String>empty());
+    }
+
+    private IdpIdaStatus(Status status, Optional<String> message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Status getStatusCode() {
+        return status;
+    }
+
+    public Optional<String> getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        IdpIdaStatus idpIdaStatus = (IdpIdaStatus) o;
+
+        if (status != idpIdaStatus.status) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = status.hashCode();
+        result = 31 * result;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "IdaStatus{" +
+            "status=" + status +
+            ", message=" + message +
+            '}';
+    }
+
+    public static class IdpIdaStatusFactory {
+        public IdpIdaStatus create(
+                final IdpIdaStatus.Status statusCode,
+                final Optional<String> message) {
+
+            if (!statusCode.equals(Status.RequesterError)) {
+                return new IdpIdaStatus(statusCode);
+            }
+
+            return new IdpIdaStatus(statusCode, message);
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundHealthCheckResponseFromMatchingService.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundHealthCheckResponseFromMatchingService.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
+import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatus;
+
+public class InboundHealthCheckResponseFromMatchingService extends IdaMatchingServiceResponse {
+    private MatchingServiceIdaStatus status;
+
+    @SuppressWarnings("unused") // needed for JAXB
+    private InboundHealthCheckResponseFromMatchingService() {
+    }
+
+    public InboundHealthCheckResponseFromMatchingService(
+            final String responseId,
+            final String inResponseTo,
+            final String issuer,
+            final DateTime issueInstant,
+            final MatchingServiceIdaStatus status) {
+
+        super(responseId, inResponseTo, issuer, issueInstant);
+
+        this.status = status;
+    }
+
+    public MatchingServiceIdaStatus getStatus() {
+        return status;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromIdp.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromIdp.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.IdaSamlResponse;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class InboundResponseFromIdp extends IdaSamlResponse {
+    private Optional<PassthroughAssertion> matchingDatasetAssertion;
+    private Optional<PassthroughAssertion> authnStatementAssertion;
+    private Optional<Signature> signature;
+    private IdpIdaStatus status;
+
+    public InboundResponseFromIdp(
+            String id,
+            String inResponseTo,
+            String issuer,
+            DateTime issueInstant,
+            IdpIdaStatus status,
+            Optional<Signature> signature,
+            Optional<PassthroughAssertion> matchingDatasetAssertion,
+            URI destination,
+            Optional<PassthroughAssertion> authnStatementAssertion) {
+        super(id, issueInstant, inResponseTo, issuer, destination);
+        this.signature = signature;
+        this.matchingDatasetAssertion = matchingDatasetAssertion;
+        this.authnStatementAssertion = authnStatementAssertion;
+        this.status = status;
+    }
+
+    public Optional<PassthroughAssertion> getMatchingDatasetAssertion() {
+        return matchingDatasetAssertion;
+    }
+
+    public Optional<PassthroughAssertion> getAuthnStatementAssertion() {
+        return authnStatementAssertion;
+    }
+
+    public Optional<Signature> getSignature() {
+        return signature;
+    }
+
+    public IdpIdaStatus getStatus() {
+        return status;
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromMatchingService.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromMatchingService.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.saml.hub.domain;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatus;
+
+public class InboundResponseFromMatchingService extends IdaMatchingServiceResponse {
+    private Optional<PassthroughAssertion> matchingServiceAssertion;
+    private MatchingServiceIdaStatus status;
+
+    @SuppressWarnings("unused") // needed for JAXB
+    private InboundResponseFromMatchingService() {
+    }
+
+    public InboundResponseFromMatchingService(String responseId, String inResponseTo, String issuer, DateTime issueInstant, MatchingServiceIdaStatus status, Optional<PassthroughAssertion> matchingServiceAssertion) {
+        super(responseId, inResponseTo, issuer, issueInstant);
+        this.matchingServiceAssertion = matchingServiceAssertion;
+        this.status = status;
+    }
+
+    public Optional<PassthroughAssertion> getMatchingServiceAssertion() {
+        return matchingServiceAssertion;
+    }
+
+    public MatchingServiceIdaStatus getStatus() {
+        return status;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/LevelOfAssurance.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/LevelOfAssurance.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.saml.hub.domain;
+
+import uk.gov.ida.saml.core.domain.AuthnContext;
+
+import java.util.Arrays;
+
+public enum LevelOfAssurance implements Comparable<LevelOfAssurance> {
+
+    LOW("http://eidas.europa.eu/LoA/low"),
+
+    SUBSTANTIAL("http://eidas.europa.eu/LoA/substantial"),
+
+    HIGH("http://eidas.europa.eu/LoA/high");
+
+    private final String value;
+
+    LevelOfAssurance(String value) {
+        this.value = value;
+    }
+
+    public static LevelOfAssurance fromString(String levelOfAssurance) {
+        return Arrays.stream(LevelOfAssurance.values())
+            .filter(x -> x.value.equals(levelOfAssurance))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("Unknown level of Assurance"));
+    }
+
+    public AuthnContext toVerifyLevelOfAssurance() {
+        switch (this) {
+            case LOW:
+                return AuthnContext.LEVEL_1;
+            case SUBSTANTIAL:
+                return AuthnContext.LEVEL_2;
+            case HIGH:
+                return AuthnContext.LEVEL_2; // Verify doesn't support LoA 3 yet, so return LoA 2
+            default:
+                throw new IllegalStateException("Unknown level of assurance from requested AuthnContext : " + this.value);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/MatchingServiceHealthCheckRequest.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/MatchingServiceHealthCheckRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.PersistentId;
+import uk.gov.ida.saml.hub.HubConstants;
+
+import java.net.URI;
+
+public class MatchingServiceHealthCheckRequest extends BaseHubAttributeQueryRequest {
+
+    public MatchingServiceHealthCheckRequest(String id, DateTime issueInstant, PersistentId persistentId, URI assertionConsumerServiceUrl, String authnRequestIssuerEntityId, String hubEntityId) {
+        super(id, hubEntityId, issueInstant, null, persistentId, assertionConsumerServiceUrl, authnRequestIssuerEntityId);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.saml.hub.domain;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import java.io.Serializable;
+
+public enum UserAccountCreationAttribute implements Serializable {
+    FIRST_NAME("firstname"),
+    FIRST_NAME_VERIFIED("firstname_verified"),
+    MIDDLE_NAME("middlename"),
+    MIDDLE_NAME_VERIFIED("middlename_verified"),
+    SURNAME("surname"),
+    SURNAME_VERIFIED("surname_verified"),
+    DATE_OF_BIRTH("dateofbirth"),
+    DATE_OF_BIRTH_VERIFIED("dateofbirth_verified"),
+    CURRENT_ADDRESS("currentaddress"),
+    CURRENT_ADDRESS_VERIFIED("currentaddress_verified"),
+    ADDRESS_HISTORY("addresshistory"),
+    CYCLE_3("cycle_3");
+
+    private String attributeName;
+
+    private UserAccountCreationAttribute(final String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    public String getAttributeName(){
+        return attributeName;
+    }
+
+    public static UserAccountCreationAttribute getUserAccountCreationAttribute(final String name){
+        return Iterables.find(ImmutableList.copyOf(values()), new Predicate<UserAccountCreationAttribute>() {
+            @Override
+            public boolean apply(final UserAccountCreationAttribute input) {
+                return input.getAttributeName().equals(name);
+            }
+        });
+    }
+}
+

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/VerifyMessage.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/VerifyMessage.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+
+public abstract class VerifyMessage {
+
+    private String id;
+    private String issuer;
+    private DateTime issueInstant;
+
+    protected VerifyMessage() {
+    }
+
+    public VerifyMessage(String id, String issuer, DateTime issueInstant) {
+        this.id = id;
+        this.issuer = issuer;
+        this.issueInstant = issueInstant;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public DateTime getIssueInstant() {
+        return issueInstant;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/VerifySamlMessage.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/VerifySamlMessage.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.joda.time.DateTime;
+
+import java.net.URI;
+
+public abstract class VerifySamlMessage extends VerifyMessage {
+
+    private URI destination;
+
+    protected VerifySamlMessage() {
+    }
+
+    public VerifySamlMessage(String id, String issuer, DateTime issueInstant, URI destination) {
+        super(id, issuer, issueInstant);
+        this.destination = destination;
+    }
+
+    public URI getDestination() {
+        return destination;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/exception/SamlDuplicateRequestIdException.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/exception/SamlDuplicateRequestIdException.java
@@ -1,0 +1,14 @@
+package uk.gov.ida.saml.hub.exception;
+
+import org.slf4j.event.Level;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+
+public class SamlDuplicateRequestIdException extends SamlTransformationErrorException {
+    public SamlDuplicateRequestIdException(String errorMessage, Exception cause, Level logLevel) {
+        super(errorMessage, cause, logLevel);
+    }
+
+    public SamlDuplicateRequestIdException(String errorMessage, Level logLevel) {
+        super(errorMessage, logLevel);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/exception/SamlRequestTooOldException.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/exception/SamlRequestTooOldException.java
@@ -1,0 +1,14 @@
+package uk.gov.ida.saml.hub.exception;
+
+import org.slf4j.event.Level;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+
+public class SamlRequestTooOldException extends SamlTransformationErrorException {
+    public SamlRequestTooOldException(String errorMessage, Exception cause, Level logLevel) {
+        super(errorMessage, cause, logLevel);
+    }
+
+    public SamlRequestTooOldException(String errorMessage, Level logLevel) {
+        super(errorMessage, logLevel);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/exception/SamlValidationException.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/exception/SamlValidationException.java
@@ -1,0 +1,10 @@
+package uk.gov.ida.saml.hub.exception;
+
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+public class SamlValidationException extends SamlTransformationErrorException {
+    public SamlValidationException(SamlValidationSpecificationFailure failure) {
+        super(failure.getErrorMessage(), failure.getLogLevel());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/factories/AttributeQueryAttributeFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/factories/AttributeQueryAttributeFactory.java
@@ -1,0 +1,23 @@
+package uk.gov.ida.saml.hub.factories;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute;
+
+public class AttributeQueryAttributeFactory {
+
+    private final OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+
+    @Inject
+    public AttributeQueryAttributeFactory(OpenSamlXmlObjectFactory openSamlXmlObjectFactory) {
+        this.openSamlXmlObjectFactory = openSamlXmlObjectFactory;
+    }
+
+    public Attribute createAttribute(final UserAccountCreationAttribute userAccountCreationAttribute) {
+        final Attribute attribute = openSamlXmlObjectFactory.createAttribute();
+        attribute.setName(userAccountCreationAttribute.getAttributeName());
+        attribute.setNameFormat(Attribute.UNSPECIFIED);
+        return attribute;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestFromRelyingPartyUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestFromRelyingPartyUnmarshaller.java
@@ -1,0 +1,86 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.EncryptedAttribute;
+import org.opensaml.saml.saml2.core.Extensions;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.xmlsec.encryption.support.DecryptionException;
+import org.opensaml.xmlsec.signature.Signature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.core.extensions.versioning.Version;
+import uk.gov.ida.saml.hub.domain.AuthnRequestFromRelyingParty;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+
+public class AuthnRequestFromRelyingPartyUnmarshaller {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuthnRequestFromRelyingPartyUnmarshaller.class);
+
+    private final Decrypter decrypter;
+
+    public AuthnRequestFromRelyingPartyUnmarshaller(Decrypter decrypter) {
+        this.decrypter = decrypter;
+    }
+
+    public AuthnRequestFromRelyingParty fromSamlMessage(AuthnRequest authnRequest) {
+        final String id = authnRequest.getID();
+        final String issuerId = authnRequest.getIssuer().getValue();
+        final DateTime issueInstant = authnRequest.getIssueInstant();
+        final Boolean forceAuthn = authnRequest.isForceAuthn();
+        final Optional<String> assertionConsumerServiceURL = Optional.ofNullable(authnRequest.getAssertionConsumerServiceURL());
+        final Integer assertionConsumerServiceIndex = authnRequest.getAssertionConsumerServiceIndex();
+        final Signature signature = authnRequest.getSignature();
+        final Optional<String> verifyServiceProviderVersion = extractVerifyServiceProviderVersion(authnRequest.getExtensions(), issuerId);
+
+        return new AuthnRequestFromRelyingParty(
+            id,
+            issuerId,
+            issueInstant,
+            URI.create(authnRequest.getDestination()),
+            Optional.ofNullable(forceAuthn),
+            assertionConsumerServiceURL.map(URI::create),
+            ofNullable(assertionConsumerServiceIndex),
+            ofNullable(signature),
+            verifyServiceProviderVersion
+        );
+    }
+
+    private Optional<String> extractVerifyServiceProviderVersion(Extensions extensions, String issuerId) {
+        return Optional.ofNullable(extensions).flatMap(item -> {
+            try {
+                return extensions.getUnknownXMLObjects().stream()
+                    .filter(EncryptedAttribute.class::isInstance)
+                    .findFirst()
+                    .map(EncryptedAttribute.class::cast)
+                    .map(this::decrypt)
+                    .map(this::extractVersion);
+            } catch (Exception e) {
+                LOG.error("Error while processing the VSP version for issuer " + issuerId, e);
+                return Optional.empty();
+            }
+        });
+    }
+
+    private String extractVersion(Attribute attribute) {
+        return attribute.getAttributeValues().stream()
+            .filter(Version.class::isInstance)
+            .findFirst()
+            .map(Version.class::cast)
+            .map(version -> version.getApplicationVersion().getValue())
+            .orElseThrow(() -> new RuntimeException("Attribute does not contain VSP Version"));
+    }
+
+    private Attribute decrypt(EncryptedAttribute encryptedAttribute) {
+        try {
+            return decrypter.decrypt(encryptedAttribute);
+        } catch (DecryptionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestToIdaRequestFromRelyingPartyTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestToIdaRequestFromRelyingPartyTransformer.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import uk.gov.ida.saml.core.validators.DestinationValidator;
+import uk.gov.ida.saml.hub.domain.AuthnRequestFromRelyingParty;
+import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestFromTransactionValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidator;
+
+import java.util.function.Function;
+
+public class AuthnRequestToIdaRequestFromRelyingPartyTransformer implements Function<AuthnRequest, AuthnRequestFromRelyingParty> {
+
+    private final AuthnRequestFromRelyingPartyUnmarshaller authnRequestFromRelyingPartyUnmarshaller;
+    private final SamlRequestSignatureValidator<AuthnRequest> samlRequestSignatureValidator;
+    private final DestinationValidator authnRequestDestinationValidator;
+    private final AuthnRequestFromTransactionValidator authnRequestFromTransactionValidator;
+
+    public AuthnRequestToIdaRequestFromRelyingPartyTransformer(
+        AuthnRequestFromRelyingPartyUnmarshaller authnRequestFromRelyingPartyUnmarshaller,
+        SamlRequestSignatureValidator<AuthnRequest> samlRequestSignatureValidator,
+        DestinationValidator authnRequestDestinationValidator,
+        AuthnRequestFromTransactionValidator authnRequestFromTransactionValidator
+    ) {
+        this.authnRequestFromRelyingPartyUnmarshaller = authnRequestFromRelyingPartyUnmarshaller;
+        this.samlRequestSignatureValidator = samlRequestSignatureValidator;
+        this.authnRequestDestinationValidator = authnRequestDestinationValidator;
+        this.authnRequestFromTransactionValidator = authnRequestFromTransactionValidator;
+    }
+
+    @Override
+    public AuthnRequestFromRelyingParty apply(final AuthnRequest authnRequest) {
+        authnRequestFromTransactionValidator.validate(authnRequest);
+        authnRequestDestinationValidator.validate(authnRequest.getDestination());
+        samlRequestSignatureValidator.validate(authnRequest, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        return authnRequestFromRelyingPartyUnmarshaller.fromSamlMessage(authnRequest);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class IdaResponseFromIdpUnmarshaller {
+    private final IdpIdaStatusUnmarshaller statusUnmarshaller;
+    private final PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller;
+
+    public IdaResponseFromIdpUnmarshaller(
+            IdpIdaStatusUnmarshaller statusUnmarshaller,
+            PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller) {
+        this.statusUnmarshaller = statusUnmarshaller;
+        this.passthroughAssertionUnmarshaller = passthroughAssertionUnmarshaller;
+    }
+
+    public InboundResponseFromIdp fromSaml(ValidatedResponse validatedResponse, ValidatedAssertions validatedAssertions) {
+        Optional<PassthroughAssertion> matchingDatasetAssertion = validatedAssertions.getMatchingDatasetAssertion()
+                .map(passthroughAssertionUnmarshaller::fromAssertion);
+
+        Optional<PassthroughAssertion> authnStatementAssertion = validatedAssertions.getAuthnStatementAssertion()
+                .map(passthroughAssertionUnmarshaller::fromAssertion);
+
+        IdpIdaStatus transformedStatus = statusUnmarshaller.fromSaml(validatedResponse.getStatus());
+        URI destination = URI.create(validatedResponse.getDestination());
+
+
+        return new InboundResponseFromIdp(
+                validatedResponse.getID(),
+                validatedResponse.getInResponseTo(),
+                validatedResponse.getIssuer().getValue(),
+                validatedResponse.getIssueInstant(),
+                transformedStatus,
+                Optional.ofNullable(validatedResponse.getSignature()),
+                matchingDatasetAssertion,
+                destination,
+                authnStatementAssertion);
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaStatusUnmarshaller.java
@@ -1,0 +1,105 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.domain.IdaStatus;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+
+import java.text.MessageFormat;
+import java.util.Map;
+
+import static java.text.MessageFormat.format;
+
+public abstract class IdaStatusUnmarshaller<T extends IdaStatus> {
+
+    private final Map<IdaStatusMapperStatus, T> statusMap;
+
+    public IdaStatusUnmarshaller(Map<IdaStatusMapperStatus, T> statusMap) {
+        this.statusMap = statusMap;
+    }
+
+    public T fromSaml(Status status) {
+        IdaStatusMapperStatus statusMapperStatus = getStatusMapperStatus(status);
+
+        if (!statusMap.containsKey(statusMapperStatus)) {
+            throw new IllegalArgumentException(MessageFormat.format("{0} is not valid in this context", statusMapperStatus));
+        }
+
+        String message = null;
+        if (status.getStatusMessage() != null) {
+            message = status.getStatusMessage().getMessage();
+        }
+        return transformStatus(statusMapperStatus, message);
+    }
+
+    protected T transformStatus(IdaStatusMapperStatus statusMapperStatus, String message) {
+        return statusMap.get(statusMapperStatus);
+    }
+
+    private IdaStatusMapperStatus getStatusMapperStatus(Status status) {
+        StatusCode topLevelStatusCode = status.getStatusCode();
+
+        switch (topLevelStatusCode.getValue()) {
+            case StatusCode.SUCCESS:
+                return getSubStatusForTopLevelSuccessStatus(topLevelStatusCode);
+            case StatusCode.RESPONDER:
+                return getResponderStatus(topLevelStatusCode);
+            case StatusCode.REQUESTER:
+                return IdaStatusMapperStatus.RequesterError;
+        }
+        throw new IllegalArgumentException(format("Unrecognised top-level status code: {0}", topLevelStatusCode.getValue()));
+    }
+
+    private IdaStatusMapperStatus getResponderStatus(StatusCode topLevelStatusCode) {
+        StatusCode subStatusCode = topLevelStatusCode.getStatusCode();
+        switch (subStatusCode.getValue()) {
+            case StatusCode.AUTHN_FAILED:
+                return IdaStatusMapperStatus.AuthenticationFailed;
+            case SamlStatusCode.NO_MATCH:
+                return IdaStatusMapperStatus.NoMatchingServiceMatchFromMatchingService;
+            case StatusCode.NO_AUTHN_CONTEXT:
+                return IdaStatusMapperStatus.NoAuthenticationContext;
+            case StatusCode.REQUESTER:
+                return IdaStatusMapperStatus.RequesterErrorFromIdpAsSentByHub;
+            case SamlStatusCode.CREATE_FAILURE:
+                return IdaStatusMapperStatus.CreateFailed;
+            default:
+                throw new IllegalArgumentException(format("{0} - Unrecognised sub-status code.", topLevelStatusCode.getValue()));
+        }
+    }
+
+    private IdaStatusMapperStatus getSubStatusForTopLevelSuccessStatus(StatusCode topLevelStatusCode) {
+        StatusCode subStatusCode = topLevelStatusCode.getStatusCode();
+
+        if (subStatusCode != null) {
+            if (SamlStatusCode.MATCH.equals(subStatusCode.getValue())) {
+                return IdaStatusMapperStatus.MatchingServiceMatch;
+            }
+            if (SamlStatusCode.NO_MATCH.equals(subStatusCode.getValue())) {
+                return IdaStatusMapperStatus.NoMatchingServiceMatchFromHub;
+            }
+            if (SamlStatusCode.HEALTHY.equals(subStatusCode.getValue())) {
+                return IdaStatusMapperStatus.Healthy;
+            }
+            if (SamlStatusCode.CREATED.equals(subStatusCode.getValue())) {
+                return IdaStatusMapperStatus.Created;
+            }
+        }
+
+        return IdaStatusMapperStatus.Success;
+    }
+
+    protected enum IdaStatusMapperStatus {
+        Success,
+        NoAuthenticationContext,
+        RequesterError,
+        RequesterErrorFromIdpAsSentByHub,
+        AuthenticationFailed,
+        NoMatchingServiceMatchFromHub,
+        NoMatchingServiceMatchFromMatchingService,
+        MatchingServiceMatch,
+        Healthy,
+        Created,
+        CreateFailed
+        }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshaller.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusMessage;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+
+import java.util.Optional;
+
+import static java.text.MessageFormat.format;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+public class IdpIdaStatusUnmarshaller {
+
+    private final SamlStatusToIdaStatusCodeMapper idpStatusMapper;
+    private final IdpIdaStatus.IdpIdaStatusFactory statusFactory;
+
+    public IdpIdaStatusUnmarshaller(
+            final IdpIdaStatus.IdpIdaStatusFactory statusFactory,
+            final SamlStatusToIdpIdaStatusMappingsFactory statusMappingsFactory) {
+
+        this.idpStatusMapper = new SamlStatusToIdaStatusCodeMapper(
+                statusMappingsFactory.getSamlToIdpIdaStatusMappings()
+        );
+        this.statusFactory = statusFactory;
+    }
+
+    public IdpIdaStatus fromSaml(final Status samlStatus) {
+        final IdpIdaStatus.Status status = getStatus(samlStatus);
+        final Optional<String> message = getStatusMessage(samlStatus);
+        return statusFactory.create(status, message);
+    }
+
+    private IdpIdaStatus.Status getStatus(final Status samlStatus) {
+        return idpStatusMapper.map(samlStatus).orElseThrow(() -> new IllegalStateException(
+                format("Could not map status to a IdpIdaStatus: {0}", SerializeSupport.nodeToString(samlStatus.getDOM()))
+        ));
+    }
+
+    private Optional<String> getStatusMessage(final Status samlStatus) {
+        final StatusMessage statusMessage = samlStatus.getStatusMessage();
+        return statusMessage != null ? of(statusMessage.getMessage()) : empty();
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundHealthCheckResponseFromMatchingServiceUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundHealthCheckResponseFromMatchingServiceUnmarshaller.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.hub.domain.InboundHealthCheckResponseFromMatchingService;
+
+public class InboundHealthCheckResponseFromMatchingServiceUnmarshaller {
+    private MatchingServiceIdaStatusUnmarshaller statusUnmarshaller;
+
+    public InboundHealthCheckResponseFromMatchingServiceUnmarshaller(
+            MatchingServiceIdaStatusUnmarshaller statusUnmarshaller) {
+
+        this.statusUnmarshaller = statusUnmarshaller;
+    }
+
+    public InboundHealthCheckResponseFromMatchingService fromSaml(Response response) {
+        MatchingServiceIdaStatus transformedStatus = statusUnmarshaller.fromSaml(response.getStatus());
+
+        return new InboundHealthCheckResponseFromMatchingService(
+                response.getID(),
+                response.getInResponseTo(),
+                response.getIssuer().getValue(),
+                response.getIssueInstant(),
+                transformedStatus);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromIdpDataGenerator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromIdpDataGenerator.java
@@ -1,0 +1,62 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import static java.util.Optional.empty;
+
+import java.util.Optional;
+
+import com.google.inject.Inject;
+
+import uk.gov.ida.saml.core.domain.InboundResponseFromIdpData;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.AssertionBlobEncrypter;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
+
+public class InboundResponseFromIdpDataGenerator {
+
+    private AssertionBlobEncrypter assertionBlobEncrypter;
+
+    @Inject
+    public InboundResponseFromIdpDataGenerator(AssertionBlobEncrypter assertionBlobEncrypter) {
+        this.assertionBlobEncrypter = assertionBlobEncrypter;
+    }
+
+    public InboundResponseFromIdpData generate(InboundResponseFromIdp idaResponseFromIdp, String matchingServiceEntityId) {
+        Optional<String> principalIpAddressFromIdp = empty();
+        Optional<String> persistentId = empty();
+        Optional<String> idpFraudEventId = empty();
+        Optional<String> fraudIndicator = empty();
+        Optional<String> authnAssertionBlob = empty();
+        Optional<String> encryptedMatchingDatasetAssertion = empty();
+        String levelOfAssurance = null;
+
+        if(idaResponseFromIdp.getAuthnStatementAssertion().isPresent()) {
+            final PassthroughAssertion authnStatementAssertion = idaResponseFromIdp.getAuthnStatementAssertion().get();
+            authnAssertionBlob = Optional.of(authnStatementAssertion.getUnderlyingAssertionBlob());
+            principalIpAddressFromIdp = Optional.ofNullable(authnStatementAssertion.getPrincipalIpAddressAsSeenByIdp().orElse(null));
+            persistentId = Optional.ofNullable(authnStatementAssertion.getPersistentId().getNameId());
+            if(authnStatementAssertion.getAuthnContext().isPresent()) {
+                levelOfAssurance = authnStatementAssertion.getAuthnContext().get().name();
+            }
+            if(authnStatementAssertion.getFraudDetectedDetails().isPresent()) {
+                idpFraudEventId = Optional.of(authnStatementAssertion.getFraudDetectedDetails().get().getIdpFraudEventId());
+                fraudIndicator = Optional.of(authnStatementAssertion.getFraudDetectedDetails().get().getFraudIndicator());
+            }
+        }
+        if(idaResponseFromIdp.getMatchingDatasetAssertion().isPresent()) {
+            encryptedMatchingDatasetAssertion = Optional.ofNullable(idaResponseFromIdp.getMatchingDatasetAssertion().get())
+                    .map(PassthroughAssertion::getUnderlyingAssertionBlob)
+                    .map(blob -> assertionBlobEncrypter.encryptAssertionBlob(matchingServiceEntityId, blob));
+        }
+        return new InboundResponseFromIdpData(
+                idaResponseFromIdp.getStatus().getStatusCode(),
+                idaResponseFromIdp.getStatus().getMessage(),
+                idaResponseFromIdp.getIssuer(),
+                authnAssertionBlob,
+                encryptedMatchingDatasetAssertion,
+                persistentId,
+                principalIpAddressFromIdp,
+                levelOfAssurance,
+                idpFraudEventId,
+                fraudIndicator);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromMatchingServiceUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromMatchingServiceUnmarshaller.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.base.Optional;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromMatchingService;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+public class InboundResponseFromMatchingServiceUnmarshaller {
+    private PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller;
+    private MatchingServiceIdaStatusUnmarshaller statusUnmarshaller;
+
+    public InboundResponseFromMatchingServiceUnmarshaller(
+            PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller,
+            MatchingServiceIdaStatusUnmarshaller statusUnmarshaller) {
+        this.passthroughAssertionUnmarshaller = passthroughAssertionUnmarshaller;
+        this.statusUnmarshaller = statusUnmarshaller;
+    }
+
+    public InboundResponseFromMatchingService fromSaml(ValidatedResponse validatedResponse, ValidatedAssertions validatedAssertions) {
+        Optional<PassthroughAssertion> idaAssertion = null;
+        if (validatedAssertions.getAssertions().size() > 0){
+            idaAssertion = Optional.fromNullable(passthroughAssertionUnmarshaller.fromAssertion(validatedAssertions.getAssertions().get(0)));
+        }
+
+        MatchingServiceIdaStatus transformedStatus = statusUnmarshaller.fromSaml(validatedResponse.getStatus());
+
+        return new InboundResponseFromMatchingService(
+                validatedResponse.getID(),
+                validatedResponse.getInResponseTo(),
+                validatedResponse.getIssuer().getValue(),
+                validatedResponse.getIssueInstant(),
+                transformedStatus,
+                idaAssertion);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/MatchingServiceIdaStatus.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/MatchingServiceIdaStatus.java
@@ -1,0 +1,12 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import uk.gov.ida.saml.core.domain.IdaStatus;
+
+public enum MatchingServiceIdaStatus implements IdaStatus {
+    NoMatchingServiceMatchFromMatchingService,
+    RequesterError,
+    MatchingServiceMatch,
+    UserAccountCreated,
+    UserAccountCreationFailed,
+    Healthy
+    }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/MatchingServiceIdaStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/MatchingServiceIdaStatusUnmarshaller.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MatchingServiceIdaStatusUnmarshaller extends IdaStatusUnmarshaller<MatchingServiceIdaStatus> {
+
+    private static final ImmutableMap<IdaStatusMapperStatus, MatchingServiceIdaStatus> SAML_TO_REST_CODES =
+            ImmutableMap.<IdaStatusMapperStatus, MatchingServiceIdaStatus>builder()
+                    .put(IdaStatusMapperStatus.RequesterError, MatchingServiceIdaStatus.RequesterError)
+                    .put(IdaStatusMapperStatus.NoMatchingServiceMatchFromMatchingService, MatchingServiceIdaStatus.NoMatchingServiceMatchFromMatchingService)
+                    .put(IdaStatusMapperStatus.MatchingServiceMatch, MatchingServiceIdaStatus.MatchingServiceMatch)
+                    .put(IdaStatusMapperStatus.Healthy, MatchingServiceIdaStatus.Healthy)
+                    .put(IdaStatusMapperStatus.Created, MatchingServiceIdaStatus.UserAccountCreated)
+                    .put(IdaStatusMapperStatus.CreateFailed, MatchingServiceIdaStatus.UserAccountCreationFailed)
+                    .build();
+
+    public MatchingServiceIdaStatusUnmarshaller() {
+        super(SAML_TO_REST_CODES);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/PassthroughAssertionUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/PassthroughAssertionUnmarshaller.java
@@ -1,0 +1,107 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableList;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.FraudDetectedDetails;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+import uk.gov.ida.saml.core.extensions.Gpg45Status;
+import uk.gov.ida.saml.core.extensions.IPAddress;
+import uk.gov.ida.saml.core.extensions.IdpFraudEventId;
+import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Optional;
+
+public class PassthroughAssertionUnmarshaller {
+
+    private static final List<String> VALID_GPG45_STATUSES = ImmutableList.of("DF01", "FI01", "IT01");
+    private final XmlObjectToBase64EncodedStringTransformer<Assertion> assertionStringTransformer;
+
+    private final AuthnContextFactory authnContextFactory;
+
+    public PassthroughAssertionUnmarshaller(
+            XmlObjectToBase64EncodedStringTransformer<Assertion> assertionStringTransformer,
+            AuthnContextFactory authnContextFactory) {
+
+        this.assertionStringTransformer = assertionStringTransformer;
+        this.authnContextFactory = authnContextFactory;
+    }
+
+    public PassthroughAssertion fromAssertion(Assertion assertion) {
+        return fromAssertion(assertion, false);
+    }
+
+    public PassthroughAssertion fromAssertion(Assertion assertion, boolean isEidas) {
+        PersistentId persistentId = new PersistentId(assertion.getSubject().getNameID().getValue());
+        Optional<AuthnContext> levelOfAssurance = Optional.empty();
+        Optional<String> principalIpAddress = getPrincipalIpAddress(assertion.getAttributeStatements());
+        if (!assertion.getAuthnStatements().isEmpty()) {
+            String levelOfAssuranceAsString = assertion.getAuthnStatements().get(0).getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef();
+
+            levelOfAssurance = isEidas ?
+                    Optional.ofNullable(authnContextFactory.mapFromEidasToLoA(levelOfAssuranceAsString)) :
+                    Optional.ofNullable(authnContextFactory.authnContextForLevelOfAssurance(levelOfAssuranceAsString));
+        }
+
+        String underlyingAssertion = assertionStringTransformer.apply(assertion);
+
+        Optional<FraudDetectedDetails> fraudDetectedDetails = Optional.empty();
+        if (levelOfAssurance.isPresent() && levelOfAssurance.get().equals(AuthnContext.LEVEL_X)) {
+            String idpFraudEventId = getIdpFraudEventId(assertion.getAttributeStatements());
+            fraudDetectedDetails = Optional.ofNullable(new FraudDetectedDetails(idpFraudEventId, gpg45Status(assertion.getAttributeStatements())));
+        }
+
+        return new PassthroughAssertion(persistentId, levelOfAssurance, underlyingAssertion, fraudDetectedDetails, principalIpAddress);
+    }
+
+    private Optional<String> getPrincipalIpAddress(List<AttributeStatement> attributeStatements) {
+        Optional<XMLObject> attribute = getAttributeNamed(attributeStatements, IdaConstants.Attributes_1_1.IPAddress.NAME);
+        if (!attribute.isPresent()){
+            return Optional.empty();
+        }
+        String ipAddress = ((IPAddress) attribute.get()).getValue();
+        return Optional.ofNullable(ipAddress);
+    }
+
+    private String gpg45Status(List<AttributeStatement> attributeStatements) {
+        Optional<XMLObject> gpg45StatusAttribute = getAttributeNamed(attributeStatements, IdaConstants.Attributes_1_1.GPG45Status.NAME);
+        if (gpg45StatusAttribute.isPresent()) {
+            String gpg45StatusValue = ((Gpg45Status) gpg45StatusAttribute.get()).getValue();
+            if (VALID_GPG45_STATUSES.contains(gpg45StatusValue)) {
+                return gpg45StatusValue;
+            } else {
+                throw new IllegalStateException(MessageFormat.format("Gpg45 status {0} is not recognised", gpg45StatusValue));
+            }
+        }
+
+        throw new IllegalStateException("Fraud assertion found with no fraud indicator.");
+    }
+
+    private String getIdpFraudEventId(List<AttributeStatement> attributeStatements) {
+        Optional<XMLObject> idpFraudEventAttribute = getAttributeNamed(attributeStatements, IdaConstants.Attributes_1_1.IdpFraudEventId.NAME);
+        if (idpFraudEventAttribute.isPresent()) {
+            return ((IdpFraudEventId) idpFraudEventAttribute.get()).getValue();
+        }
+        throw new IllegalStateException("Fraud assertion found with no Idp Fraud Event Id");
+    }
+
+    private Optional<XMLObject> getAttributeNamed(List<AttributeStatement> attributeStatements, String attributeName) {
+        for (AttributeStatement attributeStatement : attributeStatements) {
+            for (Attribute attribute : attributeStatement.getAttributes()) {
+                if (attribute.getName().equals(attributeName)) {
+                    return Optional.ofNullable(attribute.getAttributeValues().get(0));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdaStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdaStatusCodeMapper.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.StatusDetail;
+import uk.gov.ida.saml.core.extensions.StatusValue;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
+
+public class SamlStatusToIdaStatusCodeMapper {
+
+    private final ImmutableMap<SamlStatusToIdpIdaStatusMappingsFactory.SamlStatusDefinitions, IdpIdaStatus.Status> statusMappings;
+
+    public SamlStatusToIdaStatusCodeMapper(
+            final ImmutableMap<SamlStatusToIdpIdaStatusMappingsFactory.SamlStatusDefinitions, IdpIdaStatus.Status> statusMappings) {
+        this.statusMappings = statusMappings;
+    }
+
+    public Optional<IdpIdaStatus.Status> map(Status samlStatus) {
+        final String statusCodeValue = getStatusCodeValue(samlStatus);
+        final Optional<String> subStatusCodeValue = getSubStatusCodeValue(samlStatus);
+        final List<String> statusDetailValues = getStatusDetailValues(samlStatus);
+
+        return statusMappings.keySet().stream()
+                .filter(k -> k.matches(statusCodeValue, subStatusCodeValue, statusDetailValues))
+                .findFirst()
+                .map(statusMappings::get);
+    }
+
+    private String getStatusCodeValue(final Status status) {
+        return status.getStatusCode().getValue();
+    }
+
+    private Optional<String> getSubStatusCodeValue(final Status status) {
+        return ofNullable(status.getStatusCode().getStatusCode()).map(StatusCode::getValue);
+    }
+
+    private List<String> getStatusDetailValues(Status samlStatus) {
+        Optional<StatusDetail> statusDetail = ofNullable(samlStatus.getStatusDetail());
+
+        return statusDetail.map(x -> x.getUnknownXMLObjects().stream()
+                        .filter(child -> child.getElementQName().getLocalPart().equals(StatusValue.DEFAULT_ELEMENT_LOCAL_NAME))
+                        .map(statusDetailVal -> statusDetailVal.getDOM().getFirstChild().getTextContent()).collect(toList())
+        ).orElseGet(Collections::emptyList);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdpIdaStatusMappingsFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdpIdaStatusMappingsFactory.java
@@ -1,0 +1,52 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableMap;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.core.extensions.StatusValue;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+
+public class SamlStatusToIdpIdaStatusMappingsFactory {
+    enum SamlStatusDefinitions {
+        Success(DetailedStatusCode.Success, Optional.empty()),
+        AuthenticationCancelled(DetailedStatusCode.NoAuthenticationContext, Optional.of(StatusValue.CANCEL)),
+        AuthenticationPending(DetailedStatusCode.NoAuthenticationContext, Optional.of(StatusValue.PENDING)),
+        NoAuthenticationContext(DetailedStatusCode.NoAuthenticationContext, Optional.empty()),
+        AuthenticationFailed(DetailedStatusCode.AuthenticationFailed, Optional.empty()),
+        RequesterErrorFromIdp(DetailedStatusCode.RequesterErrorFromIdp, Optional.empty()),
+        RequesterErrorRequestDeniedFromIdp(DetailedStatusCode.RequesterErrorRequestDeniedFromIdp, Optional.empty()),
+        UpliftFailed(DetailedStatusCode.NoAuthenticationContext, Optional.of(StatusValue.UPLIFT_FAILED));
+
+        private final DetailedStatusCode statusCode;
+        private final Optional<String> statusDetailValue;
+
+        SamlStatusDefinitions(DetailedStatusCode statusCode, Optional<String> statusDetailValue) {
+            this.statusCode = statusCode;
+            this.statusDetailValue = statusDetailValue;
+        }
+
+        public boolean matches(String samlStatusValue, Optional<String> samlSubStatusValue, List<String> statusDetailValues) {
+            boolean statusCodesMatch = statusCode.getStatus().equals(samlStatusValue) && statusCode.getSubStatus().equals(samlSubStatusValue);
+            boolean statusDetailsMatch = statusDetailValue.map(statusDetailValues::contains).orElse(true);
+            return statusCodesMatch && statusDetailsMatch;
+        }
+    }
+
+    public ImmutableMap<SamlStatusDefinitions, IdpIdaStatus.Status> getSamlToIdpIdaStatusMappings() {
+        // Matching SAML statuses to their IdpIdaStatus counterparts is dependent on the ordering of these put()
+        // statements. There must be a better way of doing this.
+        return ImmutableMap.<SamlStatusDefinitions, IdpIdaStatus.Status>builder()
+                .put(SamlStatusDefinitions.Success, IdpIdaStatus.Status.Success)
+                .put(SamlStatusDefinitions.AuthenticationCancelled, IdpIdaStatus.Status.AuthenticationCancelled)
+                .put(SamlStatusDefinitions.AuthenticationPending, IdpIdaStatus.Status.AuthenticationPending)
+                .put(SamlStatusDefinitions.UpliftFailed, IdpIdaStatus.Status.UpliftFailed)
+                .put(SamlStatusDefinitions.NoAuthenticationContext, IdpIdaStatus.Status.NoAuthenticationContext)
+                .put(SamlStatusDefinitions.AuthenticationFailed, IdpIdaStatus.Status.AuthenticationFailed)
+                .put(SamlStatusDefinitions.RequesterErrorFromIdp, IdpIdaStatus.Status.RequesterError)
+                .put(SamlStatusDefinitions.RequesterErrorRequestDeniedFromIdp, IdpIdaStatus.Status.RequesterError)
+                .build();
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/TransactionIdaStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/TransactionIdaStatusUnmarshaller.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableMap;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+
+public class TransactionIdaStatusUnmarshaller extends IdaStatusUnmarshaller<TransactionIdaStatus> {
+
+    private static final ImmutableMap<IdaStatusMapperStatus, TransactionIdaStatus> SAML_TO_REST_CODES =
+        ImmutableMap.<IdaStatusMapperStatus, TransactionIdaStatus>builder()
+            .put(IdaStatusMapperStatus.RequesterErrorFromIdpAsSentByHub, TransactionIdaStatus.RequesterError)
+            .put(IdaStatusMapperStatus.AuthenticationFailed, TransactionIdaStatus.AuthenticationFailed)
+            .put(IdaStatusMapperStatus.NoAuthenticationContext, TransactionIdaStatus.NoAuthenticationContext)
+            .put(IdaStatusMapperStatus.NoMatchingServiceMatchFromHub, TransactionIdaStatus.NoMatchingServiceMatchFromHub) // This line represents Success:no-match (Legacy functionality which will be deleted in the distant future)
+            .put(IdaStatusMapperStatus.NoMatchingServiceMatchFromMatchingService, TransactionIdaStatus.NoMatchingServiceMatchFromHub) // This line represents Responder:no-match
+            .put(IdaStatusMapperStatus.Success, TransactionIdaStatus.Success)
+            .build();
+
+    public TransactionIdaStatusUnmarshaller() {
+        super(SAML_TO_REST_CODES);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.saml.hub.transformers.inbound.providers;
+
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.core.validators.DestinationValidator;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
+import uk.gov.ida.saml.hub.transformers.inbound.IdaResponseFromIdpUnmarshaller;
+import uk.gov.ida.saml.hub.validators.response.idp.IdpResponseValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+import java.util.function.Function;
+
+public class DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer implements Function<Response, InboundResponseFromIdp> {
+
+    private final IdaResponseFromIdpUnmarshaller idaResponseUnmarshaller;
+    private IdpResponseValidator idpResponseValidator;
+
+    @Deprecated
+    public DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
+            IdaResponseFromIdpUnmarshaller idaResponseUnmarshaller,
+            SamlResponseSignatureValidator samlResponseSignatureValidator,
+            AssertionDecrypter assertionDecrypter,
+            SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
+            EncryptedResponseFromIdpValidator responseFromIdpValidator,
+            DestinationValidator responseDestinationValidator,
+            ResponseAssertionsFromIdpValidator responseAssertionsFromIdpValidator) {
+
+        this(new IdpResponseValidator(
+            samlResponseSignatureValidator,
+            assertionDecrypter,
+            samlAssertionsSignatureValidator,
+            responseFromIdpValidator,
+            responseDestinationValidator,
+            responseAssertionsFromIdpValidator),
+            idaResponseUnmarshaller);
+    }
+
+    public DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(IdpResponseValidator idpResponseValidator,
+                                                                    IdaResponseFromIdpUnmarshaller idaResponseUnmarshaller){
+        this.idaResponseUnmarshaller = idaResponseUnmarshaller;
+        this.idpResponseValidator = idpResponseValidator;
+    }
+
+    @Override
+    public InboundResponseFromIdp apply(Response response) {
+        this.idpResponseValidator.validate(response);
+        ValidatedResponse validatedResponse = this.idpResponseValidator.getValidatedResponse();
+        ValidatedAssertions validatedAssertions = this.idpResponseValidator.getValidatedAssertions();
+
+        return idaResponseUnmarshaller.fromSaml(validatedResponse, validatedAssertions);
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.hub.transformers.inbound.providers;
+
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.AttributeAuthorityDescriptor;
+import uk.gov.ida.saml.hub.domain.InboundHealthCheckResponseFromMatchingService;
+import uk.gov.ida.saml.hub.transformers.inbound.InboundHealthCheckResponseFromMatchingServiceUnmarshaller;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.HealthCheckResponseFromMatchingServiceValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+public class DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer {
+
+    private final InboundHealthCheckResponseFromMatchingServiceUnmarshaller healthCheckUnmarshaller;
+    private final SamlResponseSignatureValidator samlResponseSignatureValidator;
+    private final HealthCheckResponseFromMatchingServiceValidator healthCheckResponseFromMatchingServiceValidator;
+
+    public DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer(
+            InboundHealthCheckResponseFromMatchingServiceUnmarshaller healthCheckUnmarshaller,
+            SamlResponseSignatureValidator samlResponseSignatureValidator,
+            HealthCheckResponseFromMatchingServiceValidator healthCheckResponseFromMatchingServiceValidator) {
+
+        this.healthCheckUnmarshaller = healthCheckUnmarshaller;
+        this.samlResponseSignatureValidator = samlResponseSignatureValidator;
+        this.healthCheckResponseFromMatchingServiceValidator = healthCheckResponseFromMatchingServiceValidator;
+    }
+
+    public InboundHealthCheckResponseFromMatchingService transform(Response response) {
+        healthCheckResponseFromMatchingServiceValidator.validate(response);
+        samlResponseSignatureValidator.validate(response, AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
+        return healthCheckUnmarshaller.fromSaml(response);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.saml.hub.transformers.inbound.providers;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.AttributeAuthorityDescriptor;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.EncryptedResponseFromMatchingServiceValidator;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromMatchingService;
+import uk.gov.ida.saml.hub.transformers.inbound.InboundResponseFromMatchingServiceUnmarshaller;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.ResponseAssertionsFromMatchingServiceValidator;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+import java.util.List;
+
+public class DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer {
+
+    private final InboundResponseFromMatchingServiceUnmarshaller responseUnmarshaller;
+    private final SamlResponseSignatureValidator samlResponseSignatureValidator;
+    private final AssertionDecrypter samlResponseAssertionDecrypter;
+    private final SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+    private final EncryptedResponseFromMatchingServiceValidator responseFromMatchingServiceValidator;
+    private final ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator;
+
+    public DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer(
+            InboundResponseFromMatchingServiceUnmarshaller responseUnmarshaller,
+            SamlResponseSignatureValidator samlResponseSignatureValidator,
+            AssertionDecrypter samlResponseAssertionDecrypter,
+            SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
+            EncryptedResponseFromMatchingServiceValidator responseFromMatchingServiceValidator,
+            ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator) {
+
+        this.responseUnmarshaller = responseUnmarshaller;
+        this.samlResponseSignatureValidator = samlResponseSignatureValidator;
+        this.samlResponseAssertionDecrypter = samlResponseAssertionDecrypter;
+        this.samlAssertionsSignatureValidator = samlAssertionsSignatureValidator;
+        this.responseFromMatchingServiceValidator = responseFromMatchingServiceValidator;
+        this.responseAssertionsFromMatchingServiceValidator = responseAssertionsFromMatchingServiceValidator;
+    }
+
+    public InboundResponseFromMatchingService transform(Response response) {
+        responseFromMatchingServiceValidator.validate(response);
+
+        /* Decrypt and validate assertions independently. */
+        ValidatedResponse validatedResponse = samlResponseSignatureValidator.validate(response, AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
+        /* Decrypt and validate assertions independently. */
+        List<Assertion> decryptedAssertions = samlResponseAssertionDecrypter.decryptAssertions(validatedResponse);
+        ValidatedAssertions validatedAssertions = samlAssertionsSignatureValidator.validate(decryptedAssertions, AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
+
+        responseAssertionsFromMatchingServiceValidator.validate(validatedResponse, validatedAssertions);
+
+        return responseUnmarshaller.fromSaml(validatedResponse, validatedAssertions);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/AssertionFromIdpToAssertionTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/AssertionFromIdpToAssertionTransformer.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+
+public class AssertionFromIdpToAssertionTransformer {
+
+    private final StringToOpenSamlObjectTransformer<Assertion> stringAssertionTransformer;
+
+    public AssertionFromIdpToAssertionTransformer(StringToOpenSamlObjectTransformer<Assertion> stringAssertionTransformer) {
+        this.stringAssertionTransformer = stringAssertionTransformer;
+    }
+
+    public Assertion transform(String assertionString) {
+        Assertion assertion = stringAssertionTransformer.apply(assertionString);
+        assertion.detach();
+        return assertion;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/AttributeQueryToElementTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/AttributeQueryToElementTransformer.java
@@ -1,0 +1,49 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.w3c.dom.Element;
+import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlAttributeQueryAssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.hub.transformers.outbound.decorators.SamlAttributeQueryAssertionSignatureSigner;
+import uk.gov.ida.saml.hub.transformers.outbound.decorators.SigningRequestAbstractTypeSignatureCreator;
+
+import java.util.function.Function;
+
+public class AttributeQueryToElementTransformer implements Function<AttributeQuery, Element> {
+
+    private final SigningRequestAbstractTypeSignatureCreator<AttributeQuery> signatureCreator;
+    private final SamlAttributeQueryAssertionSignatureSigner samlAttributeQueryAssertionSignatureSigner;
+    private final SamlSignatureSigner<AttributeQuery> samlSignatureSigner;
+    private final XmlObjectToElementTransformer<AttributeQuery> xmlObjectToElementTransformer;
+    private final SamlAttributeQueryAssertionEncrypter encrypter;
+
+    @Inject
+    public AttributeQueryToElementTransformer(
+            final SigningRequestAbstractTypeSignatureCreator<AttributeQuery> signatureCreator,
+            final SamlAttributeQueryAssertionSignatureSigner samlAttributeQueryAssertionSignatureSigner,
+            final SamlSignatureSigner<AttributeQuery> samlSignatureSigner,
+            final XmlObjectToElementTransformer<AttributeQuery> xmlObjectToElementTransformer,
+            final SamlAttributeQueryAssertionEncrypter encrypter) {
+
+        this.signatureCreator = signatureCreator;
+        this.samlSignatureSigner = samlSignatureSigner;
+        this.samlAttributeQueryAssertionSignatureSigner = samlAttributeQueryAssertionSignatureSigner;
+        this.xmlObjectToElementTransformer = xmlObjectToElementTransformer;
+        this.encrypter = encrypter;
+    }
+
+    @Override
+    public Element apply(final AttributeQuery attributeQuery) {
+        final AttributeQuery queryWithSignature = signatureCreator.addUnsignedSignatureTo(attributeQuery);
+        final AttributeQuery queryWithSignedAssertions =
+                samlAttributeQueryAssertionSignatureSigner.signAssertions(queryWithSignature);
+        final AttributeQuery queryWithEncryptedAssertions =
+                encrypter.encryptAssertions(queryWithSignedAssertions);
+        final AttributeQuery signedQuery =
+                samlSignatureSigner.sign(queryWithEncryptedAssertions);
+        return xmlObjectToElementTransformer.apply(signedQuery);
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestFromHubToAuthnRequestTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestFromHubToAuthnRequestTransformer.java
@@ -1,0 +1,12 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+
+public class EidasAuthnRequestFromHubToAuthnRequestTransformer extends EidasAuthnRequestToAuthnRequestTransformer {
+
+    @Inject
+    public EidasAuthnRequestFromHubToAuthnRequestTransformer(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestToAuthnRequestTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestToAuthnRequestTransformer.java
@@ -1,0 +1,146 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import org.opensaml.core.xml.XMLObjectBuilder;
+import org.opensaml.core.xml.XMLObjectBuilderFactory;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Extensions;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.core.impl.ExtensionsBuilder;
+import org.opensaml.security.SecurityException;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.extensions.RequestedAttribute;
+import uk.gov.ida.saml.core.extensions.RequestedAttributes;
+import uk.gov.ida.saml.core.extensions.SPType;
+import uk.gov.ida.saml.core.extensions.impl.RequestedAttributeImpl;
+import uk.gov.ida.saml.core.extensions.impl.RequestedAttributesImpl;
+import uk.gov.ida.saml.core.extensions.impl.SPTypeImpl;
+import uk.gov.ida.saml.hub.domain.EidasAuthnRequestFromHub;
+import uk.gov.ida.saml.hub.domain.LevelOfAssurance;
+
+import javax.annotation.Nonnull;
+import java.util.function.Function;
+
+
+public abstract class EidasAuthnRequestToAuthnRequestTransformer implements Function<EidasAuthnRequestFromHub,AuthnRequest> {
+    public static final AuthnContextComparisonTypeEnumeration MINIMUM_AUTHNCONTEXT = AuthnContextComparisonTypeEnumeration.MINIMUM;
+
+    public static final String NATURAL_PERSON_NAME_PREFIX = "http://eidas.europa.eu/attributes/naturalperson/";
+
+    private OpenSamlXmlObjectFactory samlObjectFactory;
+    private final XMLObjectBuilderFactory xmlObjectBuilderFactory = XMLObjectProviderRegistrySupport.getBuilderFactory();
+
+    @Inject
+    protected EidasAuthnRequestToAuthnRequestTransformer(OpenSamlXmlObjectFactory samlObjectFactory) {
+        this.samlObjectFactory = samlObjectFactory;
+    }
+
+    @Override
+    public AuthnRequest apply(EidasAuthnRequestFromHub originalRequestToCountry) {
+        AuthnRequest authnRequest = samlObjectFactory.createAuthnRequest();
+        authnRequest.setID(originalRequestToCountry.getId());
+        authnRequest.setIssueInstant(originalRequestToCountry.getIssueInstant());
+        authnRequest.setDestination(originalRequestToCountry.getDestination().toASCIIString());
+        authnRequest.setProtocolBinding(SAMLConstants.SAML2_POST_BINDING_URI);
+        authnRequest.setConsent(StatusResponseType.UNSPECIFIED_CONSENT);
+        authnRequest.setForceAuthn(true);
+        authnRequest.setProviderName(originalRequestToCountry.getProviderName());
+        authnRequest.setNameIDPolicy(getNameIDPolicy());
+        authnRequest.setIssuer(samlObjectFactory.createIssuer(originalRequestToCountry.getIssuer()));
+        authnRequest.setRequestedAuthnContext(getRequestedAuthnContext(originalRequestToCountry));
+        authnRequest.setExtensions(getExtensions());
+        return authnRequest;
+    }
+
+    private NameIDPolicy getNameIDPolicy() {
+        NameIDPolicy nameIdPolicy = samlObjectFactory.createNameIdPolicy();
+        nameIdPolicy.setFormat(NameIDType.PERSISTENT);
+        nameIdPolicy.setAllowCreate(true);
+        return nameIdPolicy;
+    }
+
+    private RequestedAuthnContext getRequestedAuthnContext(EidasAuthnRequestFromHub originalRequestToCountry) {
+        RequestedAuthnContext requestedAuthnContext = samlObjectFactory.createRequestedAuthnContext(MINIMUM_AUTHNCONTEXT);
+
+        String levelOfAssuranceRequested = null;
+        try {
+            AuthnContext lowestAuthnContext = originalRequestToCountry.getLevelsOfAssurance().stream()
+                .min(AuthnContext::compareTo)
+                .orElseThrow(() -> new SecurityException("Expected to find at least 1 Level of Assurance in requested authn context"));
+
+            switch (lowestAuthnContext) {
+                case LEVEL_1    :   levelOfAssuranceRequested = LevelOfAssurance.LOW.toString();            break;
+                case LEVEL_2    :   levelOfAssuranceRequested = LevelOfAssurance.SUBSTANTIAL.toString();    break;
+                case LEVEL_3    :   levelOfAssuranceRequested = LevelOfAssurance.HIGH.toString();           break;
+                case LEVEL_4    :   levelOfAssuranceRequested = LevelOfAssurance.HIGH.toString();           break;
+                default         :
+                    throw new SecurityException("Unknown level of assurance from requested AuthnContext : " + lowestAuthnContext);
+            }
+        } catch(SecurityException e) {
+            throw new IllegalStateException("Expected to find, or map to, a level of assurance ", e);
+        }
+        requestedAuthnContext.getAuthnContextClassRefs().add(samlObjectFactory.createAuthnContextClassReference(levelOfAssuranceRequested));
+        return requestedAuthnContext;
+    }
+
+    private Extensions getExtensions() {
+        Extensions extensions = new ExtensionsBuilder().buildObject();
+
+        XMLObjectBuilder<?> spTypeBuilder = xmlObjectBuilderFactory.getBuilder(SPType.DEFAULT_ELEMENT_NAME);
+        SPTypeImpl spTypeObject = (SPTypeImpl) spTypeBuilder.buildObject(SPType.DEFAULT_ELEMENT_NAME);
+        spTypeObject.setValue("public");
+        extensions.getUnknownXMLObjects().add(spTypeObject);
+
+        RequestedAttributesImpl requestedAttributesObject = getRequestedAttributes();
+
+        extensions.getUnknownXMLObjects().add(requestedAttributesObject);
+        return extensions;
+    }
+
+    private RequestedAttributesImpl getRequestedAttributes() {
+        XMLObjectBuilder<?> requestedAttributesBuilder = xmlObjectBuilderFactory.getBuilder(RequestedAttributes.DEFAULT_ELEMENT_NAME);
+        RequestedAttributesImpl requestedAttributesObject = (RequestedAttributesImpl) requestedAttributesBuilder.buildObject(RequestedAttributes.DEFAULT_ELEMENT_NAME);
+        requestedAttributesObject.setRequestedAttributes(
+            createMandatoryRequestedAttribute("FirstName", "CurrentGivenName"),
+            createMandatoryRequestedAttribute("FamilyName", "CurrentFamilyName"),
+            createMandatoryRequestedAttribute("DateOfBirth", "DateOfBirth"),
+            createMandatoryRequestedAttribute("PersonIdentifier", "PersonIdentifier"),
+            createOptionalRequestedAttribute("CurrentAddress", "CurrentAddress"),
+            createOptionalRequestedAttribute("Gender", "Gender")
+        );
+        return requestedAttributesObject;
+    }
+
+    protected OpenSamlXmlObjectFactory getSamlObjectFactory() {
+        return samlObjectFactory;
+    }
+
+    @Nonnull
+    private RequestedAttributeImpl createOptionalRequestedAttribute(String friendlyName, String nameSuffix) {
+        return createRequestedAttribute(friendlyName, nameSuffix, false);
+    }
+
+    @Nonnull
+    private RequestedAttributeImpl createMandatoryRequestedAttribute(String friendlyName, String nameSuffix) {
+        return createRequestedAttribute(friendlyName, nameSuffix, true);
+    }
+
+    @Nonnull
+    private RequestedAttributeImpl createRequestedAttribute(String friendlyName, String nameSuffix, boolean required) {
+        XMLObjectBuilder<?> requestedAttributeBuilder = xmlObjectBuilderFactory.getBuilder(RequestedAttribute.DEFAULT_ELEMENT_NAME);
+        RequestedAttributeImpl requestedAttribute = (RequestedAttributeImpl) requestedAttributeBuilder.buildObject(RequestedAttribute.DEFAULT_ELEMENT_NAME);
+        requestedAttribute.setName(NATURAL_PERSON_NAME_PREFIX + nameSuffix);
+        requestedAttribute.setFriendlyName(friendlyName);
+        requestedAttribute.setNameFormat(Attribute.URI_REFERENCE);
+        requestedAttribute.setIsRequired(required);
+        return requestedAttribute;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EncryptedAssertionUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EncryptedAssertionUnmarshaller.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+
+public class EncryptedAssertionUnmarshaller {
+    private final StringToOpenSamlObjectTransformer<EncryptedAssertion> stringAssertionTransformer;
+
+    public EncryptedAssertionUnmarshaller(StringToOpenSamlObjectTransformer<EncryptedAssertion> stringAssertionTransformer) {
+        this.stringAssertionTransformer = stringAssertionTransformer;
+    }
+
+    public EncryptedAssertion transform(String assertionString) {
+        EncryptedAssertion assertion = stringAssertionTransformer.apply(assertionString);
+        assertion.detach();
+        return assertion;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/HubAssertionMarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/HubAssertionMarshaller.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.Issuer;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.Cycle3Dataset;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.transformers.outbound.OutboundAssertionToSubjectTransformer;
+import uk.gov.ida.saml.hub.factories.AttributeFactory;
+
+import java.util.Map;
+
+public class HubAssertionMarshaller {
+
+    private final OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+    private final AttributeFactory attributeFactory;
+    private final OutboundAssertionToSubjectTransformer outboundAssertionToSubjectTransformer;
+
+    public HubAssertionMarshaller(
+            OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+            AttributeFactory attributeFactory,
+            OutboundAssertionToSubjectTransformer outboundAssertionToSubjectTransformer) {
+
+        this.openSamlXmlObjectFactory = openSamlXmlObjectFactory;
+        this.attributeFactory = attributeFactory;
+        this.outboundAssertionToSubjectTransformer = outboundAssertionToSubjectTransformer;
+    }
+
+    public Assertion toSaml(HubAssertion hubAssertion) {
+
+        Assertion transformedAssertion = openSamlXmlObjectFactory.createAssertion();
+        transformedAssertion.setIssueInstant(hubAssertion.getIssueInstant());
+        Issuer transformedIssuer = openSamlXmlObjectFactory.createIssuer(hubAssertion.getIssuerId());
+        transformedAssertion.setIssuer(transformedIssuer);
+        transformedAssertion.setID(hubAssertion.getId());
+
+        if (hubAssertion.getCycle3Data().isPresent()){
+            Cycle3Dataset cycle3Data = hubAssertion.getCycle3Data().get();
+            transformedAssertion.getAttributeStatements().add(transform(cycle3Data));
+        }
+
+        transformedAssertion.setSubject(outboundAssertionToSubjectTransformer.transform(hubAssertion));
+
+        return transformedAssertion;
+    }
+
+    private AttributeStatement transform(Cycle3Dataset cycle3Data) {
+        AttributeStatement attributeStatement = openSamlXmlObjectFactory.createAttributeStatement();
+        for (Map.Entry<String, String> entry : cycle3Data.getAttributes().entrySet()) {
+            Attribute data = attributeFactory.createCycle3DataAttribute(entry.getKey(), entry.getValue());
+            attributeStatement.getAttributes().add(data);
+
+        }
+        return attributeStatement;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/HubAttributeQueryRequestToSamlAttributeQueryTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/HubAttributeQueryRequestToSamlAttributeQueryTransformer.java
@@ -1,0 +1,97 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.hub.domain.HubAttributeQueryRequest;
+import uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute;
+import uk.gov.ida.saml.hub.factories.AttributeQueryAttributeFactory;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+public class HubAttributeQueryRequestToSamlAttributeQueryTransformer implements Function<HubAttributeQueryRequest,AttributeQuery> {
+
+    private final OpenSamlXmlObjectFactory samlObjectFactory;
+    private final HubAssertionMarshaller hubAssertionMarshaller;
+    private final AssertionFromIdpToAssertionTransformer assertionFromIdpTransformer;
+    private final AttributeQueryAttributeFactory attributeQueryAttributeFactory;
+    private final EncryptedAssertionUnmarshaller encryptedAssertionUnmarshaller;
+
+    public HubAttributeQueryRequestToSamlAttributeQueryTransformer(
+            final OpenSamlXmlObjectFactory samlObjectFactory,
+            final HubAssertionMarshaller hubAssertionMarshaller,
+            final AssertionFromIdpToAssertionTransformer assertionFromIdpTransformer,
+            final AttributeQueryAttributeFactory attributeQueryAttributeFactory,
+            final EncryptedAssertionUnmarshaller encryptedAssertionUnmarshaller) {
+
+        this.samlObjectFactory = samlObjectFactory;
+        this.hubAssertionMarshaller = hubAssertionMarshaller;
+        this.assertionFromIdpTransformer = assertionFromIdpTransformer;
+        this.attributeQueryAttributeFactory = attributeQueryAttributeFactory;
+        this.encryptedAssertionUnmarshaller = encryptedAssertionUnmarshaller;
+    }
+
+    public AttributeQuery apply(HubAttributeQueryRequest originalQuery) {
+        AttributeQuery transformedQuery = samlObjectFactory.createAttributeQuery();
+
+        Issuer issuer = samlObjectFactory.createIssuer(originalQuery.getIssuer());
+
+        transformedQuery.setID(originalQuery.getId());
+        transformedQuery.setIssuer(issuer);
+        transformedQuery.setIssueInstant(DateTime.now());
+
+        if (originalQuery.getUserAccountCreationAttributes().isPresent()){
+            transformedQuery.getAttributes().addAll(createAttributeList(originalQuery.getUserAccountCreationAttributes().get()));
+        }
+
+        Subject subject = samlObjectFactory.createSubject();
+        NameID nameId = samlObjectFactory.createNameId(originalQuery.getPersistentId().getNameId());
+        nameId.setSPNameQualifier(originalQuery.getAuthnRequestIssuerEntityId());
+        nameId.setNameQualifier(originalQuery.getAssertionConsumerServiceUrl().toASCIIString());
+        subject.setNameID(nameId);
+
+        SubjectConfirmation subjectConfirmation = samlObjectFactory.createSubjectConfirmation();
+        SubjectConfirmationData subjectConfirmationData = samlObjectFactory.createSubjectConfirmationData();
+
+        final String encryptedMatchingDatasetAssertion = originalQuery.getEncryptedMatchingDatasetAssertion();
+        EncryptedAssertion encryptedAssertion = encryptedAssertionUnmarshaller.transform(encryptedMatchingDatasetAssertion);
+        subjectConfirmationData.getUnknownXMLObjects(EncryptedAssertion.DEFAULT_ELEMENT_NAME).add(encryptedAssertion);
+
+        final String authnStatementAssertion = originalQuery.getAuthnStatementAssertion();
+        Assertion transformedAuthnStatementAssertion = assertionFromIdpTransformer.transform(authnStatementAssertion);
+        subjectConfirmationData.getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME).add(transformedAuthnStatementAssertion);
+
+        final Optional<HubAssertion> cycle3DatasetAssertion = originalQuery.getCycle3AttributeAssertion();
+        if (cycle3DatasetAssertion.isPresent()) {
+            Assertion transformedCycle3DatasetAssertion = hubAssertionMarshaller.toSaml(cycle3DatasetAssertion.get());
+            subjectConfirmationData.getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME).add(transformedCycle3DatasetAssertion);
+        }
+
+        subjectConfirmation.setSubjectConfirmationData(subjectConfirmationData);
+        subject.getSubjectConfirmations().add(subjectConfirmation);
+
+        transformedQuery.setSubject(subject);
+
+        return transformedQuery;
+    }
+
+    private List<Attribute> createAttributeList(List<UserAccountCreationAttribute> userAccountCreationAttributes) {
+        return userAccountCreationAttributes
+                .stream()
+                .map(attributeQueryAttributeFactory::createAttribute)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer.java
@@ -1,0 +1,93 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.hub.domain.HubEidasAttributeQueryRequest;
+import uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute;
+import uk.gov.ida.saml.hub.factories.AttributeQueryAttributeFactory;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+public class HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer implements Function<HubEidasAttributeQueryRequest,AttributeQuery> {
+
+    private final OpenSamlXmlObjectFactory samlObjectFactory;
+    private final HubAssertionMarshaller hubAssertionMarshaller;
+    private final AssertionFromIdpToAssertionTransformer assertionFromIdpTransformer;
+    private final AttributeQueryAttributeFactory attributeQueryAttributeFactory;
+    private final EncryptedAssertionUnmarshaller encryptedAssertionUnmarshaller;
+
+    public HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer(
+            final OpenSamlXmlObjectFactory samlObjectFactory,
+            final HubAssertionMarshaller hubAssertionMarshaller,
+            final AssertionFromIdpToAssertionTransformer assertionFromIdpTransformer,
+            final AttributeQueryAttributeFactory attributeQueryAttributeFactory,
+            final EncryptedAssertionUnmarshaller encryptedAssertionUnmarshaller) {
+
+        this.samlObjectFactory = samlObjectFactory;
+        this.hubAssertionMarshaller = hubAssertionMarshaller;
+        this.assertionFromIdpTransformer = assertionFromIdpTransformer;
+        this.attributeQueryAttributeFactory = attributeQueryAttributeFactory;
+        this.encryptedAssertionUnmarshaller = encryptedAssertionUnmarshaller;
+    }
+
+    public AttributeQuery apply(HubEidasAttributeQueryRequest originalQuery) {
+        AttributeQuery transformedQuery = samlObjectFactory.createAttributeQuery();
+
+        Issuer issuer = samlObjectFactory.createIssuer(originalQuery.getIssuer());
+
+        transformedQuery.setID(originalQuery.getId());
+        transformedQuery.setIssuer(issuer);
+        transformedQuery.setIssueInstant(DateTime.now());
+
+        if (originalQuery.getUserAccountCreationAttributes().isPresent()){
+            transformedQuery.getAttributes().addAll(createAttributeList(originalQuery.getUserAccountCreationAttributes().get()));
+        }
+
+        Subject subject = samlObjectFactory.createSubject();
+        NameID nameId = samlObjectFactory.createNameId(originalQuery.getPersistentId().getNameId());
+        nameId.setSPNameQualifier(originalQuery.getAuthnRequestIssuerEntityId());
+        nameId.setNameQualifier(originalQuery.getAssertionConsumerServiceUrl().toASCIIString());
+        subject.setNameID(nameId);
+
+        SubjectConfirmation subjectConfirmation = samlObjectFactory.createSubjectConfirmation();
+        SubjectConfirmationData subjectConfirmationData = samlObjectFactory.createSubjectConfirmationData();
+
+        final String encryptedIdentityAssertion = originalQuery.getEncryptedIdentityAssertion();
+        EncryptedAssertion encryptedAssertion = encryptedAssertionUnmarshaller.transform(encryptedIdentityAssertion);
+        subjectConfirmationData.getUnknownXMLObjects(EncryptedAssertion.DEFAULT_ELEMENT_NAME).add(encryptedAssertion);
+
+        final Optional<HubAssertion> cycle3DatasetAssertion = originalQuery.getCycle3AttributeAssertion();
+        if (cycle3DatasetAssertion.isPresent()) {
+            Assertion transformedCycle3DatasetAssertion = hubAssertionMarshaller.toSaml(cycle3DatasetAssertion.get());
+            subjectConfirmationData.getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME).add(transformedCycle3DatasetAssertion);
+        }
+
+        subjectConfirmation.setSubjectConfirmationData(subjectConfirmationData);
+        subject.getSubjectConfirmations().add(subjectConfirmation);
+
+        transformedQuery.setSubject(subject);
+
+        return transformedQuery;
+    }
+
+    private List<Attribute> createAttributeList(List<UserAccountCreationAttribute> userAccountCreationAttributes) {
+        return userAccountCreationAttributes
+                .stream()
+                .map(attributeQueryAttributeFactory::createAttribute)
+                .collect(Collectors.toList());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/IdaAuthnRequestFromHubToAuthnRequestTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/IdaAuthnRequestFromHubToAuthnRequestTransformer.java
@@ -1,0 +1,54 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
+import org.opensaml.saml.saml2.core.Scoping;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.hub.HubConstants;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+
+public class IdaAuthnRequestFromHubToAuthnRequestTransformer extends IdaAuthnRequestToAuthnRequestTransformer<IdaAuthnRequestFromHub> {
+
+    @Inject
+    public IdaAuthnRequestFromHubToAuthnRequestTransformer(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+
+    protected void supplementAuthnRequestWithDetails(IdaAuthnRequestFromHub originalRequestFromHub, AuthnRequest authnRequest) {
+
+        Conditions conditions = getSamlObjectFactory().createConditions();
+        conditions.setNotOnOrAfter(originalRequestFromHub.getSessionExpiryTimestamp());
+        authnRequest.setConditions(conditions);
+
+        Scoping scoping = getSamlObjectFactory().createScoping();
+        scoping.setProxyCount(0);
+        authnRequest.setScoping(scoping);
+
+        AuthnContextComparisonTypeEnumeration comparisonType = originalRequestFromHub.getComparisonType();
+        RequestedAuthnContext requestedAuthnContext = getSamlObjectFactory().createRequestedAuthnContext(comparisonType);
+
+        originalRequestFromHub.getLevelsOfAssurance().stream()
+                .map(AuthnContext::getUri)
+                .map(uri -> getSamlObjectFactory().createAuthnContextClassReference(uri))
+                .forEach(ref -> requestedAuthnContext.getAuthnContextClassRefs().add(ref));
+
+        NameIDPolicy nameIdPolicy = getSamlObjectFactory().createNameIdPolicy();
+        nameIdPolicy.setFormat(NameIDType.PERSISTENT);
+        nameIdPolicy.setSPNameQualifier(HubConstants.SP_NAME_QUALIFIER);
+        nameIdPolicy.setAllowCreate(true);
+        authnRequest.setNameIDPolicy(nameIdPolicy);
+
+        authnRequest.setRequestedAuthnContext(requestedAuthnContext);
+
+        if (originalRequestFromHub.getForceAuthentication().isPresent()) {
+            authnRequest.setForceAuthn(originalRequestFromHub.getForceAuthentication().get());
+        }
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/IdaAuthnRequestToAuthnRequestTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/IdaAuthnRequestToAuthnRequestTransformer.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Issuer;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.IdaSamlMessage;
+
+import java.util.function.Function;
+
+public abstract class IdaAuthnRequestToAuthnRequestTransformer<TInput extends IdaSamlMessage> implements Function<TInput,AuthnRequest> {
+    private OpenSamlXmlObjectFactory samlObjectFactory;
+
+    @Inject
+    protected IdaAuthnRequestToAuthnRequestTransformer(OpenSamlXmlObjectFactory samlObjectFactory) {
+        this.samlObjectFactory = samlObjectFactory;
+    }
+
+    @Override
+    public AuthnRequest apply(TInput originalRequestToIdp) {
+        AuthnRequest authnRequest = samlObjectFactory.createAuthnRequest();
+        authnRequest.setID(originalRequestToIdp.getId());
+        authnRequest.setIssueInstant(originalRequestToIdp.getIssueInstant());
+        authnRequest.setDestination(originalRequestToIdp.getDestination().toASCIIString());
+        authnRequest.setProtocolBinding(SAMLConstants.SAML2_POST_BINDING_URI);
+
+        Issuer issuer = samlObjectFactory.createIssuer(originalRequestToIdp.getIssuer());
+        authnRequest.setIssuer(issuer);
+
+        supplementAuthnRequestWithDetails(originalRequestToIdp, authnRequest);
+
+        return authnRequest;
+    }
+
+    protected abstract void supplementAuthnRequestWithDetails(TInput originalRequestToIdp, AuthnRequest authnRequest);
+
+    protected OpenSamlXmlObjectFactory getSamlObjectFactory() {
+        return samlObjectFactory;
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/IdpIdaStatusMarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/IdpIdaStatusMarshaller.java
@@ -1,0 +1,60 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensaml.saml.saml2.core.StatusDetail;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.core.extensions.StatusValue;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+public class IdpIdaStatusMarshaller extends IdaStatusMarshaller<IdpIdaStatus> {
+
+    private static final ImmutableMap<IdpIdaStatus, DetailedStatusCode> REST_TO_SAML_CODES =
+            ImmutableMap.<IdpIdaStatus, DetailedStatusCode>builder()
+                    .put(IdpIdaStatus.success(), DetailedStatusCode.Success)
+                    .put(IdpIdaStatus.noAuthenticationContext(), DetailedStatusCode.NoAuthenticationContext)
+                    .put(IdpIdaStatus.authenticationFailed(), DetailedStatusCode.AuthenticationFailed)
+                    .put(IdpIdaStatus.requesterError(), DetailedStatusCode.RequesterErrorFromIdp)
+                    .put(IdpIdaStatus.authenticationCancelled(), DetailedStatusCode.NoAuthenticationContext)
+                    .put(IdpIdaStatus.authenticationPending(), DetailedStatusCode.NoAuthenticationContext)
+                    .put(IdpIdaStatus.upliftFailed(), DetailedStatusCode.NoAuthenticationContext)
+                    .build();
+
+    private static final ImmutableMap<IdpIdaStatus, String> REST_TO_STATUS_DETAIL =
+            ImmutableMap.<IdpIdaStatus, String>builder()
+                    .put(IdpIdaStatus.authenticationCancelled(), StatusValue.CANCEL)
+                    .put(IdpIdaStatus.authenticationPending(), StatusValue.PENDING)
+                    .put(IdpIdaStatus.upliftFailed(), StatusValue.UPLIFT_FAILED)
+                    .build();
+
+    public IdpIdaStatusMarshaller(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+
+    @Override
+    protected Optional<String> getStatusMessage(IdpIdaStatus originalStatus) {
+        return originalStatus.getMessage();
+    }
+
+    @Override
+    protected Optional<StatusDetail> getStatusDetail(IdpIdaStatus originalStatus) {
+        if (REST_TO_STATUS_DETAIL.containsKey(originalStatus)) {
+            StatusDetail statusDetail = this.samlObjectFactory.createStatusDetail();
+            StatusValue statusValue = this.samlObjectFactory.createStatusValue(REST_TO_STATUS_DETAIL.get(originalStatus));
+            statusDetail.getUnknownXMLObjects().add(statusValue);
+            return of(statusDetail);
+        }
+        return empty();
+    }
+
+    @Override
+    protected DetailedStatusCode getDetailedStatusCode(IdpIdaStatus originalStatus) {
+        return REST_TO_SAML_CODES.get(originalStatus);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/MatchingServiceHealthCheckRequestToSamlAttributeQueryTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/MatchingServiceHealthCheckRequestToSamlAttributeQueryTransformer.java
@@ -1,0 +1,51 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.hub.domain.MatchingServiceHealthCheckRequest;
+
+import java.util.function.Function;
+
+public class MatchingServiceHealthCheckRequestToSamlAttributeQueryTransformer implements Function<MatchingServiceHealthCheckRequest,AttributeQuery> {
+
+    private final OpenSamlXmlObjectFactory samlObjectFactory;
+
+    @Inject
+    public MatchingServiceHealthCheckRequestToSamlAttributeQueryTransformer(OpenSamlXmlObjectFactory samlObjectFactory) {
+        this.samlObjectFactory = samlObjectFactory;
+    }
+
+    public AttributeQuery apply(MatchingServiceHealthCheckRequest originalQuery) {
+        AttributeQuery transformedQuery = samlObjectFactory.createAttributeQuery();
+
+        Issuer issuer = samlObjectFactory.createIssuer(originalQuery.getIssuer());
+
+        transformedQuery.setID(originalQuery.getId());
+        transformedQuery.setIssuer(issuer);
+        transformedQuery.setIssueInstant(DateTime.now());
+
+        Subject subject = samlObjectFactory.createSubject();
+        NameID nameId = samlObjectFactory.createNameId(originalQuery.getPersistentId().getNameId());
+        nameId.setSPNameQualifier(originalQuery.getAuthnRequestIssuerEntityId());
+        nameId.setNameQualifier(originalQuery.getAssertionConsumerServiceUrl().toASCIIString());
+        subject.setNameID(nameId);
+
+        SubjectConfirmation subjectConfirmation = samlObjectFactory.createSubjectConfirmation();
+        SubjectConfirmationData subjectConfirmationData = samlObjectFactory.createSubjectConfirmationData();
+
+        subjectConfirmation.setSubjectConfirmationData(subjectConfirmationData);
+        subject.getSubjectConfirmations().add(subjectConfirmation);
+
+        transformedQuery.setSubject(subject);
+
+        return transformedQuery;
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/MatchingServiceIdaStatusMarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/MatchingServiceIdaStatusMarshaller.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.core.domain.MatchingServiceIdaStatus;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+
+public class MatchingServiceIdaStatusMarshaller extends IdaStatusMarshaller<MatchingServiceIdaStatus> {
+
+    private static final ImmutableMap<MatchingServiceIdaStatus, DetailedStatusCode> REST_TO_SAML_CODES =
+            ImmutableMap.<MatchingServiceIdaStatus, DetailedStatusCode>builder()
+                    .put(MatchingServiceIdaStatus.MatchingServiceMatch, DetailedStatusCode.MatchingServiceMatch)
+                    .put(MatchingServiceIdaStatus.NoMatchingServiceMatchFromMatchingService, DetailedStatusCode.NoMatchingServiceMatchFromMatchingService)
+                    .put(MatchingServiceIdaStatus.RequesterError, DetailedStatusCode.RequesterErrorFromIdp)
+                    .put(MatchingServiceIdaStatus.Healthy, DetailedStatusCode.Healthy)
+                    .build();
+
+    @Inject
+    public MatchingServiceIdaStatusMarshaller(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+
+    @Override
+    protected DetailedStatusCode getDetailedStatusCode(MatchingServiceIdaStatus originalStatus) {
+        return REST_TO_SAML_CODES.get(originalStatus);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundLegacyResponseFromHubToStringFunction.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundLegacyResponseFromHubToStringFunction.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+
+import java.util.function.Function;
+
+/**
+ * This concrete class is necessary to convince guice to inject two Function<OutboundResponseFromHub, String> implementations.
+ */
+public class OutboundLegacyResponseFromHubToStringFunction implements Function<OutboundResponseFromHub, String> {
+    private Function<OutboundResponseFromHub, String> transformer;
+
+    public OutboundLegacyResponseFromHubToStringFunction(Function<OutboundResponseFromHub,String> transformer) {
+        this.transformer = transformer;
+    }
+
+    @Override
+    public String apply(OutboundResponseFromHub outboundResponseFromHub) {
+        return transformer.apply(outboundResponseFromHub);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformer.java
@@ -1,0 +1,48 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.transformers.outbound.IdaResponseToSamlResponseTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+
+import java.util.Optional;
+
+public class OutboundResponseFromHubToSamlResponseTransformer extends IdaResponseToSamlResponseTransformer<OutboundResponseFromHub> {
+
+    private final IdaStatusMarshaller<TransactionIdaStatus> statusMarshaller;
+    private final AssertionFromIdpToAssertionTransformer assertionTransformer;
+
+    public OutboundResponseFromHubToSamlResponseTransformer(
+            IdaStatusMarshaller<TransactionIdaStatus> statusMarshaller,
+            OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+            AssertionFromIdpToAssertionTransformer assertionTransformer) {
+
+        super(openSamlXmlObjectFactory);
+
+        this.statusMarshaller = statusMarshaller;
+        this.assertionTransformer = assertionTransformer;
+    }
+
+    @Override
+    protected void transformAssertions(OutboundResponseFromHub originalResponse, Response transformedResponse) {
+        Optional<String> matchingServiceAssertion = originalResponse.getMatchingServiceAssertion();
+        if (matchingServiceAssertion.isPresent()) {
+            Assertion transformedAssertion = assertionTransformer.transform(matchingServiceAssertion.get());
+            transformedResponse.getAssertions().add(transformedAssertion);
+        }
+    }
+
+    @Override
+    protected Status transformStatus(OutboundResponseFromHub originalResponse) {
+        return statusMarshaller.toSamlStatus(originalResponse.getStatus());
+    }
+
+    @Override
+    protected void transformDestination(OutboundResponseFromHub originalResponse, Response transformedResponse) {
+        transformedResponse.setDestination(originalResponse.getDestination().toASCIIString());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundSamlProfileResponseFromHubToStringFunction.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundSamlProfileResponseFromHubToStringFunction.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+
+import java.util.function.Function;
+
+/**
+ * This concrete class is necessary to convince guice to inject two Function<OutboundResponseFromHub, String> implementations.
+ */
+public class OutboundSamlProfileResponseFromHubToStringFunction implements Function<OutboundResponseFromHub, String> {
+    private Function<OutboundResponseFromHub, String> transformer;
+
+    public OutboundSamlProfileResponseFromHubToStringFunction(Function<OutboundResponseFromHub,String> transformer) {
+        this.transformer = transformer;
+    }
+
+    @Override
+    public String apply(OutboundResponseFromHub outboundResponseFromHub) {
+        return transformer.apply(outboundResponseFromHub);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/RequestAbstractTypeToStringTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/RequestAbstractTypeToStringTransformer.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.inject.Inject;
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.hub.transformers.outbound.decorators.SigningRequestAbstractTypeSignatureCreator;
+
+import java.util.function.Function;
+
+public class RequestAbstractTypeToStringTransformer<TInput extends RequestAbstractType> implements Function<TInput, String> {
+
+    private final SigningRequestAbstractTypeSignatureCreator<TInput> signatureCreator;
+    private final SamlSignatureSigner<TInput> samlSignatureSigner;
+    private final XmlObjectToBase64EncodedStringTransformer<TInput> xmlObjectToBase64EncodedStringTransformer;
+
+    @Inject
+    public RequestAbstractTypeToStringTransformer(
+            final SigningRequestAbstractTypeSignatureCreator<TInput> signatureCreator,
+            final SamlSignatureSigner<TInput> samlSignatureSigner,
+            final XmlObjectToBase64EncodedStringTransformer<TInput> xmlObjectToBase64EncodedStringTransformer) {
+
+        this.signatureCreator = signatureCreator;
+        this.samlSignatureSigner = samlSignatureSigner;
+        this.xmlObjectToBase64EncodedStringTransformer = xmlObjectToBase64EncodedStringTransformer;
+    }
+
+    @Override
+    public String apply(final TInput input) {
+        final TInput requestWithSignature = signatureCreator.addUnsignedSignatureTo(input);
+
+        final TInput signedRequest = samlSignatureSigner.sign(requestWithSignature);
+
+        return xmlObjectToBase64EncodedStringTransformer.apply(signedRequest);
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SamlProfileTransactionIdaStatusMarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SamlProfileTransactionIdaStatusMarshaller.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+
+/**
+ * This class is the same as TransactionIdaStatusMarshaller except that TransactionIdaStatus.NoMatchingServiceMatchFromHub
+ * is mapped to DetailedStatusCode.SamlProfileNoMatchingServiceMatchFromHub. This is because the saml profile specifies that a
+ * no-match (which has no Assertions) should have Status of Responder. TransactionIdaStatusMarshaller is kept in the package
+ * for backwards compatibility (RPs receive Success:no-match at time of writing) but the goal is to deprecate it
+ * (but this might take years).
+ */
+public class SamlProfileTransactionIdaStatusMarshaller extends IdaStatusMarshaller<TransactionIdaStatus> {
+
+    private static final ImmutableMap<TransactionIdaStatus, DetailedStatusCode> REST_TO_SAML_CODES =
+            ImmutableMap.<TransactionIdaStatus, DetailedStatusCode>builder()
+                    .put(TransactionIdaStatus.Success, DetailedStatusCode.Success)
+                    .put(TransactionIdaStatus.NoAuthenticationContext, DetailedStatusCode.NoAuthenticationContext)
+                    .put(TransactionIdaStatus.NoMatchingServiceMatchFromHub, DetailedStatusCode.SamlProfileNoMatchingServiceMatchFromHub)
+                    .put(TransactionIdaStatus.AuthenticationFailed, DetailedStatusCode.AuthenticationFailed)
+                    .put(TransactionIdaStatus.RequesterError, DetailedStatusCode.RequesterErrorFromIdpAsSentByHub)
+                    .build();
+
+    @Inject
+    public SamlProfileTransactionIdaStatusMarshaller(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+
+
+    @Override
+    protected DetailedStatusCode getDetailedStatusCode(TransactionIdaStatus originalStatus) {
+        return REST_TO_SAML_CODES.get(originalStatus);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileOutboundResponseFromHubToSamlResponseTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileOutboundResponseFromHubToSamlResponseTransformer.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import javax.inject.Inject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+import uk.gov.ida.saml.core.transformers.outbound.IdaResponseToSamlResponseTransformer;
+
+import java.util.Optional;
+
+public class SimpleProfileOutboundResponseFromHubToSamlResponseTransformer extends IdaResponseToSamlResponseTransformer<OutboundResponseFromHub> {
+
+    private final SimpleProfileTransactionIdaStatusMarshaller statusMarshaller;
+    private final AssertionFromIdpToAssertionTransformer assertionTransformer;
+
+    @Inject
+    public SimpleProfileOutboundResponseFromHubToSamlResponseTransformer(
+            SimpleProfileTransactionIdaStatusMarshaller statusMarshaller,
+            OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+            AssertionFromIdpToAssertionTransformer assertionTransformer) {
+
+        super(openSamlXmlObjectFactory);
+
+        this.statusMarshaller = statusMarshaller;
+        this.assertionTransformer = assertionTransformer;
+    }
+
+    @Override
+    protected void transformAssertions(OutboundResponseFromHub originalResponse, Response transformedResponse) {
+        Optional<String> matchingServiceAssertion = originalResponse.getMatchingServiceAssertion();
+        if (matchingServiceAssertion.isPresent()) {
+            Assertion transformedAssertion = assertionTransformer.transform(matchingServiceAssertion.get());
+            transformedResponse.getAssertions().add(transformedAssertion);
+        }
+    }
+
+    @Override
+    protected Status transformStatus(OutboundResponseFromHub originalResponse) {
+        return statusMarshaller.toSamlStatus(originalResponse.getStatus());
+    }
+
+    @Override
+    protected void transformDestination(OutboundResponseFromHub originalResponse, Response transformedResponse) {
+        transformedResponse.setDestination(originalResponse.getDestination().toASCIIString());
+    }
+
+    @Override
+    protected void transformIssuer(final OutboundResponseFromHub originalResponse, final Response transformedResponse) {
+       // do nothing
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileTransactionIdaStatusMarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileTransactionIdaStatusMarshaller.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.common.collect.ImmutableMap;
+import javax.inject.Inject;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+
+public class SimpleProfileTransactionIdaStatusMarshaller extends IdaStatusMarshaller<TransactionIdaStatus> {
+
+    private static final ImmutableMap<TransactionIdaStatus, DetailedStatusCode> REST_TO_SAML_CODES =
+            ImmutableMap.<TransactionIdaStatus, DetailedStatusCode>builder()
+                    .put(TransactionIdaStatus.Success, DetailedStatusCode.Success)
+                    .put(TransactionIdaStatus.NoAuthenticationContext, DetailedStatusCode.NoAuthenticationContext)
+                    // no-match is different in the simple saml profile: because there are no assertions included
+                    // it should not be Success as it is in the standard signed responses from hub.  The Success
+                    // response was changed to Responder for the simple saml profile (see the relatively opaque text
+                    // in saml-profiles-2.0-os.pdf:544 that says a Success response MUST have an assertion
+                    .put(TransactionIdaStatus.NoMatchingServiceMatchFromHub, DetailedStatusCode.SimpleProfileNoMatchingServiceMatchFromHub)
+                    .put(TransactionIdaStatus.AuthenticationFailed, DetailedStatusCode.AuthenticationFailed)
+                    .put(TransactionIdaStatus.RequesterError, DetailedStatusCode.RequesterErrorFromIdpAsSentByHub)
+                    .build();
+
+    @Inject
+    public SimpleProfileTransactionIdaStatusMarshaller(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+
+
+    @Override
+    protected DetailedStatusCode getDetailedStatusCode(TransactionIdaStatus originalStatus) {
+        return REST_TO_SAML_CODES.get(originalStatus);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/TransactionIdaStatusMarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/TransactionIdaStatusMarshaller.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+
+public class TransactionIdaStatusMarshaller extends IdaStatusMarshaller<TransactionIdaStatus> {
+
+    private static final ImmutableMap<TransactionIdaStatus, DetailedStatusCode> REST_TO_SAML_CODES =
+            ImmutableMap.<TransactionIdaStatus, DetailedStatusCode>builder()
+                    .put(TransactionIdaStatus.Success, DetailedStatusCode.Success)
+                    .put(TransactionIdaStatus.NoAuthenticationContext, DetailedStatusCode.NoAuthenticationContext)
+                    .put(TransactionIdaStatus.NoMatchingServiceMatchFromHub, DetailedStatusCode.NoMatchingServiceMatchFromHub)
+                    .put(TransactionIdaStatus.AuthenticationFailed, DetailedStatusCode.AuthenticationFailed)
+                    .put(TransactionIdaStatus.RequesterError, DetailedStatusCode.RequesterErrorFromIdpAsSentByHub)
+                    .build();
+
+    @Inject
+    public TransactionIdaStatusMarshaller(OpenSamlXmlObjectFactory samlObjectFactory) {
+        super(samlObjectFactory);
+    }
+
+
+    @Override
+    protected DetailedStatusCode getDetailedStatusCode(TransactionIdaStatus originalStatus) {
+        return REST_TO_SAML_CODES.get(originalStatus);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/NoOpSamlAttributeQueryAssertionEncrypter.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/NoOpSamlAttributeQueryAssertionEncrypter.java
@@ -1,0 +1,15 @@
+package uk.gov.ida.saml.hub.transformers.outbound.decorators;
+
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlAttributeQueryAssertionEncrypter;
+
+public class NoOpSamlAttributeQueryAssertionEncrypter extends SamlAttributeQueryAssertionEncrypter {
+    public NoOpSamlAttributeQueryAssertionEncrypter() {
+        super(null, null, null);
+    }
+
+    @Override
+    public AttributeQuery encryptAssertions(AttributeQuery attributeQuery) {
+        return attributeQuery;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSigner.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSigner.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.saml.hub.transformers.outbound.decorators;
+
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.hub.HubConstants;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+
+import static org.opensaml.xmlsec.signature.support.Signer.signObject;
+
+public class SamlAttributeQueryAssertionSignatureSigner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SamlAttributeQueryAssertionSignatureSigner.class);
+
+    private final IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever;
+    private final OpenSamlXmlObjectFactory samlObjectFactory;
+    private final String hubEntityId;
+
+    public SamlAttributeQueryAssertionSignatureSigner(
+            IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever,
+            OpenSamlXmlObjectFactory samlObjectFactory,
+            String hubEntityId) {
+
+        this.keyStoreCredentialRetriever = keyStoreCredentialRetriever;
+        this.samlObjectFactory = samlObjectFactory;
+        this.hubEntityId = hubEntityId;
+    }
+
+    public AttributeQuery signAssertions(AttributeQuery attributeQuery) {
+        LOG.debug("Sign attribute query's C3 assertion's signatures");
+
+        for (SubjectConfirmation subjectConfirmation : attributeQuery.getSubject().getSubjectConfirmations()) {
+            for (XMLObject xmlObject : subjectConfirmation.getSubjectConfirmationData().getUnknownXMLObjects(Assertion.TYPE_NAME)) {
+                Assertion assertion = (Assertion) xmlObject;
+                if (assertion.getIssuer().getValue().equals(hubEntityId)) {
+                    assertion.setSignature(samlObjectFactory.createSignature());
+                    assertion.getSignature().setSigningCredential(keyStoreCredentialRetriever.getSigningCredential());
+                    try {
+                        XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(assertion).marshall(assertion);
+                        signObject(assertion.getSignature());
+                    } catch (SignatureException | MarshallingException e) {
+                        throw new IllegalStateException("Unable to sign assertion.", e);
+                    }
+                }
+            }
+        }
+        return attributeQuery;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SigningRequestAbstractTypeSignatureCreator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SigningRequestAbstractTypeSignatureCreator.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.hub.transformers.outbound.decorators;
+
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.security.SignatureFactory;
+
+public class SigningRequestAbstractTypeSignatureCreator<T extends RequestAbstractType> {
+    private final SignatureFactory signatureFactory;
+
+    public SigningRequestAbstractTypeSignatureCreator(SignatureFactory signatureFactory) {
+        this.signatureFactory = signatureFactory;
+    }
+
+    public T addUnsignedSignatureTo(T requestAbstractType) {
+        Signature signature = signatureFactory.createSignature(requestAbstractType.getID());
+        requestAbstractType.setSignature(signature);
+        return requestAbstractType;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/providers/ResponseToUnsignedStringTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/providers/ResponseToUnsignedStringTransformer.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.saml.hub.transformers.outbound.providers;
+
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlResponseAssertionEncrypter;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+import javax.inject.Inject;
+import java.util.function.Function;
+
+public class ResponseToUnsignedStringTransformer implements Function<Response, String> {
+
+    protected final XmlObjectToBase64EncodedStringTransformer<Response> xmlObjectToBase64EncodedStringTransformer;
+    protected final ResponseAssertionSigner responseAssertionSigner;
+    protected final SamlResponseAssertionEncrypter assertionEncrypter;
+
+    @Inject
+    public ResponseToUnsignedStringTransformer(
+            XmlObjectToBase64EncodedStringTransformer<Response> xmlObjectToBase64EncodedStringTransformer,
+            ResponseAssertionSigner responseAssertionSigner,
+            SamlResponseAssertionEncrypter assertionEncrypter) {
+
+        this.xmlObjectToBase64EncodedStringTransformer = xmlObjectToBase64EncodedStringTransformer;
+        this.responseAssertionSigner = responseAssertionSigner;
+        this.assertionEncrypter = assertionEncrypter;
+    }
+
+    @Override
+    public String apply(Response response) {
+        Response signedResponse = responseAssertionSigner.signAssertions(response);
+        Response signedEncryptedResponse = assertionEncrypter.encryptAssertions(signedResponse);
+        return xmlObjectToBase64EncodedStringTransformer.apply(signedEncryptedResponse);
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/providers/SimpleProfileOutboundResponseFromHubToResponseTransformerProvider.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/providers/SimpleProfileOutboundResponseFromHubToResponseTransformerProvider.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.saml.hub.transformers.outbound.providers;
+
+import com.google.inject.Provider;
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+import uk.gov.ida.saml.hub.transformers.outbound.SimpleProfileOutboundResponseFromHubToSamlResponseTransformer;
+
+import javax.inject.Inject;
+import java.util.function.Function;
+
+public class SimpleProfileOutboundResponseFromHubToResponseTransformerProvider implements
+        Provider<Function<OutboundResponseFromHub, String>> {
+
+    private final Function<OutboundResponseFromHub, String> outboundResponseFromHubToStringTransformer;
+
+    @Inject
+    public SimpleProfileOutboundResponseFromHubToResponseTransformerProvider(
+            SimpleProfileOutboundResponseFromHubToSamlResponseTransformer outboundToResponseTransformer,
+            ResponseToUnsignedStringTransformer responseToStringTransformer) {
+
+        this.outboundResponseFromHubToStringTransformer = responseToStringTransformer.compose(outboundToResponseTransformer);
+    }
+
+    public Function<OutboundResponseFromHub, String> get() {
+        return outboundResponseFromHubToStringTransformer;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestFromTransactionValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestFromTransactionValidator.java
@@ -1,0 +1,145 @@
+package uk.gov.ida.saml.hub.validators.authnrequest;
+
+import com.google.common.base.Strings;
+import org.joda.time.DateTime;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorManager;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;import uk.gov.ida.saml.core.validators.SamlValidator;
+import uk.gov.ida.saml.hub.exception.SamlDuplicateRequestIdException;
+import uk.gov.ida.saml.hub.exception.SamlRequestTooOldException;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil;
+
+public class AuthnRequestFromTransactionValidator implements SamlValidator<AuthnRequest> {
+
+    private final IssuerValidator issuerValidator;
+    private final DuplicateAuthnRequestValidator duplicateAuthnRequestValidator;
+    private final AuthnRequestIssueInstantValidator issueInstantValidator;
+
+    public AuthnRequestFromTransactionValidator(
+            IssuerValidator issuerValidator,
+            DuplicateAuthnRequestValidator duplicateAuthnRequestValidator,
+            AuthnRequestIssueInstantValidator issueInstantValidator) {
+        this.issuerValidator = issuerValidator;
+        this.duplicateAuthnRequestValidator = duplicateAuthnRequestValidator;
+        this.issueInstantValidator = issueInstantValidator;
+    }
+
+    @Override
+    public void validate(AuthnRequest request) {
+        issuerValidator.validate(request.getIssuer());
+        validateRequestId(request);
+        validateIssueInstant(request);
+        validateSignaturePresence(request);
+        validateVersion(request);
+        validateNameIdPolicy(request);
+        validateScoping(request);
+        validateProtocolBinding(request);
+        validatePassiveXSBoolean(request);
+    }
+
+    private void validateScoping(final AuthnRequest request) {
+        if (request.getScoping() != null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.scopingNotAllowed();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void validatePassiveXSBoolean(final AuthnRequest request) {
+        if (request.isPassiveXSBoolean() != null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.isPassiveNotAllowed();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void validateRequestId(final AuthnRequest request) {
+        final String requestId = request.getID();
+        if (Strings.isNullOrEmpty(requestId)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingRequestId();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (!requestIdStartsWithUnderscoreOrLetter(requestId)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.invalidRequestID();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (!duplicateAuthnRequestValidator.valid(request.getID())) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.duplicateRequestId(request.getID(), request.getIssuer().getValue());
+            throw new SamlDuplicateRequestIdException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private boolean requestIdStartsWithUnderscoreOrLetter(final String requestId) {
+        String firstCharacter = requestId.substring(0, 1);
+        return firstCharacter.equals("_") || firstCharacter.matches("[a-zA-Z]");
+    }
+
+    private void validateSignaturePresence(final AuthnRequest request) {
+        Signature signature = request.getSignature();
+        if (signature == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingSignature();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (!SamlSignatureUtil.isSignaturePresent(signature)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.signatureNotSigned();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void validateVersion(final AuthnRequest request) {
+        final String requestId = request.getID();
+        if (request.getVersion() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingRequestVersion(requestId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (request.getVersion() != SAMLVersion.VERSION_20) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.illegalRequestVersionNumber();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void validateIssueInstant(final AuthnRequest request) {
+        final String requestId = request.getID();
+        DateTime issueInstant = request.getIssueInstant();
+        if (issueInstant == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingRequestIssueInstant(requestId);
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (!issueInstantValidator.isValid(issueInstant)) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.requestTooOld(request.getID(), issueInstant, DateTime.now());
+            throw new SamlRequestTooOldException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+    private void validateNameIdPolicy(AuthnRequest request) {
+        NameIDPolicy nameIDPolicy = request.getNameIDPolicy();
+        if (nameIDPolicy != null) {
+            if (nameIDPolicy.getFormat() == null) {
+                SamlTransformationErrorManager.warn(SamlTransformationErrorFactory.missingNameIDPolicy());
+            } else if (!nameIDPolicy.getFormat().equals(NameIDType.PERSISTENT)) {
+                SamlTransformationErrorManager.warn(SamlTransformationErrorFactory.illegalNameIDPolicy(nameIDPolicy.getFormat()));
+            }
+        }
+    }
+
+    private void validateProtocolBinding(final AuthnRequest request) {
+        String protocolBinding = request.getProtocolBinding();
+        if (protocolBinding != null) {
+            if (!protocolBinding.equals(SAMLConstants.SAML2_POST_BINDING_URI)) {
+                SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.illegalProtocolBindingError(protocolBinding, SAMLConstants.SAML2_POST_BINDING_URI);
+                throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+            }
+        }
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIdKey.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIdKey.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.saml.hub.validators.authnrequest;
+
+import java.io.Serializable;
+
+public class AuthnRequestIdKey implements Serializable {
+    private final String requestId;
+
+    AuthnRequestIdKey(String requestId) {
+        this.requestId = requestId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AuthnRequestIdKey that = (AuthnRequestIdKey) o;
+
+        if (requestId != null ? !requestId.equals(that.requestId) : that.requestId != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return requestId != null ? requestId.hashCode() : 0;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIssueInstantValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIssueInstantValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.saml.hub.validators.authnrequest;
+
+import com.google.inject.Inject;
+import io.dropwizard.util.Duration;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.hub.configuration.SamlAuthnRequestValidityDurationConfiguration;
+
+public class AuthnRequestIssueInstantValidator {
+    private final SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration;
+
+    @Inject
+    public AuthnRequestIssueInstantValidator(SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration) {
+
+        this.samlAuthnRequestValidityDurationConfiguration = samlAuthnRequestValidityDurationConfiguration;
+    }
+
+    public boolean isValid(DateTime issueInstant) {
+        final Duration authnRequestValidityDuration = samlAuthnRequestValidityDurationConfiguration.getAuthnRequestValidityDuration();
+        return !issueInstant.isBefore(DateTime.now().minus(authnRequestValidityDuration.toMilliseconds()));
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidator.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.hub.validators.authnrequest;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.hub.configuration.SamlDuplicateRequestValidationConfiguration;
+
+import java.util.concurrent.ConcurrentMap;
+
+public class DuplicateAuthnRequestValidator {
+    private final ConcurrentMap<AuthnRequestIdKey, DateTime> previousRequestKeys;
+    private final SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration;
+
+    @Inject
+    public DuplicateAuthnRequestValidator(ConcurrentMap<AuthnRequestIdKey, DateTime> duplicateIds, SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration) {
+        this.previousRequestKeys = duplicateIds;
+        this.samlDuplicateRequestValidationConfiguration = samlDuplicateRequestValidationConfiguration;
+    }
+
+    public boolean valid(String requestId) {
+        AuthnRequestIdKey key = new AuthnRequestIdKey(requestId);
+
+        if (previousRequestKeys.containsKey(key) && previousRequestKeys.get(key).isAfter(DateTime.now())) {
+            return false;
+        }
+        DateTime expire = DateTime.now().plus(samlDuplicateRequestValidationConfiguration.getAuthnRequestIdExpirationDuration().toMilliseconds());
+        previousRequestKeys.put(key, expire);
+        return true;
+    }
+
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/AssertionSizeValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/AssertionSizeValidator.java
@@ -1,0 +1,11 @@
+package uk.gov.ida.saml.hub.validators.response.common;
+
+import uk.gov.ida.saml.deserializers.validators.SizeValidator;
+
+public class AssertionSizeValidator implements SizeValidator {
+
+    @Override
+    public void validate(String input) {
+        // do nothing
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/IssuerValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/IssuerValidator.java
@@ -1,0 +1,25 @@
+package uk.gov.ida.saml.hub.validators.response.common;
+
+import com.google.common.base.Strings;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.emptyIssuer;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.illegalIssuerFormat;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingIssuer;
+
+public class IssuerValidator {
+    public static void validate(Response response) {
+        Issuer issuer = response.getIssuer();
+        if (issuer == null) throw new SamlValidationException(missingIssuer());
+
+        String issuerId = issuer.getValue();
+        if (Strings.isNullOrEmpty(issuerId)) throw new SamlValidationException(emptyIssuer());
+
+        String issuerFormat = issuer.getFormat();
+        if (issuerFormat != null && !NameIDType.ENTITY.equals(issuerFormat))
+            throw new SamlValidationException(illegalIssuerFormat(issuerFormat, NameIDType.ENTITY));
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/RequestIdValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/RequestIdValidator.java
@@ -1,0 +1,16 @@
+package uk.gov.ida.saml.hub.validators.response.common;
+
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.emptyInResponseTo;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingInResponseTo;
+
+public class RequestIdValidator {
+
+    public static void validate(Response response) {
+        String requestId = response.getInResponseTo();
+        if (requestId == null) throw new SamlValidationException(missingInResponseTo());
+        if (requestId.isEmpty()) throw new SamlValidationException(emptyInResponseTo());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/ResponseMaxSizeValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/ResponseMaxSizeValidator.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.saml.hub.validators.response.common;
+
+import javax.inject.Inject;
+import uk.gov.ida.saml.hub.validators.StringSizeValidator;
+
+public class ResponseMaxSizeValidator extends ResponseSizeValidator {
+    private static final int LOWER_BOUND = 0;
+
+    @Inject
+    public ResponseMaxSizeValidator(StringSizeValidator validator) {
+        super(validator);
+    }
+
+    @Override
+    protected int getLowerBound() {
+        return LOWER_BOUND;
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/ResponseSizeValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/common/ResponseSizeValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.ida.saml.hub.validators.response.common;
+
+import com.google.inject.Inject;
+import uk.gov.ida.saml.deserializers.validators.SizeValidator;
+import uk.gov.ida.saml.hub.validators.StringSizeValidator;
+
+
+public class ResponseSizeValidator implements SizeValidator {
+    // Ensures someone doing nasty things cannot get loads of data out of core hub in a single response
+
+    private static final int LOWER_BOUND = 1400;
+    private static final int UPPER_BOUND = 50000;
+
+    private final StringSizeValidator validator;
+
+    @Inject
+    public ResponseSizeValidator(StringSizeValidator validator) {
+        this.validator = validator;
+    }
+
+    @Override
+    public void validate(String input) {
+        validator.validate(input, getLowerBound(), getUpperBound());
+    }
+
+    private int getUpperBound() {
+        return UPPER_BOUND;
+    }
+
+    protected int getLowerBound() {
+        return LOWER_BOUND;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidator.java
@@ -1,0 +1,60 @@
+package uk.gov.ida.saml.hub.validators.response.idp;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import uk.gov.ida.saml.core.validators.DestinationValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+import java.util.List;
+
+public class IdpResponseValidator {
+    private final SamlResponseSignatureValidator samlResponseSignatureValidator;
+    private final AssertionDecrypter assertionDecrypter;
+    private final SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+    private final EncryptedResponseFromIdpValidator responseFromIdpValidator;
+    private final DestinationValidator responseDestinationValidator;
+    private final ResponseAssertionsFromIdpValidator responseAssertionsFromIdpValidator;
+    private ValidatedResponse validatedResponse;
+    private ValidatedAssertions validatedAssertions;
+
+    public IdpResponseValidator(SamlResponseSignatureValidator samlResponseSignatureValidator,
+                                AssertionDecrypter assertionDecrypter,
+                                SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
+                                EncryptedResponseFromIdpValidator responseFromIdpValidator,
+                                DestinationValidator responseDestinationValidator,
+                                ResponseAssertionsFromIdpValidator responseAssertionsFromIdpValidator) {
+        this.samlResponseSignatureValidator = samlResponseSignatureValidator;
+        this.assertionDecrypter = assertionDecrypter;
+        this.samlAssertionsSignatureValidator = samlAssertionsSignatureValidator;
+        this.responseFromIdpValidator = responseFromIdpValidator;
+        this.responseDestinationValidator = responseDestinationValidator;
+        this.responseAssertionsFromIdpValidator = responseAssertionsFromIdpValidator;
+    }
+
+    public ValidatedResponse getValidatedResponse() {
+        return validatedResponse;
+    }
+
+    public ValidatedAssertions getValidatedAssertions() {
+        return validatedAssertions;
+    }
+
+    public void validate(Response response) {
+        responseFromIdpValidator.validate(response);
+        responseDestinationValidator.validate(response.getDestination());
+
+        validatedResponse = samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+        List<Assertion> decryptedAssertions = assertionDecrypter.decryptAssertions(validatedResponse);
+        validatedAssertions = samlAssertionsSignatureValidator.validate(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
+        responseAssertionsFromIdpValidator.validate(validatedResponse, validatedAssertions);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidator.java
@@ -1,0 +1,98 @@
+package uk.gov.ida.saml.hub.validators.response.idp.components;
+
+import com.google.common.base.Strings;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdaStatusCodeMapper;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
+import uk.gov.ida.saml.hub.validators.response.common.IssuerValidator;
+import uk.gov.ida.saml.hub.validators.response.common.RequestIdValidator;
+
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.*;
+import static uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil.isSignaturePresent;
+
+public class EncryptedResponseFromIdpValidator {
+    private static final int SUB_STATUS_CODE_LIMIT = 1;
+    private SamlStatusToIdaStatusCodeMapper statusCodeMapper;
+
+    public EncryptedResponseFromIdpValidator(final SamlStatusToIdpIdaStatusMappingsFactory statusMappingsFactory) {
+        this.statusCodeMapper = new SamlStatusToIdaStatusCodeMapper(
+            statusMappingsFactory.getSamlToIdpIdaStatusMappings()
+        );
+    }
+
+    protected void validateAssertionPresence(Response response) {
+        if (!response.getAssertions().isEmpty()) throw new SamlValidationException(unencryptedAssertion());
+
+        boolean responseWasSuccessful = response.getStatus().getStatusCode().getValue().equals(StatusCode.SUCCESS);
+        List<EncryptedAssertion> encryptedAssertions = response.getEncryptedAssertions();
+
+        if (responseWasSuccessful && encryptedAssertions.isEmpty()) {
+            throw new SamlValidationException(missingSuccessUnEncryptedAssertions());
+        }
+
+        if (!responseWasSuccessful && !encryptedAssertions.isEmpty()) {
+            throw new SamlValidationException(nonSuccessHasUnEncryptedAssertions());
+        }
+
+        if (responseWasSuccessful && encryptedAssertions.size() != 2) {
+            throw new SamlValidationException(unexpectedNumberOfAssertions(2, encryptedAssertions.size()));
+        }
+    }
+
+    public void validate(Response response) {
+        IssuerValidator.validate(response);
+        RequestIdValidator.validate(response);
+        validateResponse(response);
+    }
+
+    private void validateResponse(Response response) {
+        if (Strings.isNullOrEmpty(response.getID())) throw new SamlValidationException(missingId());
+        if (response.getIssueInstant() == null) throw new SamlValidationException(missingIssueInstant(response.getID()));
+
+        Signature signature = response.getSignature();
+        if (signature == null) throw new SamlValidationException(missingSignature());
+        if (!isSignaturePresent(signature)) throw new SamlValidationException(signatureNotSigned());
+
+        validateStatus(response.getStatus());
+        validateAssertionPresence(response);
+    }
+
+    private void validateStatus(Status status) {
+        validateStatusCode(status.getStatusCode(), 0);
+
+        Optional<IdpIdaStatus.Status> mappedStatus = statusCodeMapper.map(status);
+        if (!mappedStatus.isPresent()) fail(status);
+    }
+
+    private void fail(Status status) {
+        StatusCode statusCode = status.getStatusCode();
+        StatusCode subStatusCode = statusCode.getStatusCode();
+
+        if (subStatusCode == null) throw new SamlValidationException(invalidStatusCode(statusCode.getValue()));
+
+        SamlValidationSpecificationFailure failure = invalidSubStatusCode(
+                subStatusCode.getValue(),
+                statusCode.getValue()
+        );
+        throw new SamlValidationException(failure);
+    }
+
+    private void validateStatusCode(StatusCode statusCode, int subStatusCount) {
+        if (subStatusCount > SUB_STATUS_CODE_LIMIT) {
+            throw new SamlValidationException(nestedSubStatusCodesBreached(SUB_STATUS_CODE_LIMIT));
+        }
+
+        StatusCode subStatus = statusCode.getStatusCode();
+        if (subStatus != null) validateStatusCode(subStatus, subStatusCount + 1);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/ResponseAssertionsFromIdpValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/ResponseAssertionsFromIdpValidator.java
@@ -1,0 +1,63 @@
+package uk.gov.ida.saml.hub.validators.response.idp.components;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.core.validators.assertion.AuthnStatementAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.IPAddressValidator;
+import uk.gov.ida.saml.core.validators.assertion.IdentityProviderAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.MatchingDatasetAssertionValidator;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingAuthnStatement;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingMatchingMds;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.multipleAuthnStatements;
+
+public class ResponseAssertionsFromIdpValidator {
+
+    private final IdentityProviderAssertionValidator identityProviderAssertionValidator;
+    private final MatchingDatasetAssertionValidator matchingDatasetAssertionValidator;
+    private final AuthnStatementAssertionValidator authnStatementAssertionValidator;
+    private final IPAddressValidator ipAddressValidator;
+    private String hubEntityId;
+
+    public ResponseAssertionsFromIdpValidator(IdentityProviderAssertionValidator assertionValidator,
+                                              MatchingDatasetAssertionValidator matchingDatasetAssertionValidator,
+                                              AuthnStatementAssertionValidator authnStatementAssertionValidator,
+                                              IPAddressValidator ipAddressValidator,
+                                              String hubEntityId) {
+        this.identityProviderAssertionValidator = assertionValidator;
+        this.matchingDatasetAssertionValidator = matchingDatasetAssertionValidator;
+        this.authnStatementAssertionValidator = authnStatementAssertionValidator;
+        this.ipAddressValidator = ipAddressValidator;
+        this.hubEntityId = hubEntityId;
+    }
+
+    public void validate(ValidatedResponse validatedResponse, ValidatedAssertions validatedAssertions) {
+        validatedAssertions.getAssertions().forEach(
+            assertion -> identityProviderAssertionValidator.validate(assertion, validatedResponse.getInResponseTo(), hubEntityId)
+        );
+
+        if (!validatedResponse.isSuccess()) return;
+
+        Assertion matchingDatasetAssertion = getMatchingDatasetAssertion(validatedAssertions);
+        Assertion authnStatementAssertion = getAuthnStatementAssertion(validatedAssertions);
+
+        if (authnStatementAssertion.getAuthnStatements().size() > 1) {
+            throw new SamlValidationException(multipleAuthnStatements());
+        }
+
+        matchingDatasetAssertionValidator.validate(matchingDatasetAssertion, validatedResponse.getIssuer().getValue());
+        authnStatementAssertionValidator.validate(authnStatementAssertion);
+        identityProviderAssertionValidator.validateConsistency(authnStatementAssertion, matchingDatasetAssertion);
+        ipAddressValidator.validate(authnStatementAssertion);
+    }
+
+    private Assertion getAuthnStatementAssertion(ValidatedAssertions validatedAssertions) {
+        return validatedAssertions.getAuthnStatementAssertion().orElseThrow(() -> new SamlValidationException(missingAuthnStatement()));
+    }
+
+    private Assertion getMatchingDatasetAssertion(ValidatedAssertions validatedAssertions) {
+        return validatedAssertions.getMatchingDatasetAssertion().orElseThrow(() -> new SamlValidationException(missingMatchingMds()));
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/EncryptedResponseFromMatchingServiceValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/EncryptedResponseFromMatchingServiceValidator.java
@@ -1,0 +1,103 @@
+package uk.gov.ida.saml.hub.validators.response.matchingservice;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+import uk.gov.ida.saml.hub.validators.response.common.IssuerValidator;
+import uk.gov.ida.saml.hub.validators.response.common.RequestIdValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingId;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingSignature;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingSubStatus;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingSuccessUnEncryptedAssertions;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.nonSuccessHasUnEncryptedAssertions;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.signatureNotSigned;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.subStatusMustBeOneOf;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.unencryptedAssertion;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.unexpectedNumberOfAssertions;
+import static uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil.isSignaturePresent;
+
+public class EncryptedResponseFromMatchingServiceValidator {
+
+    public void validate(Response response) {
+        IssuerValidator.validate(response);
+        RequestIdValidator.validate(response);
+        validateResponse(response);
+    }
+
+    private void validateResponse(Response response) {
+        if (Strings.isNullOrEmpty(response.getID())) throw new SamlValidationException(missingId());
+
+        Signature signature = response.getSignature();
+        if (signature == null) throw new SamlValidationException(missingSignature());
+        if (!isSignaturePresent(signature)) throw new SamlValidationException(signatureNotSigned());
+
+        validateStatusAndSubStatus(response);
+        validateAssertionPresence(response);
+    }
+
+    protected void validateStatusAndSubStatus(Response response) {
+        StatusCode statusCode = response.getStatus().getStatusCode();
+        String statusCodeValue = statusCode.getValue();
+
+        StatusCode subStatusCode = statusCode.getStatusCode();
+
+        if (StatusCode.REQUESTER.equals(statusCodeValue)) return;
+
+        if (subStatusCode == null) throw new SamlValidationException(missingSubStatus());
+
+        String subStatusCodeValue = subStatusCode.getValue();
+
+        if (!StatusCode.RESPONDER.equals(statusCodeValue)) {
+            validateSuccessResponse(statusCodeValue, subStatusCodeValue);
+        } else {
+            validateResponderError(subStatusCodeValue);
+        }
+    }
+
+    private void validateResponderError(String subStatusCodeValue) {
+        if (ImmutableList.of(
+            SamlStatusCode.NO_MATCH,
+            SamlStatusCode.MULTI_MATCH,
+            SamlStatusCode.CREATE_FAILURE).contains(subStatusCodeValue)) {
+            return;
+        }
+
+        throw new SamlValidationException(subStatusMustBeOneOf("Responder", "No Match", "Multi Match", "Create Failure"));
+    }
+
+    private void validateSuccessResponse(String statusCodeValue, String subStatusCodeValue) {
+        if (!StatusCode.SUCCESS.equals(statusCodeValue)) return;
+        if (ImmutableList.of(
+                SamlStatusCode.MATCH,
+                SamlStatusCode.NO_MATCH,
+                SamlStatusCode.CREATED).contains(subStatusCodeValue)) {
+            return;
+        }
+
+        throw new SamlValidationException(subStatusMustBeOneOf("Success", "Match", "No Match", "Created"));
+    }
+
+    protected void validateAssertionPresence(Response response) {
+        if (!response.getAssertions().isEmpty()) throw new SamlValidationException(unencryptedAssertion());
+
+        boolean responseWasSuccessful = StatusCode.SUCCESS.equals(response.getStatus().getStatusCode().getValue());
+        boolean responseHasNoAssertions = response.getEncryptedAssertions().isEmpty();
+
+        if (responseWasSuccessful && responseHasNoAssertions)
+            throw new SamlValidationException(missingSuccessUnEncryptedAssertions());
+
+        if (!responseWasSuccessful && !responseHasNoAssertions) {
+            throw new SamlValidationException(nonSuccessHasUnEncryptedAssertions());
+        }
+
+        if (response.getEncryptedAssertions().size() > 1) {
+            throw new SamlValidationException(unexpectedNumberOfAssertions(1, response.getEncryptedAssertions().size()));
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/HealthCheckResponseFromMatchingServiceValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/HealthCheckResponseFromMatchingServiceValidator.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.saml.hub.validators.response.matchingservice;
+
+import com.google.common.base.Strings;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+import uk.gov.ida.saml.hub.validators.response.common.IssuerValidator;
+import uk.gov.ida.saml.hub.validators.response.common.RequestIdValidator;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidStatusCode;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidSubStatusCode;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingId;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingSignature;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingSubStatus;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.signatureNotSigned;
+import static uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil.isSignaturePresent;
+
+public class HealthCheckResponseFromMatchingServiceValidator {
+
+    public void validate(Response response) {
+        IssuerValidator.validate(response);
+        RequestIdValidator.validate(response);
+        validateResponse(response);
+    }
+
+    private void validateResponse(Response response) {
+        if (Strings.isNullOrEmpty(response.getID())) throw new SamlValidationException(missingId());
+
+        Signature signature = response.getSignature();
+        if (signature == null) throw new SamlValidationException(missingSignature());
+        if (!isSignaturePresent(signature)) throw new SamlValidationException(signatureNotSigned());
+
+        validateStatusAndSubStatus(response);
+    }
+
+    protected void validateStatusAndSubStatus(Response response) {
+        StatusCode statusCode = response.getStatus().getStatusCode();
+
+        if(StatusCode.REQUESTER.equals(statusCode.getValue())) return;
+
+        if (statusCode.getStatusCode() == null) throw new SamlValidationException(missingSubStatus());
+
+        String statusCodeValue = statusCode.getValue();
+        if (!StatusCode.SUCCESS.equals(statusCodeValue)) throw new SamlValidationException(invalidStatusCode(statusCodeValue));
+
+        String subStatusCodeValue = statusCode.getStatusCode().getValue();
+        if (!SamlStatusCode.HEALTHY.equals(subStatusCodeValue)) {
+            throw new SamlValidationException(invalidSubStatusCode(subStatusCodeValue, StatusCode.SUCCESS));
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/ResponseAssertionsFromMatchingServiceValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/ResponseAssertionsFromMatchingServiceValidator.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.hub.validators.response.matchingservice;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.core.validators.assertion.AssertionValidator;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnContextMissingError;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingAuthnStatement;
+
+public class ResponseAssertionsFromMatchingServiceValidator {
+
+    private AssertionValidator assertionValidator;
+    private String hubEntityId;
+
+    public ResponseAssertionsFromMatchingServiceValidator(AssertionValidator assertionValidator, String hubEntityId) {
+        this.assertionValidator = assertionValidator;
+        this.hubEntityId = hubEntityId;
+    }
+
+    public void validate(ValidatedResponse validatedResponse, ValidatedAssertions validatedAssertions) {
+        if (!validatedResponse.isSuccess()) return;
+
+        for (Assertion assertion : validatedAssertions.getAssertions()) {
+            assertionValidator.validate(assertion, validatedResponse.getInResponseTo(), hubEntityId);
+
+            if (assertion.getAuthnStatements().isEmpty()) {
+                throw new SamlValidationException(missingAuthnStatement());
+            }
+
+            if (assertion.getAuthnStatements().get(0).getAuthnContext() == null) {
+                throw new SamlValidationException(authnContextMissingError());
+            }
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStore.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStore.java
@@ -1,0 +1,81 @@
+package uk.gov.ida.saml.metadata;
+
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.xmlsec.signature.X509Certificate;
+import org.opensaml.xmlsec.signature.X509Data;
+import uk.gov.ida.saml.security.PublicKeyFactory;
+import uk.gov.ida.saml.core.InternalPublicKeyStore;
+import uk.gov.ida.saml.metadata.exceptions.HubEntityMissingException;
+
+import javax.inject.Named;
+import java.security.PublicKey;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @deprecated Use {@link uk.gov.ida.saml.security.MetadataBackedSignatureValidator} instead
+ */
+@Deprecated
+public class HubMetadataPublicKeyStore implements InternalPublicKeyStore {
+
+    private final MetadataResolver metadataResolver;
+    private final PublicKeyFactory publicKeyFactory;
+    private final String hubEntityId;
+
+    @Inject
+    public HubMetadataPublicKeyStore(MetadataResolver metadataResolver,
+                                     PublicKeyFactory publicKeyFactory,
+                                     @Named("HubEntityId") String hubEntityId) {
+        this.metadataResolver = metadataResolver;
+        this.publicKeyFactory = publicKeyFactory;
+        this.hubEntityId = hubEntityId;
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity() {
+        try {
+            CriteriaSet criteria = new CriteriaSet(new EntityIdCriterion(hubEntityId));
+            return Optional.ofNullable(metadataResolver.resolveSingle(criteria))
+                    .map(this::getPublicKeys)
+                    .orElseThrow(hubMissingException());
+        } catch (ResolverException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private Supplier<HubEntityMissingException> hubMissingException() {
+        return () -> new HubEntityMissingException(MessageFormat.format("The HUB entity-id: \"{0}\" could not be found in the metadata. Metadata could be expired, invalid, or missing entities", this.hubEntityId));
+    }
+
+    private List<PublicKey> getPublicKeys(EntityDescriptor entityDescriptor) {
+        return entityDescriptor
+                .getSPSSODescriptor(SAMLConstants.SAML20P_NS)
+                .getKeyDescriptors()
+                .stream()
+                .filter(keyDescriptor -> keyDescriptor.getUse() == UsageType.SIGNING)
+                .flatMap(this::getCertificateFromKeyDescriptor)
+                .map(publicKeyFactory::create)
+                .collect(Collectors.toList());
+    }
+
+    private Stream<X509Certificate> getCertificateFromKeyDescriptor(KeyDescriptor keyDescriptor) {
+        List<X509Data> x509Datas = keyDescriptor.getKeyInfo().getX509Datas();
+        return x509Datas
+                .stream()
+                .flatMap(x509Data -> x509Data.getX509Certificates().stream());
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStore.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStore.java
@@ -1,0 +1,99 @@
+package uk.gov.ida.saml.metadata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.apache.xml.security.exceptions.Base64DecodingException;
+import org.apache.xml.security.utils.Base64;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.xmlsec.signature.X509Certificate;
+import uk.gov.ida.saml.security.SigningKeyStore;
+import uk.gov.ida.saml.metadata.exceptions.NoKeyConfiguredForEntityException;
+
+import java.io.ByteArrayInputStream;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Throwables.propagate;
+
+
+/**
+ * @deprecated Use {@link uk.gov.ida.saml.security.MetadataBackedSignatureValidator} instead
+ */
+@Deprecated
+public class IdpMetadataPublicKeyStore implements SigningKeyStore {
+
+    private final MetadataResolver metadataResolver;
+
+    @Inject
+    public IdpMetadataPublicKeyStore(MetadataResolver metadataResolver) {
+        this.metadataResolver = metadataResolver;
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity(String entityId) {
+        Optional<EntityDescriptor> entityDescriptor = getEntityDescriptor(entityId);
+        if (entityDescriptor.isPresent()) {
+            final List<PublicKey> publicKeys = getPublicKeys(entityDescriptor.get(), UsageType.SIGNING);
+            if (!publicKeys.isEmpty()) {
+                return publicKeys;
+            }
+        }
+        throw new NoKeyConfiguredForEntityException(entityId);
+    }
+
+    private List<PublicKey> getPublicKeys(EntityDescriptor entityDescriptor, UsageType keyType) {
+        return Optional.ofNullable(entityDescriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS))
+                .map(descriptor -> getPublicKeys(descriptor, keyType))
+                .orElse(Collections.emptyList());
+    }
+
+    private List<PublicKey> getPublicKeys(IDPSSODescriptor descriptor, UsageType keyType) {
+        return descriptor.getKeyDescriptors().stream()
+                .filter(keyDescriptor -> keyDescriptor.getUse().equals(keyType))
+                .flatMap(this::getPublicKeys)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf));
+    }
+
+    private Stream<PublicKey> getPublicKeys(KeyDescriptor keyDescriptor) {
+        return keyDescriptor.getKeyInfo().getX509Datas().stream()
+                .flatMap(x -> x.getX509Certificates().stream())
+                .map(this::getPublicKey);
+    }
+
+    private PublicKey getPublicKey(X509Certificate x509Certificate) {
+        try {
+            byte[] derValue = Base64.decode(x509Certificate.getValue());
+            CertificateFactory certificateFactory =
+                    CertificateFactory
+                            .getInstance("X.509");
+            Certificate certificate = certificateFactory.generateCertificate(new ByteArrayInputStream(derValue));
+            return certificate.getPublicKey();
+        } catch (Base64DecodingException | CertificateException e) {
+            throw propagate(e);
+        }
+    }
+
+    private Optional<EntityDescriptor> getEntityDescriptor(String entityId) {
+        try {
+            CriteriaSet criteria = new CriteriaSet(new EntityIdCriterion(entityId));
+            return Optional.ofNullable(metadataResolver.resolveSingle(criteria));
+        } catch (ResolverException e) {
+            throw propagate(e);
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/AssertionConsumerServiceEndpointDto.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/AssertionConsumerServiceEndpointDto.java
@@ -1,0 +1,32 @@
+package uk.gov.ida.saml.metadata.domain;
+
+
+import java.net.URI;
+
+public class AssertionConsumerServiceEndpointDto extends SamlEndpointDto {
+
+    private boolean isDefault;
+    private int index;
+
+    @SuppressWarnings("unused") // needed for JAXB
+    private AssertionConsumerServiceEndpointDto() {
+    }
+
+    public AssertionConsumerServiceEndpointDto(URI location, boolean isDefault, int index) {
+        super(SamlEndpointDto.Binding.POST, location); // Assertion Consumer Services must always be post
+        this.isDefault = isDefault;
+        this.index = index;
+    }
+
+    public boolean getIsDefault() {
+        return isDefault;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public static AssertionConsumerServiceEndpointDto createAssertionConsumerService(URI location, boolean isDefault, int index) {
+        return new AssertionConsumerServiceEndpointDto(location, isDefault, index);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/ContactPersonDto.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/ContactPersonDto.java
@@ -1,0 +1,49 @@
+package uk.gov.ida.saml.metadata.domain;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContactPersonDto {
+    private String givenName;
+    private String surName;
+    private List<String> telephoneNumbers = new ArrayList<>();
+    private List<URI> emailAddresses = new ArrayList<>();
+    private String companyName;
+
+    @SuppressWarnings("unused")//Needed by JAXB
+    private ContactPersonDto() {}
+
+    public ContactPersonDto(
+            String companyName,
+            String givenName,
+            String surName,
+            List<String> telephoneNumbers,
+            List<URI> emailAddresses) {
+        this.companyName = companyName;
+        this.givenName = givenName;
+        this.surName = surName;
+        this.telephoneNumbers = telephoneNumbers;
+        this.emailAddresses = emailAddresses;
+    }
+
+    public String getGivenName() {
+        return givenName;
+    }
+
+    public String getSurName() {
+        return surName;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public List<URI> getEmailAddresses() {
+        return emailAddresses;
+    }
+
+    public List<String> getTelephoneNumbers() {
+        return telephoneNumbers;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/FetchedMetadata.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/FetchedMetadata.java
@@ -1,0 +1,48 @@
+package uk.gov.ida.saml.metadata.domain;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.common.shared.security.Certificate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public abstract class FetchedMetadata {
+    private DateTime validUntil;
+    private String entityId;
+    private OrganisationDto organisation;
+    private Collection<ContactPersonDto> contactPersons = new ArrayList<>();
+    private Certificate signingCertificate;
+
+    public FetchedMetadata(
+        String entityId,
+        DateTime validUntil,
+        OrganisationDto organisation,
+        Collection<ContactPersonDto> contactPersons,
+        Certificate signingCertificate) {
+        this.entityId = entityId;
+        this.validUntil = validUntil;
+        this.organisation = organisation;
+        this.contactPersons = contactPersons;
+        this.signingCertificate = signingCertificate;
+    }
+
+    public DateTime getValidUntil() {
+        return validUntil;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public OrganisationDto getOrganisation() {
+        return organisation;
+    }
+
+    public Collection<ContactPersonDto> getContactPersons() {
+        return contactPersons;
+    }
+
+    public Certificate getSigningCertificate() {
+        return signingCertificate;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/HubIdentityProviderMetadataDto.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/HubIdentityProviderMetadataDto.java
@@ -1,0 +1,40 @@
+package uk.gov.ida.saml.metadata.domain;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.common.shared.security.Certificate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class HubIdentityProviderMetadataDto extends MetadataDto {
+
+    private Collection<Certificate> idpSigningCertificates;
+    private Collection<SamlEndpointDto> singleSignOnEndpoints = new ArrayList<>();
+
+    public HubIdentityProviderMetadataDto(
+            Collection<SamlEndpointDto> singleSignOnEndpoints,
+            String entityId,
+            OrganisationDto organisation,
+            Collection<ContactPersonDto> contactPersons,
+            Collection<Certificate> idpSigningCertificates,
+            DateTime validUntil,
+            List<Certificate> hubSigningCertificates,
+            Certificate hubEncryptionCertificate) {
+
+        super(entityId, validUntil, organisation, contactPersons, hubSigningCertificates, Arrays.asList(hubEncryptionCertificate));
+
+        this.singleSignOnEndpoints = singleSignOnEndpoints;
+
+        this.idpSigningCertificates = idpSigningCertificates;
+    }
+
+    public Collection<Certificate> getIdpSigningCertificates() {
+        return idpSigningCertificates;
+    }
+
+    public Collection<SamlEndpointDto> getSingleSignOnEndpoints() {
+        return singleSignOnEndpoints;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/MetadataDto.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/MetadataDto.java
@@ -1,0 +1,65 @@
+package uk.gov.ida.saml.metadata.domain;
+
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+import uk.gov.ida.common.shared.security.Certificate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public abstract class MetadataDto {
+    protected List<Certificate> encryptionCertificates;
+    private DateTime validUntil;
+    private String entityId;
+    private OrganisationDto organisation;
+    private Collection<ContactPersonDto> contactPersons = new ArrayList<>();
+    private List<Certificate> hubSigningCertificates;
+
+    protected MetadataDto() {}
+
+    public MetadataDto(
+            String entityId,
+            DateTime validUntil,
+            OrganisationDto organisation,
+            Collection<ContactPersonDto> contactPersons,
+            List<Certificate> hubSigningCertificates, List<Certificate> encryptionCertificates) {
+        this.entityId = entityId;
+        this.validUntil = validUntil;
+        this.organisation = organisation;
+        this.contactPersons = contactPersons;
+        this.hubSigningCertificates = hubSigningCertificates;
+        this.encryptionCertificates = encryptionCertificates;
+    }
+
+    public DateTime getValidUntil() {
+        return validUntil;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public OrganisationDto getOrganisation() {
+        return organisation;
+    }
+
+    public Collection<ContactPersonDto> getContactPersons() {
+        return contactPersons;
+    }
+
+    public List<Certificate> getSigningCertificates() {
+        return hubSigningCertificates;
+    }
+
+    public Collection<Certificate> getCertificates() {
+        return ImmutableList.<Certificate>builder()
+            .addAll(hubSigningCertificates)
+            .addAll(encryptionCertificates)
+            .build();
+    }
+
+    public List<Certificate> getEncryptionCertificates() {
+        return encryptionCertificates;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/OrganisationDto.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/OrganisationDto.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.saml.metadata.domain;
+
+public class OrganisationDto {
+    private String displayName;
+    private String name;
+    private String url;
+
+    @SuppressWarnings("unused")//Needed by JAXB
+    private OrganisationDto() {}
+
+    public OrganisationDto(String displayName, String name, String url) {
+        this.displayName = displayName;
+        this.name = name;
+        this.url = url;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/SamlEndpointDto.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/SamlEndpointDto.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.saml.metadata.domain;
+
+import java.net.URI;
+
+public class SamlEndpointDto {
+
+    private Binding binding;
+    private URI location;
+
+    SamlEndpointDto() {}
+
+    public SamlEndpointDto(Binding binding, URI location) {
+        this.binding = binding;
+        this.location = location;
+    }
+
+    public enum Binding {
+        POST,
+        SOAP
+    }
+
+    public static SamlEndpointDto createPostBinding(URI location){
+        return new SamlEndpointDto(Binding.POST, location);
+    }
+
+    public static SamlEndpointDto createSoapBinding(URI location) {
+        return new SamlEndpointDto(Binding.SOAP, location);
+    }
+
+    public Binding getBinding() {
+        return binding;
+    }
+
+    public URI getLocation() {
+        return location;
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/exceptions/HubEntityMissingException.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/exceptions/HubEntityMissingException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.saml.metadata.exceptions;
+
+public class HubEntityMissingException extends RuntimeException {
+    public HubEntityMissingException(String msg) {
+        super(msg);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/exceptions/NoKeyConfiguredForEntityException.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/exceptions/NoKeyConfiguredForEntityException.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.saml.metadata.exceptions;
+
+import static java.text.MessageFormat.format;
+
+public class NoKeyConfiguredForEntityException extends RuntimeException {
+    public NoKeyConfiguredForEntityException(String entityId) {
+        super(format("KeyStore contains no keys for Entity: {0}", entityId));
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformer.java
@@ -1,0 +1,78 @@
+package uk.gov.ida.saml.metadata.transformers;
+
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.ContactPerson;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml.saml2.metadata.Organization;
+import uk.gov.ida.common.shared.security.IdGenerator;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
+import uk.gov.ida.saml.metadata.domain.SamlEndpointDto;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class HubIdentityProviderMetadataDtoToEntityDescriptorTransformer implements Function<HubIdentityProviderMetadataDto,EntityDescriptor> {
+
+    private final OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+    private final KeyDescriptorsUnmarshaller keyDescriptorsUnmarshaller;
+    private final IdGenerator idGenerator;
+
+    public HubIdentityProviderMetadataDtoToEntityDescriptorTransformer(
+        OpenSamlXmlObjectFactory openSamlXmlObjectFactory,
+        KeyDescriptorsUnmarshaller keyDescriptorsUnmarshaller,
+        IdGenerator idGenerator) {
+
+        this.openSamlXmlObjectFactory = openSamlXmlObjectFactory;
+        this.keyDescriptorsUnmarshaller = keyDescriptorsUnmarshaller;
+        this.idGenerator = idGenerator;
+    }
+
+    @Override
+    public EntityDescriptor apply(HubIdentityProviderMetadataDto dto) {
+        final EntityDescriptor entityDescriptor = doTransform(dto);
+
+        final List<KeyDescriptor> keyDescriptors = entityDescriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS).getKeyDescriptors();
+        keyDescriptors.addAll(getKeyDescriptorsUnmarshaller().fromCertificates(dto.getIdpSigningCertificates()));
+        keyDescriptors.addAll(getKeyDescriptorsUnmarshaller().fromCertificates(dto.getEncryptionCertificates()));
+
+
+        return entityDescriptor;
+    }
+
+    public EntityDescriptor doTransform(HubIdentityProviderMetadataDto dto) {
+        EntityDescriptor entityDescriptor = openSamlXmlObjectFactory.createEntityDescriptor();
+
+        entityDescriptor.setID(idGenerator.getId());
+        entityDescriptor.setEntityID(dto.getEntityId());
+        entityDescriptor.setValidUntil(dto.getValidUntil());
+
+        IDPSSODescriptor idpSsoDescriptor = openSamlXmlObjectFactory.createIDPSSODescriptor();
+        idpSsoDescriptor.addSupportedProtocol(SAMLConstants.SAML20P_NS);
+
+        transformSingleSignOnServiceEndpoints(idpSsoDescriptor, dto);
+
+        List <KeyDescriptor> signingKeyDescriptors = keyDescriptorsUnmarshaller.fromCertificates(newArrayList(dto.getSigningCertificates()));
+        idpSsoDescriptor.getKeyDescriptors().addAll(signingKeyDescriptors);
+
+        entityDescriptor.getRoleDescriptors().add(idpSsoDescriptor);
+
+        return entityDescriptor;
+    }
+
+    private void transformSingleSignOnServiceEndpoints(IDPSSODescriptor idpSsoDescriptor, HubIdentityProviderMetadataDto dto) {
+        for (SamlEndpointDto endpoint : dto.getSingleSignOnEndpoints()) {
+            String bindingUri = SAMLConstants.SAML2_POST_BINDING_URI; // These will always be post
+            idpSsoDescriptor.getSingleSignOnServices().add(openSamlXmlObjectFactory.createSingleSignOnService(bindingUri, endpoint.getLocation().toASCIIString()));
+        }
+    }
+
+    protected KeyDescriptorsUnmarshaller getKeyDescriptorsUnmarshaller() {
+        return keyDescriptorsUnmarshaller;
+    }
+
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/KeyDescriptorFinder.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/KeyDescriptorFinder.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.metadata.transformers;
+
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.security.credential.UsageType;
+import org.slf4j.event.Level;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import java.util.List;
+
+public class KeyDescriptorFinder {
+
+    public KeyDescriptor find(
+            List<KeyDescriptor> keyDescriptors,
+            UsageType usageType,
+            String entityId) {
+
+        return keyDescriptors.stream()
+                .filter(keyDescriptor -> keyDescriptor.getUse().equals(usageType))
+                .filter(keyDescriptor -> (keyDescriptor.getKeyInfo().getKeyNames().isEmpty() || entityId == null || keyDescriptor.getKeyInfo().getKeyNames().get(0).getValue().equals(entityId)))
+                .findFirst()
+                .orElseThrow(() -> throwError(usageType, entityId));
+    }
+
+    private SamlTransformationErrorException throwError(UsageType usageType, String entityId) {
+        SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingKey(usageType.toString(), entityId);
+        return new SamlTransformationErrorException(failure.getErrorMessage(), Level.ERROR);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidator.java
@@ -1,0 +1,68 @@
+package uk.gov.ida.saml.metadata.transformers.decorators;
+
+import com.google.common.base.Strings;
+import org.apache.commons.lang.StringUtils;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.Organization;
+import org.opensaml.saml.saml2.metadata.OrganizationDisplayName;
+import org.opensaml.saml.saml2.metadata.RoleDescriptor;
+import org.opensaml.xmlsec.signature.KeyInfo;
+import org.opensaml.xmlsec.signature.X509Certificate;
+import org.opensaml.xmlsec.signature.X509Data;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import java.util.List;
+
+public class SamlEntityDescriptorValidator {
+
+    public void validate(EntityDescriptor descriptor) {
+        if (Strings.isNullOrEmpty(descriptor.getEntityID())) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingOrEmptyEntityID();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        if (descriptor.getCacheDuration() == null && descriptor.getValidUntil() == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingCacheDurationAndValidUntil();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        validateRoleDescriptor(descriptor);
+    }
+
+    private void validateRoleDescriptor(EntityDescriptor descriptor) {
+        if (descriptor.getRoleDescriptors().isEmpty()) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingRoleDescriptor();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        RoleDescriptor roleDescriptor = descriptor.getRoleDescriptors().get(0);
+
+        if (roleDescriptor.getKeyDescriptors().isEmpty()) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingKeyDescriptor();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        KeyInfo keyInfo = roleDescriptor.getKeyDescriptors().get(0).getKeyInfo();
+        if (keyInfo == null) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingKeyInfo();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        if (keyInfo.getX509Datas().isEmpty()) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingX509Data();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+        X509Data x509Data = keyInfo.getX509Datas().get(0);
+        if (x509Data.getX509Certificates().isEmpty()) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingX509Certificate();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+
+        X509Certificate x509Certificate = x509Data.getX509Certificates().get(0);
+        if (StringUtils.isEmpty(x509Certificate.getValue())) {
+            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.emptyX509Certificiate();
+            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
+        }
+    }
+
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/DateTimeFreezer.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/DateTimeFreezer.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.core;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+
+public abstract class DateTimeFreezer {
+
+    public static void freezeTime (DateTime dateTime) {
+        DateTimeUtils.setCurrentMillisFixed(dateTime.getMillis());
+    }
+
+    public static void freezeTime() {
+        unfreezeTime();
+        DateTimeUtils.setCurrentMillisFixed(DateTime.now().getMillis());
+    }
+
+    public static void unfreezeTime() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/security/RelayStateValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/security/RelayStateValidatorTest.java
@@ -1,0 +1,74 @@
+package uk.gov.ida.saml.core.security;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import static java.util.Arrays.asList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RelayStateValidatorTest {
+
+    private RelayStateValidator relayStateValidator;
+
+    @Before
+    public void setUp() throws Exception {
+        relayStateValidator = new RelayStateValidator();
+    }
+
+    @Test
+    public void validate_shouldCheckRelayStateLengthIsLessThanEightyOneCharactersOrRaiseException() {
+        final String aStringMoreThanEightyCharacters = generateLongString();
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                new SamlTransformationErrorManagerTestHelper.Action() {
+                    @Override
+                    public void execute() {
+                        relayStateValidator.validate(aStringMoreThanEightyCharacters);
+                    }
+                },
+                SamlTransformationErrorFactory.invalidRelayState(aStringMoreThanEightyCharacters)
+        );
+
+    }
+
+    @Test
+    public void validate_shouldCheckRelayStateForValidStringAndNotThrowAnException() {
+        String aStringLessThanEightyCharacters = generateShortString();
+
+        relayStateValidator.validate(aStringLessThanEightyCharacters);
+    }
+
+    @Test
+    public void validate_shouldCheckForInvalidCharacters() {
+        final String aString = "aStringWith";
+
+        for (final String i : asList(">", "<", "'", "\"", "%", "&", ";")) {
+
+            SamlTransformationErrorManagerTestHelper.validateFail(
+                    new SamlTransformationErrorManagerTestHelper.Action() {
+                        @Override
+                        public void execute() {
+                            relayStateValidator.validate(aString + i);
+                        }
+                    },
+                    SamlTransformationErrorFactory.relayStateContainsInvalidCharacter(i, aString + i)
+            );
+        }
+    }
+
+    private String generateShortString() {
+        return "short string";
+    }
+
+
+    private String generateLongString() {
+        String longString = "";
+        for (int i = 0; i < 82; i++) {
+            longString = longString + "a";
+        }
+        return longString;
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/transformers/outbound/EntitiesDescriptorToElementTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/transformers/outbound/EntitiesDescriptorToElementTransformerTest.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.saml.core.transformers.outbound;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.w3c.dom.Element;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.builders.AuthnRequestBuilder.anAuthnRequest;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+
+@RunWith(OpenSAMLRunner.class)
+public class EntitiesDescriptorToElementTransformerTest {
+
+    @Test
+    public void transform_shouldTransformASamlObjectIntoAnElement() throws Exception {
+        AuthnRequest authnRequest = anAuthnRequest().withIssuer(anIssuer().build()).build();
+        XmlObjectToElementTransformer<AuthnRequest> transformer = new XmlObjectToElementTransformer<>();
+
+        Element result = transformer.apply(authnRequest);
+
+        assertThat(result).isNotNull();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionEncrypterTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/transformers/outbound/decorators/SamlAttributeQueryAssertionEncrypterTest.java
@@ -1,0 +1,122 @@
+package uk.gov.ida.saml.core.transformers.outbound.decorators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import org.opensaml.saml.saml2.encryption.Encrypter;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.encryption.support.EncryptionException;
+import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EncryptionCredentialFactory;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder.anAttributeQuery;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SamlAttributeQueryAssertionEncrypterTest {
+
+    @Mock(answer = Answers.RETURNS_SMART_NULLS)
+    public Credential credential;
+    @Mock(answer = Answers.RETURNS_SMART_NULLS)
+    public EncryptionCredentialFactory credentialFactory;
+    public final EntityToEncryptForLocator entityToEncryptForLocator = mock(EntityToEncryptForLocator.class);
+    public final EncrypterFactory encrypterFactory = mock(EncrypterFactory.class);
+    public final Encrypter encrypter = mock(Encrypter.class);
+
+    public AttributeQuery attributeQuery;
+    public EncryptedAssertion encryptedAssertion;
+    public SamlAttributeQueryAssertionEncrypter samlAttributeQueryAssertionEncrypter;
+    public Assertion assertion;
+
+    @Before
+    public void setUp() throws Exception {
+        assertion = anAssertion().buildUnencrypted();
+        attributeQuery = anAttributeQueryWithAssertion(assertion);
+        encryptedAssertion = anAssertion().build();
+        when(entityToEncryptForLocator.fromRequestId(anyString())).thenReturn("some id");
+        when(credentialFactory.getEncryptingCredential("some id")).thenReturn(credential);
+        when(encrypterFactory.createEncrypter(credential)).thenReturn(encrypter);
+        when(encrypter.encrypt(assertion)).thenReturn(encryptedAssertion);
+        samlAttributeQueryAssertionEncrypter = new SamlAttributeQueryAssertionEncrypter(
+                credentialFactory,
+                encrypterFactory,
+                entityToEncryptForLocator
+        );
+    }
+
+    @Test
+    public void shouldConvertAssertionIntoEncryptedAssertion() throws EncryptionException {
+        final AttributeQuery decoratedAttributeQuery = samlAttributeQueryAssertionEncrypter.encryptAssertions(attributeQuery);
+
+        final SubjectConfirmationData subjectConfirmationData = decoratedAttributeQuery.getSubject()
+                .getSubjectConfirmations()
+                .get(0)
+                .getSubjectConfirmationData();
+        final List<XMLObject> encryptedAssertions = subjectConfirmationData
+                .getUnknownXMLObjects(EncryptedAssertion.DEFAULT_ELEMENT_NAME);
+        assertThat(encryptedAssertions.size()).isEqualTo(1);
+        assertThat((EncryptedAssertion) encryptedAssertions.get(0)).isEqualTo(encryptedAssertion);
+
+        final List<XMLObject> unencryptedAssertions = subjectConfirmationData
+                .getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+        assertThat(unencryptedAssertions.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void decorate_shouldWrapEncryptionAssertionInSamlExceptionWhenEncryptionFails() throws EncryptionException {
+        EncryptionException encryptionException = new EncryptionException("BLAM!");
+        when(encrypter.encrypt(assertion)).thenThrow(encryptionException);
+
+        SamlAttributeQueryAssertionEncrypter assertionEncrypter =
+                new SamlAttributeQueryAssertionEncrypter(
+                        credentialFactory,
+                        encrypterFactory,
+                        entityToEncryptForLocator
+                );
+
+        try {
+            assertionEncrypter.encryptAssertions(attributeQuery);
+        } catch (Exception e) {
+            assertThat(e.getCause()).isEqualTo(encryptionException);
+            return;
+        }
+        fail("Should never get here");
+    }
+
+    private AttributeQuery anAttributeQueryWithAssertion(final Assertion assertion) {
+        return anAttributeQuery()
+                    .withSubject(
+                            aSubject()
+                                    .withSubjectConfirmation(
+                                            aSubjectConfirmation()
+                                                    .withSubjectConfirmationData(
+                                                            aSubjectConfirmationData()
+                                                                    .addAssertion(assertion)
+                                                                    .build()
+                                                    )
+                                                    .build()
+                                    )
+                                    .build()
+                    )
+                    .build();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/DestinationValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/DestinationValidatorTest.java
@@ -1,0 +1,68 @@
+package uk.gov.ida.saml.core.validators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.fail;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.destinationEmpty;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.destinationMissing;
+import static uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DestinationValidatorTest {
+
+    private static final String EXPECTED_DESTINATION = "http://correct.destination.com";
+    private static final String EXPECTED_ENDPOINT = "/foo/bar";
+
+    private DestinationValidator validator;
+
+    @Before
+    public void setup() throws URISyntaxException {
+        validator = new DestinationValidator(URI.create(EXPECTED_DESTINATION), EXPECTED_ENDPOINT);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfDestinationIsAbsent() throws Exception {
+        validateException(
+            destinationMissing(URI.create(EXPECTED_DESTINATION + EXPECTED_ENDPOINT)),
+            null
+        );
+    }
+
+    @Test
+    public void validate_shouldNotThrowExceptionIfUriMatches() throws Exception {
+        validator.validate("http://correct.destination.com/foo/bar");
+    }
+
+    @Test
+    public void validate_shouldBeValidIfPortSpecifiedOnDestinationButNotForSamlProxy() throws Exception {
+        validator.validate("http://correct.destination.com:999/foo/bar");
+    }
+
+    @Test
+    public void validate_shouldThrowSamlExceptionIfHostForTheUriOnResponseDoesNotMatchTheSamlReceiverHost() throws Exception {
+        String invalidDestination = "http://saml.com/foo/bar";
+        validateException(
+            destinationEmpty(URI.create(EXPECTED_DESTINATION + EXPECTED_ENDPOINT), invalidDestination),
+            invalidDestination
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowSamlExceptionIfHostsMatchButPathsDoNot() throws Exception {
+        validateException(
+            destinationEmpty(URI.create(EXPECTED_DESTINATION + EXPECTED_ENDPOINT), EXPECTED_DESTINATION + "/this/is/a/path"),
+            EXPECTED_DESTINATION + "/this/is/a/path"
+        );
+    }
+
+    private void validateException(SamlValidationSpecificationFailure failure, final String destination) {
+        validateFail(() -> validator.validate(destination), failure);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionAttributeStatementValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionAttributeStatementValidatorTest.java
@@ -1,0 +1,75 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
+import uk.gov.ida.saml.core.test.builders.IdpFraudEventIdAttributeBuilder;
+
+import static java.util.Arrays.asList;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidAttributeLanguageInAssertion;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidFraudAttribute;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.SimpleStringAttributeBuilder.aSimpleStringAttribute;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionAttributeStatementValidatorTest {
+
+    private AssertionAttributeStatementValidator validator;
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new AssertionAttributeStatementValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowWhenAttributesIsNotEnGb() throws Exception {
+        Attribute validAttributeOne = aSimpleStringAttribute().build();
+        PersonName validFirstNameAttribute = openSamlXmlObjectFactory.createPersonNameAttributeValue("Dave");
+        validAttributeOne.getAttributeValues().add(validFirstNameAttribute);
+
+        Attribute validAttributeTwo = aSimpleStringAttribute().build();
+        PersonName validSurnameAttributeValue = openSamlXmlObjectFactory.createPersonNameAttributeValue("Jones");
+        validAttributeTwo.getAttributeValues().add(validSurnameAttributeValue);
+
+        Attribute invalidMiddlenameAttribute = aSimpleStringAttribute().build();
+        PersonName invalidMiddlenameAttributeValue = openSamlXmlObjectFactory.createPersonNameAttributeValue("Middle");
+        invalidMiddlenameAttributeValue.setLanguage("en-US");
+        invalidMiddlenameAttribute.getAttributeValues().add(invalidMiddlenameAttributeValue);
+
+        final Assertion assertion = AssertionBuilder.anAssertion()
+                .addAttributeStatement(anAttributeStatement().build())
+                .addAttributeStatement(anAttributeStatement().build())
+                .buildUnencrypted();
+
+        assertion.getAttributeStatements().get(0).getAttributes().add(validAttributeOne);
+        assertion.getAttributeStatements().get(1).getAttributes().addAll(asList(validAttributeTwo, invalidMiddlenameAttribute));
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> validator.validate(assertion),
+                invalidAttributeLanguageInAssertion(invalidMiddlenameAttribute.getName(), invalidMiddlenameAttributeValue.getLanguage())
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowWhenFraudEventNotCorrect() throws Exception{
+        final Assertion assertion = AssertionBuilder.anAssertion()
+                .addAttributeStatement(anAttributeStatement().addAttribute(IdpFraudEventIdAttributeBuilder.anIdpFraudEventIdAttribute().buildInvalidAttribute()).build())
+                .buildUnencrypted();
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> validator.validateFraudEvent(assertion),
+                invalidFraudAttribute(AssertionAttributeStatementValidator.INVALID_FRAUD_EVENT_TYPE)
+        );
+
+    }
+
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/AssertionValidatorTest.java
@@ -1,0 +1,146 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.BasicAssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionValidatorTest {
+
+    @Mock
+    private AssertionSubjectValidator subjectValidator;
+    @Mock
+    private IssuerValidator issuerValidator;
+    @Mock
+    private AssertionAttributeStatementValidator assertionAttributeStatementValidator;
+    @Mock
+    private BasicAssertionSubjectConfirmationValidator basicAssertionSubjectConfirmationValidator;
+
+    private AssertionValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new AssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, basicAssertionSubjectConfirmationValidator);
+    }
+
+    @Test
+    public void validate_shouldDelegateSubjectValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion()
+                .withSubject(aSubject().build())
+                .buildUnencrypted();
+
+        validator.validate(assertion, requestId, "");
+
+        verify(subjectValidator).validate(assertion.getSubject(), assertion.getID());
+    }
+
+    @Test
+    public void validate_shouldDelegateSubjectConfirmationValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
+        Assertion assertion = anAssertion()
+                .withSubject(aSubject().withSubjectConfirmation(subjectConfirmation).build())
+                .buildUnencrypted();
+
+        validator.validate(assertion, requestId, "");
+
+        verify(basicAssertionSubjectConfirmationValidator).validate(subjectConfirmation);
+    }
+
+    @Test
+    public void validate_shouldDelegateAttributeValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion()
+                .withSubject(aSubject().build())
+                .buildUnencrypted();
+
+        validator.validate(assertion, requestId, "");
+
+        verify(assertionAttributeStatementValidator).validate(assertion);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAnyAssertionDoesNotContainASignature() throws Exception {
+        String someID = UUID.randomUUID().toString();
+        Assertion assertion = anAssertion().withSignature(null).withId(someID).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.assertionSignatureMissing(someID));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAnAssertionIsNotSigned() throws Exception {
+        String someID = UUID.randomUUID().toString();
+
+        Assertion assertion = anAssertion().withoutSigning().withId(someID).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.assertionNotSigned(someID));
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfAllAssertionsAreSigned() throws Exception {
+        Assertion assertion = anAssertion().buildUnencrypted();
+
+        validator.validate(assertion, "", assertion.getID());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+        Assertion assertion = anAssertion().withId(null).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingId());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfVersionIsMissing() throws Exception {
+        Assertion assertion = anAssertion().withVersion(null).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingVersion(assertion.getID()));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfVersionIsNotSamlTwoPointZero() throws Exception {
+        Assertion assertion = anAssertion().withVersion(SAMLVersion.VERSION_10).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.illegalVersion(assertion.getID()));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
+        Assertion assertion = anAssertion().withIssueInstant(null).buildUnencrypted();
+
+        assertExceptionMessage(assertion, SamlTransformationErrorFactory.missingIssueInstant(assertion.getID()));
+    }
+
+    private void assertExceptionMessage(
+            final Assertion assertion,
+            SamlValidationSpecificationFailure failure) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                new SamlTransformationErrorManagerTestHelper.Action() {
+                    @Override
+                    public void execute() {
+                        validator.validate(assertion, "", "");
+                    }
+                },
+                failure
+        );
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/AuthnStatementAssertionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/AuthnStatementAssertionValidatorTest.java
@@ -1,0 +1,91 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnContext;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
+import uk.gov.ida.saml.core.test.builders.AuthnContextBuilder;
+import uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder;
+import uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnContextClassRefMissing;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnContextClassRefValueMissing;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnContextMissingError;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnInstantMissing;
+import static uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper.validateFail;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AuthnStatementAssertionValidatorTest {
+
+    @Mock
+    private DuplicateAssertionValidator duplicateAssertionValidator;
+
+    private AuthnStatementAssertionValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new AuthnStatementAssertionValidator(duplicateAssertionValidator);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAuthnContextIsAbsent() throws Exception {
+        AuthnStatement authnStatement = AuthnStatementBuilder.anAuthnStatement().withAuthnContext(null).build();
+        Assertion assertion = AssertionBuilder.anAssertion().addAuthnStatement(authnStatement).buildUnencrypted();
+
+        validateFail(() -> validator.validate(assertion), authnContextMissingError());
+    }
+
+    @Test
+    public void validate_shouldPassValidation() throws Exception {
+        AuthnStatement authnStatement = AuthnStatementBuilder.anAuthnStatement().build();
+        Assertion assertion = AssertionBuilder.anAssertion().addAuthnStatement(authnStatement).buildUnencrypted();
+
+        validator.validate(assertion);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAuthnContextClassRefIsAbsent() throws Exception {
+        AuthnContext authnContext = AuthnContextBuilder.anAuthnContext().withAuthnContextClassRef(null).build();
+        AuthnStatement authnStatement = AuthnStatementBuilder.anAuthnStatement().withAuthnContext(authnContext).build();
+        Assertion assertion = AssertionBuilder.anAssertion().addAuthnStatement(authnStatement).buildUnencrypted();
+
+        validateFail(() -> validator.validate(assertion), authnContextClassRefMissing());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAuthnContextClassRefValueIsAbsent() throws Exception {
+        AuthnContextClassRef authnContextClassRef = AuthnContextClassRefBuilder.anAuthnContextClassRef().withAuthnContextClasRefValue(null).build();
+        AuthnContext authnContext = AuthnContextBuilder.anAuthnContext().withAuthnContextClassRef(authnContextClassRef).build();
+        AuthnStatement authnStatement = AuthnStatementBuilder.anAuthnStatement().withAuthnContext(authnContext).build();
+        Assertion assertion = AssertionBuilder.anAssertion().addAuthnStatement(authnStatement).buildUnencrypted();
+
+        validateFail(() -> validator.validate(assertion), authnContextClassRefValueMissing());
+    }
+
+    @Test
+    public void validate_shouldValidateForDuplicateIds() throws Exception {
+        String id = "duplicate-id";
+        Assertion assertion = AssertionBuilder.anAssertion().withId(id).addAuthnStatement(AuthnStatementBuilder.anAuthnStatement().build()).buildUnencrypted();
+
+        validator.validate(assertion);
+
+        verify(duplicateAssertionValidator, times(1)).validateAuthnStatementAssertion(assertion);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAuthnInstantIsAbsent() throws Exception {
+        AuthnStatement authnStatement = AuthnStatementBuilder.anAuthnStatement().withAuthnInstant(null).build();
+        Assertion assertion = AssertionBuilder.anAssertion().addAuthnStatement(authnStatement).buildUnencrypted();
+
+        validateFail(() -> validator.validate(assertion), authnInstantMissing());
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidatorTest.java
@@ -1,0 +1,126 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.DateTimeFreezer;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnStatementAlreadyReceived;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.duplicateMatchingDataset;
+import static uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper.validateFail;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+
+@RunWith(OpenSAMLRunner.class)
+public class DuplicateAssertionValidatorTest {
+
+    private ConcurrentMap<String, DateTime> duplicateIds;
+    private DuplicateAssertionValidator duplicateAssertionValidator;
+
+    @Before
+    public void setUp() {
+        DateTimeFreezer.freezeTime();
+
+        duplicateIds = new ConcurrentHashMap<>();
+        duplicateIds.put("duplicate", DateTime.now().plusMinutes(5));
+        duplicateIds.put("expired-duplicate", DateTime.now().minusMinutes(2));
+
+        duplicateAssertionValidator = new DuplicateAssertionValidator(duplicateIds);
+    }
+
+    @Test
+    public void validateAuthnStatementAssertion_shouldPassIfTheAssertionIsNotADuplicateOfAPreviousOne() throws Exception {
+        Assertion assertion = anAssertion().withId("not-duplicate").buildUnencrypted();
+        duplicateAssertionValidator.validateAuthnStatementAssertion(assertion);
+    }
+
+    @Test
+    public void validateAuthnStatementAssertion_shouldPassIfTwoAssertionsHaveTheSameIdButTheFirstAssertionHasExpired() throws Exception {
+        DateTime futureDate = DateTime.now().plusMinutes(6);
+
+        Assertion assertion = createAssertion("expired-duplicate", futureDate);
+        duplicateAssertionValidator.validateAuthnStatementAssertion(assertion);
+
+        assertThat(duplicateIds.get("expired-duplicate")).isEqualTo(futureDate.toDateTime(UTC));
+    }
+
+    @Test
+    public void validateAuthnStatementAssertion_shouldThrowAnExceptionIfTheAssertionIsADuplicateOfAPreviousOne() throws Exception {
+        Assertion assertion = anAssertion().withId("duplicate").buildUnencrypted();
+        validateFail(
+            ()-> duplicateAssertionValidator.validateAuthnStatementAssertion(assertion),
+            authnStatementAlreadyReceived("duplicate")
+        );
+    }
+
+    @Test
+    public void validateAuthnStatementAssertion_shouldStoreTheAssertionIdIfNotADuplicate() throws Exception {
+        DateTime futureDate = DateTime.now().plusMinutes(6);
+
+        Assertion assertion = createAssertion("new-id", futureDate);
+        duplicateAssertionValidator.validateAuthnStatementAssertion(assertion);
+
+        assertThat(duplicateIds.get("new-id")).isEqualTo(futureDate.toDateTime(UTC));
+    }
+
+    @Test
+    public void validateMatchingDataSetAssertion_shouldPassIfTheAssertionIsNotADuplicateOfAPreviousOne() throws Exception {
+        Assertion assertion = anAssertion().withId("not-duplicate").buildUnencrypted();
+        duplicateAssertionValidator.validateMatchingDataSetAssertion(assertion, "issuer");
+    }
+
+    @Test
+    public void validateMatchingDataSetAssertion_shouldPassIfTwoAssertionsHaveTheSameIdButTheFirstAssertionHasExpired() throws Exception {
+        DateTime futureDate = DateTime.now().plusMinutes(6);
+
+        Assertion assertion = createAssertion("expired-duplicate", futureDate);
+        duplicateAssertionValidator.validateMatchingDataSetAssertion(assertion, "issuer");
+
+        assertThat(duplicateIds.get("expired-duplicate")).isEqualTo(futureDate.toDateTime(UTC));
+    }
+
+    @Test
+    public void validateMatchingDataSetAssertion_shouldThrowAnExceptionIfTheAssertionIsADuplicateOfAPreviousOne() throws Exception {
+        Assertion assertion = anAssertion().withId("duplicate").buildUnencrypted();
+        validateFail(
+            ()-> duplicateAssertionValidator.validateMatchingDataSetAssertion(assertion, "issuer"),
+            duplicateMatchingDataset("duplicate", "issuer")
+        );
+    }
+
+    @Test
+    public void validateMatchingDataSetAssertion_shouldStoreTheAssertionIdIfNotADuplicate() throws Exception {
+        DateTime futureDate = DateTime.now().plusMinutes(6);
+
+        Assertion assertion = createAssertion("new-id", futureDate);
+        duplicateAssertionValidator.validateMatchingDataSetAssertion(assertion, "issuer");
+
+        assertThat(duplicateIds.get("new-id")).isEqualTo(futureDate.toDateTime(UTC));
+    }
+
+    private Assertion createAssertion(String id, DateTime notOnOrAfter) {
+        SubjectConfirmationData subjectConfirmationData = aSubjectConfirmationData()
+            .withNotOnOrAfter(notOnOrAfter).build();
+        SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+            .withSubjectConfirmationData(subjectConfirmationData).build();
+        Subject subject = aSubject()
+            .withSubjectConfirmation(subjectConfirmation).build();
+        return anAssertion()
+            .withId(id)
+            .withSubject(subject)
+            .buildUnencrypted();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/IPAddressValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/IPAddressValidatorTest.java
@@ -1,0 +1,96 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.IPAddressAttributeBuilder;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.PersonNameAttributeBuilder_1_1.aPersonName_1_1;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class IPAddressValidatorTest {
+
+    private IPAddressValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new IPAddressValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowWhenAssertionDoesNotContainAnAttributeStatement() throws Exception {
+        Assertion assertion = anAssertion().buildUnencrypted();
+        validateException(SamlTransformationErrorFactory.missingIPAddress(assertion.getID()), assertion);
+    }
+
+    @Test
+    public void validate_shouldNotThrowWhenFirstAttributeStatementContainsAnIPAddressAttribute() throws Exception {
+        Assertion assertion = anAssertion()
+                .addAttributeStatement(anAttributeStatement().addAttribute(IPAddressAttributeBuilder.anIPAddress().build()).build())
+                .buildUnencrypted();
+
+        validator.validate(assertion);
+    }
+
+    @Test
+    public void validate_shouldNotThrowWhenSecondAttributeStatementContainsAnIPAddressAttribute() throws Exception {
+        Assertion assertion = anAssertion()
+                .addAttributeStatement(anAttributeStatement().build())
+                .addAttributeStatement(anAttributeStatement().addAttribute(IPAddressAttributeBuilder.anIPAddress().build()).build())
+                .buildUnencrypted();
+
+        validator.validate(assertion);
+    }
+
+    @Test
+    public void validate_shouldNotThrowWhenFirstAttributeStatementContainsMultipleAttributesIncludingIPAddressAttribute() throws Exception {
+        Assertion assertion = anAssertion()
+                .addAttributeStatement(anAttributeStatement()
+                        .addAttribute(aPersonName_1_1().buildAsFirstname())
+                        .addAttribute(IPAddressAttributeBuilder.anIPAddress().build())
+                        .build())
+                .buildUnencrypted();
+
+        validator.validate(assertion);
+    }
+
+    @Test
+    public void validate_shouldThrowWhenAssertionContainsAttributeStatementsButNoIPAddressAttribute() throws Exception {
+        Assertion assertion = anAssertion()
+                .addAttributeStatement(anAttributeStatement().build())
+                .buildUnencrypted();
+        validateException(SamlTransformationErrorFactory.missingIPAddress(assertion.getID()), assertion);
+    }
+
+    @Test
+    public void validate_shouldThrowWhenAssertionContainsIPAddressAttributeWithNoValue() throws Exception {
+        Assertion assertion = anAssertion()
+                .addAttributeStatement(anAttributeStatement().addAttribute(IPAddressAttributeBuilder.anIPAddress().withValue(null).build()).build())
+                .buildUnencrypted();
+
+        validateException(SamlTransformationErrorFactory.emptyIPAddress(assertion.getID()), assertion);
+    }
+
+    @Test
+    public void validate_shouldNotWarnWhenAssertionContainsAnInvalidIPAddress() throws Exception {
+        final String ipAddress = "10.10.10.1a";
+        final Assertion assertion = anAssertion()
+                .addAttributeStatement(anAttributeStatement().addAttribute(IPAddressAttributeBuilder.anIPAddress().withValue(ipAddress).build()).build())
+                .buildUnencrypted();
+
+        validator.validate(assertion);
+    }
+
+    private void validateException(SamlValidationSpecificationFailure failure, final Assertion assertion) {
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> validator.validate(assertion),
+                failure
+        );
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/IdentityProviderAssertionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/IdentityProviderAssertionValidatorTest.java
@@ -1,0 +1,82 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder;
+import uk.gov.ida.saml.core.test.builders.IdpFraudEventIdAttributeBuilder;
+import uk.gov.ida.saml.core.test.builders.SubjectBuilder;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.AssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class IdentityProviderAssertionValidatorTest {
+
+    @Mock
+    private AssertionSubjectValidator subjectValidator;
+    @Mock
+    private IssuerValidator issuerValidator;
+    @Mock
+    private AssertionSubjectConfirmationValidator subjectConfirmationValidator;
+    @Mock
+    private AssertionAttributeStatementValidator assertionAttributeStatementValidator;
+
+    @Test
+    public void validate_shouldDelegateSubjectConfirmationValidation() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        String expectedRecipientId = UUID.randomUUID().toString();
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation().build();
+        Assertion assertion = anAssertion()
+                .withSubject(SubjectBuilder.aSubject().withSubjectConfirmation(subjectConfirmation).build())
+                .buildUnencrypted();
+
+        IdentityProviderAssertionValidator validator = new IdentityProviderAssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+        validator.validate(assertion, requestId, expectedRecipientId);
+
+        verify(subjectConfirmationValidator).validate(subjectConfirmation, requestId, expectedRecipientId);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfNoSubjectConfirmationMethodAttributeHasBearerValue() throws Exception {
+        String someID = UUID.randomUUID().toString();
+        final Assertion assertion = anAssertion().withId(someID).addAuthnStatement(anAuthnStatement().build()).withSubject(SubjectBuilder.aSubject().withSubjectConfirmation(aSubjectConfirmation().withMethod("invalid").build()).build()).buildUnencrypted();
+        final IdentityProviderAssertionValidator validator = new IdentityProviderAssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> validator.validateSubject(assertion, "", ""),
+                SamlTransformationErrorFactory.noSubjectConfirmationWithBearerMethod(assertion.getID())
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfInvalidFraudEventTypeUsed(){
+        final AuthnContextClassRef authnContextClassRef = anAuthnContextClassRef().withAuthnContextClasRefValue(AuthnContext.LEVEL_X.getUri()).build();
+        final org.opensaml.saml.saml2.core.AuthnContext authnContext = anAuthnContext().withAuthnContextClassRef(authnContextClassRef).build();
+
+        String someID = UUID.randomUUID().toString();
+        final Assertion assertion =
+                anAssertion().withId(someID)
+                .addAttributeStatement(AttributeStatementBuilder.anAttributeStatement().addAttribute(IdpFraudEventIdAttributeBuilder.anIdpFraudEventIdAttribute().buildInvalidAttribute()).build())
+                .addAuthnStatement(anAuthnStatement().withAuthnContext(authnContext).build())
+                .buildUnencrypted();
+        final IdentityProviderAssertionValidator validator = new IdentityProviderAssertionValidator(issuerValidator, subjectValidator, assertionAttributeStatementValidator, subjectConfirmationValidator);
+        validator.validateSubject(assertion, someID, UUID.randomUUID().toString());
+        verify(assertionAttributeStatementValidator).validateFraudEvent(assertion);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/MatchingDatasetAssertionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/MatchingDatasetAssertionValidatorTest.java
@@ -1,0 +1,246 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.IdaConstants;
+import uk.gov.ida.saml.core.extensions.Date;
+import uk.gov.ida.saml.core.extensions.PersonName;
+import uk.gov.ida.saml.core.extensions.StringBasedMdsAttributeValue;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.attributeStatementEmpty;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.attributeWithIncorrectType;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.emptyAttribute;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.mdsAttributeNotRecognised;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.mdsMultipleStatements;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.mdsStatementMissing;
+import static uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper.validateFail;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.MatchingDatasetAttributeStatementBuilder_1_1.aMatchingDatasetAttributeStatement_1_1;
+import static uk.gov.ida.saml.core.test.builders.MatchingDatasetAttributeStatementBuilder_1_1.anEmptyMatchingDatasetAttributeStatement_1_1;
+import static uk.gov.ida.saml.core.test.builders.PersonNameAttributeBuilder_1_1.aPersonName_1_1;
+import static uk.gov.ida.saml.core.test.builders.PersonNameAttributeValueBuilder.aPersonNameValue;
+import static uk.gov.ida.saml.core.test.builders.SimpleStringAttributeBuilder.aSimpleStringAttribute;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class MatchingDatasetAssertionValidatorTest {
+
+    private static final String RESPONSE_ISSUER_ID = "issuer ID";
+
+    @Mock
+    private DuplicateAssertionValidator duplicateAssertionValidator;
+
+    private MatchingDatasetAssertionValidator validator;
+
+    @Before
+    public void setUp() {
+        validator = new MatchingDatasetAssertionValidator(duplicateAssertionValidator);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenNameIsNotRecognised() throws Exception {
+        Attribute attribute = aSimpleStringAttribute().withName("dummy attribute").build();
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().addCustomAttribute(attribute).build();
+        Assertion assertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validateFail(
+            () -> validator.validate(assertion, RESPONSE_ISSUER_ID),
+            mdsAttributeNotRecognised("dummy attribute")
+        );
+    }
+
+    @Test
+    public void validate_shouldNotThrowAnExceptionWhenFirstnameIsPresent_ProfileV1_1() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().withFirstname(aPersonName_1_1().buildAsFirstname()).build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowAnExceptionWhenMiddleNameIsPresent_ProfileV1_1() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().withMiddleNames(aPersonName_1_1().buildAsMiddlename()).build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowAnExceptionWhenSurNameIsPresent_ProfileV1_1() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().withSurname(aPersonName_1_1().buildAsSurname()).build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowAnExceptionWhenDateOfBirthIsPresent_ProfileV1_1() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().withDateOfBirth().build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowAnExceptionWhenGenderIsPresent_ProfileV1_1() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().withGender().build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowAnExceptionWhenCurrentAddressIsPresent_ProfileV1_1() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().withCurrentAddress().build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowAnExceptionWhenPreviousAddressIsPresent_ProfileV1_1() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().addPreviousAddress().build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenNoAttributesArePresent() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+
+        validateFail(
+            () -> validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID),
+            attributeStatementEmpty(matchingDatasetAssertion.getID())
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenNoAttributeStatementsArePresent() throws Exception {
+        Assertion matchingDatasetAssertion = anAssertion().buildUnencrypted();
+
+        validateFail(
+            () -> validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID),
+            mdsStatementMissing()
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenMultipleAttributeStatementsArePresent() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatement)
+                .addAttributeStatement(attributeStatement)
+                .buildUnencrypted();
+
+        validateFail(
+            () -> validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID),
+            mdsMultipleStatements()
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenAttributeIsMissingValue() throws Exception {
+        Attribute attribute = aPersonName_1_1()
+                .buildAsFirstnameWithNoAttributeValues();
+        AttributeStatement attributeStatement = aMatchingDatasetAttributeStatement_1_1()
+                .withFirstname(attribute)
+                .build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatement)
+                .buildUnencrypted();
+
+        validateFail(
+            () -> validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID),
+            emptyAttribute("MDS_firstname")
+        );
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenAttributeValueIsIncorrectType() throws Exception {
+        Attribute attribute = aSimpleStringAttribute().withName(IdaConstants.Attributes_1_1.Firstname.NAME).withSimpleStringValue("Joe").build();
+        AttributeStatement attributeStatement = aMatchingDatasetAttributeStatement_1_1()
+                .withFirstname(attribute)
+                .build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatement)
+                .buildUnencrypted();
+
+        validateFail(
+            () -> validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID),
+            attributeWithIncorrectType(IdaConstants.Attributes_1_1.Firstname.NAME, PersonName.TYPE_NAME, StringBasedMdsAttributeValue.TYPE_NAME)
+        );
+    }
+
+    @Test
+    public void validate_shouldNotThrowExceptionWhenAttributeValueVerifiedIsAbsent() throws Exception {
+        Attribute attribute = aPersonName_1_1().addValue(aPersonNameValue().withVerified(null).build()).buildAsFirstname();
+        AttributeStatement attributeStatement = aMatchingDatasetAttributeStatement_1_1()
+                .withFirstname(attribute)
+                .build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatement)
+                .buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowExceptionWhenAttributeValueToDateIsAbsent() throws Exception {
+        Attribute attribute = aPersonName_1_1().addValue(aPersonNameValue().withTo(null).build()).buildAsFirstname();
+        AttributeStatement attributeStatement = aMatchingDatasetAttributeStatement_1_1()
+                .withFirstname(attribute)
+                .build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatement)
+                .buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldNotThrowExceptionWhenAttributeValueFromDateIsAbsent() throws Exception {
+        Attribute attribute = aPersonName_1_1().addValue(aPersonNameValue().withFrom(null).build()).buildAsFirstname();
+        AttributeStatement attributeStatement = aMatchingDatasetAttributeStatement_1_1()
+                .withFirstname(attribute)
+                .build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatement)
+                .buildUnencrypted();
+
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenAttributeValueTypeIsValidButIncorrectForAttribute() throws Exception {
+        Attribute attribute = aPersonName_1_1().addValue(aPersonNameValue().withFrom(null).build()).buildAsFirstname();
+        attribute.setName(IdaConstants.Attributes_1_1.DateOfBirth.NAME);
+        AttributeStatement attributeStatement = aMatchingDatasetAttributeStatement_1_1()
+                .withDateOfBirth(attribute)
+                .build();
+        Assertion matchingDatasetAssertion = anAssertion()
+                .addAttributeStatement(attributeStatement)
+                .buildUnencrypted();
+
+        validateFail(
+            () -> validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID),
+            attributeWithIncorrectType(IdaConstants.Attributes_1_1.DateOfBirth.NAME, Date.TYPE_NAME, PersonName.TYPE_NAME)
+        );
+    }
+
+    @Test
+    public void validate_shouldValidateForDuplicateIds() throws Exception {
+        AttributeStatement attributeStatement = anEmptyMatchingDatasetAttributeStatement_1_1().withFirstname(aPersonName_1_1().buildAsFirstname()).build();
+        Assertion matchingDatasetAssertion = anAssertion().addAttributeStatement(attributeStatement).buildUnencrypted();
+        validator.validate(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+        verify(duplicateAssertionValidator, times(1)).validateMatchingDataSetAssertion(matchingDatasetAssertion, RESPONSE_ISSUER_ID);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidatorTest.java
@@ -1,0 +1,57 @@
+package uk.gov.ida.saml.core.validators.subject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Subject;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.NameIdBuilder;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validation.errors.ResponseProcessingValidationSpecification;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionSubjectValidatorTest {
+
+    private static final String ASSERTION_ID = "some-assertion-id";
+
+    private static AssertionSubjectValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new AssertionSubjectValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectElementIsMissing() throws Exception {
+        assertExceptionMessage(null, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.missingAssertionSubject(ASSERTION_ID));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectNameIdIsMissing() throws Exception {
+        final Subject subject = aSubject().withNameId(null).build();
+        assertExceptionMessage(subject, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.assertionSubjectHasNoNameID(ASSERTION_ID));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectNameIdFormatAttributeIsMissing() throws Exception {
+        final Subject subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat(null).build()).build();
+        assertExceptionMessage(subject, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.missingAssertionSubjectNameIDFormat(ASSERTION_ID));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectNameIdFormatAttributeHasInvalidValue() throws Exception {
+        final Subject subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat("Invalid").build()).build();
+        assertExceptionMessage(subject, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.illegalAssertionSubjectNameIDFormat(ASSERTION_ID, subject.getNameID().getFormat()));
+    }
+
+    public static void assertExceptionMessage(
+            final Subject subject,
+            Class<? extends SamlValidationSpecificationFailure> errorClass,
+            SamlValidationSpecificationFailure failure) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(() -> validator.validate(subject, ASSERTION_ID), failure);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subjectconfirmation/AssertionSubjectConfirmationValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subjectconfirmation/AssertionSubjectConfirmationValidatorTest.java
@@ -1,0 +1,72 @@
+package uk.gov.ida.saml.core.validators.subjectconfirmation;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class AssertionSubjectConfirmationValidatorTest {
+
+    private static final String REQUEST_ID = "some-request-id";
+
+    private AssertionSubjectConfirmationValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new AssertionSubjectConfirmationValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectConfirmationDataRecipientAttributeDoesNotMatchTheExpectedIssuerId() throws Exception {
+        final String expectedRecipientId = TestEntityIds.HUB_ENTITY_ID;
+        final String actualRecipientId = TestEntityIds.TEST_RP;
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(createSubjectConfirmationDataBuilder()
+                        .withRecipient(actualRecipientId)
+                        .build())
+                .build();
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.incorrectRecipientFormat(actualRecipientId, expectedRecipientId), expectedRecipientId);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectConfirmationDataInResponseToAttributeIsNotTheOriginalRequestId() throws Exception {
+        final String subjectInResponseTo = "an-incorrect-request-id";
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(SubjectConfirmationDataBuilder.aSubjectConfirmationData()
+                        .withInResponseTo(subjectInResponseTo)
+                        .build())
+                .build();
+
+        assertExceptionMessage(
+                subjectConfirmation,
+                SamlTransformationErrorFactory.notMatchInResponseTo(subjectInResponseTo, REQUEST_ID),
+                subjectConfirmation.getSubjectConfirmationData().getRecipient());
+    }
+
+    private void assertExceptionMessage(
+            final SubjectConfirmation subjectConfirmation,
+            SamlValidationSpecificationFailure failure, final String recipient) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                new SamlTransformationErrorManagerTestHelper.Action() {
+                    @Override
+                    public void execute() {
+                        validator.validate(subjectConfirmation, REQUEST_ID, recipient);
+                    }
+                },
+                failure
+        );
+    }
+
+    private SubjectConfirmationDataBuilder createSubjectConfirmationDataBuilder() {
+        return SubjectConfirmationDataBuilder.aSubjectConfirmationData().withInResponseTo(REQUEST_ID);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subjectconfirmation/BasicAssertionSubjectConfirmationValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subjectconfirmation/BasicAssertionSubjectConfirmationValidatorTest.java
@@ -1,0 +1,118 @@
+package uk.gov.ida.saml.core.validators.subjectconfirmation;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import uk.gov.ida.saml.core.DateTimeFreezer;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class BasicAssertionSubjectConfirmationValidatorTest {
+
+    private static final String REQUEST_ID = "some-request-id";
+
+    private BasicAssertionSubjectConfirmationValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new BasicAssertionSubjectConfirmationValidator();
+    }
+
+    @After
+    public void teardown() {
+        DateTimeFreezer.unfreezeTime();
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenSubjectConfirmationDataElementIsMissing() throws Exception {
+        SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(null).build();
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.missingSubjectConfirmationData());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenSubjectConfirmationDataRecipientAttributeIsMissing() throws Exception {
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(createSubjectConfirmationDataBuilder().withRecipient(null).build()).build();
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.missingBearerRecipient());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenSubjectConfirmationDataNotOnOrAfterAttributeIsMissing() throws Exception {
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(createSubjectConfirmationDataBuilder().withNotOnOrAfter(null).build())
+                .build();
+
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.missingNotOnOrAfter());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenSubjectConfirmationDataNotOnOrAfterIsNow() throws Exception {
+        DateTimeFreezer.freezeTime();
+        DateTime expiredTime = DateTime.now(DateTimeZone.UTC);
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(createSubjectConfirmationDataBuilder().withNotOnOrAfter(expiredTime).build())
+                .build();
+
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.exceededNotOnOrAfter(expiredTime));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenSubjectConfirmationDataNotOnOrAfterHasBeenExceeded() throws Exception {
+        DateTimeFreezer.freezeTime();
+        DateTime expiredTime = DateTime.now(DateTimeZone.UTC).minus(1);
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(createSubjectConfirmationDataBuilder().withNotOnOrAfter(expiredTime).build())
+                .build();
+
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.exceededNotOnOrAfter(expiredTime));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionWhenSubjectConfirmationDataNotBeforeAttributeIsSet() throws Exception {
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation()
+                .withSubjectConfirmationData(createSubjectConfirmationDataBuilder().withNotBefore(DateTime.now()).build())
+                .build();
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.notBeforeExists());
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfSubjectConfirmationDataHasAnAddressElement() throws Exception {
+        final SubjectConfirmationData subjectConfirmationData = createSubjectConfirmationDataBuilder().withAddress("address").build();
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(subjectConfirmationData).build();
+        validator.validate(subjectConfirmation);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubjectConfirmationDataInResponseToAttributeIsMissing() throws Exception {
+        final SubjectConfirmation subjectConfirmation = aSubjectConfirmation().withSubjectConfirmationData(SubjectConfirmationDataBuilder.aSubjectConfirmationData().withInResponseTo(null).build()).build();
+        assertExceptionMessage(subjectConfirmation, SamlTransformationErrorFactory.missingBearerInResponseTo());
+    }
+
+    private void assertExceptionMessage(
+            final SubjectConfirmation subjectConfirmation,
+            SamlValidationSpecificationFailure failure) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                new SamlTransformationErrorManagerTestHelper.Action() {
+                    @Override
+                    public void execute() {
+                        validator.validate(subjectConfirmation);
+                    }
+                },
+                failure
+        );
+    }
+
+    private SubjectConfirmationDataBuilder createSubjectConfirmationDataBuilder() {
+        return SubjectConfirmationDataBuilder.aSubjectConfirmationData().withInResponseTo(REQUEST_ID);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/api/HubTransformersFactoryTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/api/HubTransformersFactoryTest.java
@@ -1,0 +1,114 @@
+package uk.gov.ida.saml.hub.api;
+
+import org.apache.xml.security.exceptions.Base64DecodingException;
+import org.apache.xml.security.utils.Base64;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.api.CoreTransformersFactory;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.hub.domain.EidasAuthnRequestFromHub;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+import uk.gov.ida.saml.hub.test.builders.EidasAuthnRequestBuilder;
+import uk.gov.ida.saml.hub.test.builders.IdaAuthnRequestBuilder;
+import uk.gov.ida.saml.security.IdaKeyStore;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+public class HubTransformersFactoryTest {
+    private StringToOpenSamlObjectTransformer<AuthnRequest> stringtoOpenSamlObjectTransformer;
+
+    @Before
+    public void setUp() {
+        IdaSamlBootstrap.bootstrap();
+        CoreTransformersFactory coreTransformersFactory = new CoreTransformersFactory();
+        stringtoOpenSamlObjectTransformer = coreTransformersFactory.
+            getStringtoOpenSamlObjectTransformer(input -> {});
+    }
+
+    @Test
+    public void getIdaAuthnRequestFromHubToStringTransformer_testDoesNotContainKeyInfo() throws Exception {
+        //Given
+        SignatureAlgorithm signatureAlgorithm = new SignatureRSASHA256();
+        DigestAlgorithm digestAlgorithm = new DigestSHA256();
+        Function<IdaAuthnRequestFromHub, String> eidasTransformer = new HubTransformersFactory().getIdaAuthnRequestFromHubToStringTransformer(
+            getKeyStore(),
+            signatureAlgorithm,
+            digestAlgorithm
+        );
+        IdaAuthnRequestFromHub idaAuthnRequestFromHub = IdaAuthnRequestBuilder.anIdaAuthnRequest()
+            .withLevelsOfAssurance(Collections.singletonList(AuthnContext.LEVEL_3))
+            .buildFromHub();
+
+        //When
+        String apply = eidasTransformer.apply(idaAuthnRequestFromHub);
+
+        //Then the Authn Request string is returned
+        Assert.assertNotNull(apply);
+
+        //And the Authn Request does not contain a KeyInfo section for Verify UK
+        AuthnRequest authnReq = stringtoOpenSamlObjectTransformer.apply(apply);
+        Assert.assertNotNull(authnReq);
+        Assert.assertNull("The Authn Request does not contain a KeyInfo section for Verify UK", authnReq.getSignature().getKeyInfo());
+    }
+
+    @Test
+    public void getEidasAuthnRequestFromHubToStringTransformer_testContainsKeyInfo() throws Exception {
+        //Given
+        SignatureAlgorithm signatureAlgorithm = new SignatureRSASHA256();
+        DigestAlgorithm digestAlgorithm = new DigestSHA256();
+        Function<EidasAuthnRequestFromHub, String> eidasTransformer = new HubTransformersFactory().getEidasAuthnRequestFromHubToStringTransformer(
+            getKeyStore(),
+            signatureAlgorithm,
+            digestAlgorithm
+        );
+        EidasAuthnRequestFromHub eidasAuthnRequestFromHub = EidasAuthnRequestBuilder.anEidasAuthnRequest()
+            .withLevelsOfAssurance(Collections.singletonList(AuthnContext.LEVEL_3))
+            .buildFromHub();
+
+        //When
+        String apply = eidasTransformer.apply(eidasAuthnRequestFromHub);
+
+        //Then the Authn Request string is returned
+        Assert.assertNotNull(apply);
+
+        //And the Authn Request contains a KeyInfo section for eIDAS
+        AuthnRequest authnReq = stringtoOpenSamlObjectTransformer.apply(apply);
+        Assert.assertNotNull(authnReq);
+        Assert.assertNotNull("The Authn Request contains a KeyInfo section for eIDAS", authnReq.getSignature().getKeyInfo());
+    }
+
+    private static IdaKeyStore getKeyStore() throws Base64DecodingException {
+        List<KeyPair> encryptionKeyPairs = new ArrayList<>();
+        PublicKeyFactory publicKeyFactory = new PublicKeyFactory(new X509CertificateFactory());
+        PrivateKeyFactory privateKeyFactory = new PrivateKeyFactory();
+        PublicKey encryptionPublicKey = publicKeyFactory.createPublicKey(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT);
+        PrivateKey encryptionPrivateKey = privateKeyFactory.createPrivateKey(Base64.decode(TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY.getBytes()));
+        encryptionKeyPairs.add(new KeyPair(encryptionPublicKey, encryptionPrivateKey));
+        PublicKey publicSigningKey = publicKeyFactory.createPublicKey(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT);
+        PrivateKey privateSigningKey = privateKeyFactory.createPrivateKey(Base64.decode(TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY.getBytes()));
+        KeyPair signingKeyPair = new KeyPair(publicSigningKey, privateSigningKey);
+
+        return new IdaKeyStore(new X509CertificateFactory().createCertificate(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT), signingKeyPair, encryptionKeyPairs);
+    }
+
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/builders/HubEidasAttributeQueryRequestBuilder.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/builders/HubEidasAttributeQueryRequestBuilder.java
@@ -1,0 +1,95 @@
+package uk.gov.ida.saml.hub.builders;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+import uk.gov.ida.saml.hub.domain.HubEidasAttributeQueryRequest;
+import uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class HubEidasAttributeQueryRequestBuilder {
+
+    private String id = "id";
+    private PersistentId persistentId = new PersistentId("default-name-id");
+    private Optional<HubAssertion> cycle3AttributeAssertion = Optional.empty();
+    private Optional<List<UserAccountCreationAttribute>> userAccountCreationAttributes = Optional.empty();
+    private URI assertionConsumerServiceUrl = URI.create("http://transaction.com");
+    private String authnRequestIssuerEntityId = "issuer-id";
+    private AuthnContext authnContext = AuthnContext.LEVEL_1;
+    private String encryptedIdentityAssertion = "encryptedIdentityAssertion";
+    private String hubEidasEntityId = "hubEntityId";
+
+    public static HubEidasAttributeQueryRequestBuilder aHubEidasAttributeQueryRequest() {
+        return new HubEidasAttributeQueryRequestBuilder();
+    }
+
+    public HubEidasAttributeQueryRequest build() {
+        return new HubEidasAttributeQueryRequest(
+                id,
+                hubEidasEntityId,
+                DateTime.now(),
+                persistentId,
+                assertionConsumerServiceUrl,
+                authnRequestIssuerEntityId,
+                encryptedIdentityAssertion,
+                authnContext,
+                cycle3AttributeAssertion,
+                userAccountCreationAttributes
+        );
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withPersistentId(PersistentId persistentId) {
+        this.persistentId = persistentId;
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withEncryptedIdentityAssertion(String assertion) {
+        this.encryptedIdentityAssertion = assertion;
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withCycle3DataAssertion(HubAssertion cycle3DataAssertion) {
+        this.cycle3AttributeAssertion = Optional.ofNullable(cycle3DataAssertion);
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withAssertionConsumerServiceUrl(URI assertionConsumerServiceUrl) {
+        this.assertionConsumerServiceUrl = assertionConsumerServiceUrl;
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withAuthnRequestIssuerEntityId(String requestIssuer) {
+        this.authnRequestIssuerEntityId = requestIssuer;
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withAuthnContext(AuthnContext authnContext) {
+        this.authnContext = authnContext;
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder addUserAccountCreationAttribute(final UserAccountCreationAttribute userAccountCreationAttribute) {
+        if(!userAccountCreationAttributes.isPresent()){
+           List<UserAccountCreationAttribute> userAccountCreationAttributeList = new ArrayList<>();
+
+           userAccountCreationAttributes = Optional.ofNullable(userAccountCreationAttributeList);
+        }
+        this.userAccountCreationAttributes.get().add(userAccountCreationAttribute);
+        return this;
+    }
+
+    public HubEidasAttributeQueryRequestBuilder withoutUserAccountCreationAttributes() {
+        userAccountCreationAttributes = Optional.empty();
+        return this;
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/domain/LevelOfAssuranceTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/domain/LevelOfAssuranceTest.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.saml.hub.domain;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class LevelOfAssuranceTest {
+
+    @Test
+    public void checkOrdering() {
+        assertTrue(LevelOfAssurance.HIGH.compareTo(LevelOfAssurance.SUBSTANTIAL) > 0);
+        assertTrue(LevelOfAssurance.HIGH.compareTo(LevelOfAssurance.LOW) > 0);
+        assertTrue(LevelOfAssurance.SUBSTANTIAL.compareTo(LevelOfAssurance.LOW) > 0);
+
+        assertTrue(LevelOfAssurance.SUBSTANTIAL.compareTo(LevelOfAssurance.HIGH) < 0);
+        assertTrue(LevelOfAssurance.LOW.compareTo(LevelOfAssurance.HIGH) < 0);
+        assertTrue(LevelOfAssurance.LOW.compareTo(LevelOfAssurance.SUBSTANTIAL) < 0);
+    }
+
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/factories/AttributeQueryAttributeFactoryTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/factories/AttributeQueryAttributeFactoryTest.java
@@ -1,0 +1,49 @@
+package uk.gov.ida.saml.hub.factories;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Attribute;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class AttributeQueryAttributeFactoryTest {
+
+    private AttributeQueryAttributeFactory attributeQueryAttributeFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        attributeQueryAttributeFactory = new AttributeQueryAttributeFactory(new OpenSamlXmlObjectFactory());
+    }
+
+    @Test
+    public void createAttribute_shouldPopulateAttributeNameFromUserAccountCreationAttributeValue(){
+        UserAccountCreationAttribute userAccountCreationAttribute = UserAccountCreationAttribute.CURRENT_ADDRESS;
+
+        Attribute attribute = attributeQueryAttributeFactory.createAttribute(userAccountCreationAttribute);
+
+        assertThat(attribute.getName()).isEqualTo("currentaddress");
+    }
+
+    @Test
+    public void createAttribute_shouldPopulateAttributeNameFormatWithUnspecifiedFormat(){
+        UserAccountCreationAttribute userAccountCreationAttribute = UserAccountCreationAttribute.CURRENT_ADDRESS;
+
+        Attribute attribute = attributeQueryAttributeFactory.createAttribute(userAccountCreationAttribute);
+
+        assertThat(attribute.getNameFormat()).isEqualTo("urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified");
+    }
+
+    @Test
+    public void createAttribute_shouldNotSetFriendlyName(){
+        UserAccountCreationAttribute userAccountCreationAttribute = UserAccountCreationAttribute.CURRENT_ADDRESS;
+
+        Attribute attribute = attributeQueryAttributeFactory.createAttribute(userAccountCreationAttribute);
+
+        assertThat(attribute.getFriendlyName()).isNull();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestFromRelyingPartyUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestFromRelyingPartyUnmarshallerTest.java
@@ -1,0 +1,137 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.codec.binary.Base64;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Extensions;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.impl.AttributeBuilder;
+import org.opensaml.saml.saml2.core.impl.AuthnRequestBuilder;
+import org.opensaml.saml.saml2.core.impl.ExtensionsBuilder;
+import org.opensaml.saml.saml2.core.impl.IssuerBuilder;
+import org.opensaml.saml.saml2.encryption.Encrypter;
+import org.opensaml.security.credential.BasicCredential;
+import org.opensaml.xmlsec.signature.impl.SignatureBuilder;
+import org.opensaml.xmlsec.signature.impl.SignatureImpl;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.extensions.versioning.Version;
+import uk.gov.ida.saml.core.extensions.versioning.VersionImpl;
+import uk.gov.ida.saml.core.extensions.versioning.application.ApplicationVersion;
+import uk.gov.ida.saml.core.extensions.versioning.application.ApplicationVersionImpl;
+import uk.gov.ida.saml.hub.domain.AuthnRequestFromRelyingParty;
+import uk.gov.ida.saml.security.DecrypterFactory;
+import uk.gov.ida.saml.security.EncrypterFactory;
+
+import java.net.URI;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT;
+
+public class AuthnRequestFromRelyingPartyUnmarshallerTest {
+
+    private static Encrypter encrypter;
+
+    private AuthnRequestFromRelyingPartyUnmarshaller unmarshaller;
+
+    @Before
+    public void setUp() {
+        IdaSamlBootstrap.bootstrap();
+
+        final BasicCredential basicCredential = createBasicCredential();
+        encrypter = new EncrypterFactory().createEncrypter(basicCredential);
+
+        unmarshaller = new AuthnRequestFromRelyingPartyUnmarshaller(new DecrypterFactory().createDecrypter(ImmutableList.of(basicCredential)));
+    }
+
+    @Test
+    public void fromSamlMessage_shouldMapAuthnRequestToAuthnRequestFromRelyingParty() throws Exception {
+        DateTime issueInstant = new DateTime();
+        SignatureImpl signature = new SignatureBuilder().buildObject();
+
+        AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
+        authnRequest.setID("some-id");
+        Issuer issuer = new IssuerBuilder().buildObject();
+        issuer.setValue("some-service-entity-id");
+        authnRequest.setIssuer(issuer);
+        authnRequest.setIssueInstant(issueInstant);
+        authnRequest.setDestination("http://example.com");
+        authnRequest.setForceAuthn(true);
+        authnRequest.setAssertionConsumerServiceURL("some-url");
+        authnRequest.setAssertionConsumerServiceIndex(Integer.valueOf(5));
+        authnRequest.setSignature(signature);
+        authnRequest.setExtensions(createApplicationVersionExtensions("some-version"));
+
+        AuthnRequestFromRelyingParty authnRequestFromRelyingParty = unmarshaller.fromSamlMessage(authnRequest);
+        AuthnRequestFromRelyingParty expected = new AuthnRequestFromRelyingParty(
+            "some-id",
+            "some-service-entity-id",
+            issueInstant,
+            URI.create("http://example.com"),
+            Optional.ofNullable(true),
+            Optional.of(URI.create("some-url")),
+            Optional.of(Integer.valueOf(5)),
+            Optional.of(signature),
+            Optional.of("some-version")
+        );
+
+        assertThat(authnRequestFromRelyingParty).isEqualTo(expected);
+    }
+
+    @Test
+    public void fromSamlMessage_shouldNotComplainWhenThereIsNoExtensionsElement() throws Exception {
+        AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
+        authnRequest.setIssuer(new IssuerBuilder().buildObject());
+        authnRequest.setDestination("http://example.com");
+
+        AuthnRequestFromRelyingParty authnRequestFromRelyingParty = unmarshaller.fromSamlMessage(authnRequest);
+
+        assertThat(authnRequestFromRelyingParty.getVerifyServiceProviderVersion()).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void fromSamlMessage_shouldNotComplainWhenExceptionDuringDecryption() throws Exception {
+        AuthnRequest authnRequest = new AuthnRequestBuilder().buildObject();
+        authnRequest.setIssuer(new IssuerBuilder().buildObject());
+        authnRequest.setDestination("http://example.com");
+        authnRequest.setExtensions(createApplicationVersionExtensions(null));
+
+        AuthnRequestFromRelyingParty authnRequestFromRelyingParty = unmarshaller.fromSamlMessage(authnRequest);
+
+        assertThat(authnRequestFromRelyingParty.getVerifyServiceProviderVersion()).isEqualTo(Optional.empty());
+    }
+
+    private Extensions createApplicationVersionExtensions(String version) throws Exception {
+        Extensions extensions = new ExtensionsBuilder().buildObject();
+        Attribute versionsAttribute = new AttributeBuilder().buildObject();
+        versionsAttribute.setName("Versions");
+        versionsAttribute.getAttributeValues().add(createApplicationVersion(version));
+        extensions.getUnknownXMLObjects().add(encrypter.encrypt(versionsAttribute));
+        return extensions;
+    }
+
+    private Version createApplicationVersion(String versionNumber) {
+        ApplicationVersion applicationVersion = new ApplicationVersionImpl();
+        applicationVersion.setValue(versionNumber);
+        Version version = new VersionImpl() {{
+            setApplicationVersion(applicationVersion);
+        }};
+        return version;
+    }
+
+    private BasicCredential createBasicCredential() {
+        final PublicKey publicKey = new PublicKeyFactory(new X509CertificateFactory()).createPublicKey(HUB_TEST_PUBLIC_ENCRYPTION_CERT);
+        PrivateKey privateKey = new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(HUB_TEST_PRIVATE_ENCRYPTION_KEY));
+        return new BasicCredential(publicKey, privateKey);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshallerTest.java
@@ -1,0 +1,67 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.builders.SignatureBuilder;
+import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.PassthroughAssertionBuilder.aPassthroughAssertion;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class IdaResponseFromIdpUnmarshallerTest {
+    @Mock
+    private IdpIdaStatusUnmarshaller statusUnmarshaller;
+    @Mock
+    private PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller;
+    @Mock
+    private Response response;
+    @Mock
+    private Issuer issuer = null;
+    private IdaResponseFromIdpUnmarshaller unmarshaller;
+    private Signature signature = new SignatureBuilder().build();
+
+    @Before
+    public void setup() {
+        when(response.getIssuer()).thenReturn(issuer);
+        when(response.getDestination()).thenReturn("http://hello.com");
+        when(response.getSignature()).thenReturn(signature);
+        unmarshaller = new IdaResponseFromIdpUnmarshaller(statusUnmarshaller, passthroughAssertionUnmarshaller);
+    }
+
+    @Test
+    public void transform_shouldTransformTheSamlResponseToIdaResponseByIdp() throws Exception {
+        Assertion mdsAssertion = anAssertion().addAttributeStatement(anAttributeStatement().build()).buildUnencrypted();
+        Assertion authnStatementAssertion = anAssertion().addAuthnStatement(anAuthnStatement().build()).buildUnencrypted();
+
+        when(response.getAssertions()).thenReturn(newArrayList(mdsAssertion, authnStatementAssertion));
+        PassthroughAssertion passthroughMdsAssertion = aPassthroughAssertion().buildMatchingDatasetAssertion();
+        when(passthroughAssertionUnmarshaller.fromAssertion(mdsAssertion)).thenReturn(passthroughMdsAssertion);
+        PassthroughAssertion passthroughAuthnAssertion = aPassthroughAssertion().buildAuthnStatementAssertion();
+        when(passthroughAssertionUnmarshaller.fromAssertion(authnStatementAssertion)).thenReturn(passthroughAuthnAssertion);
+
+        InboundResponseFromIdp inboundResponseFromIdp = unmarshaller.fromSaml(new ValidatedResponse(response), new ValidatedAssertions(response.getAssertions()));
+
+        assertThat(inboundResponseFromIdp.getSignature().isPresent()).isEqualTo(true);
+        assertThat(inboundResponseFromIdp.getMatchingDatasetAssertion().isPresent()).isEqualTo(true);
+        assertThat(inboundResponseFromIdp.getAuthnStatementAssertion().isPresent()).isEqualTo(true);
+        assertThat(inboundResponseFromIdp.getSignature().get()).isEqualTo(signature);
+        assertThat(inboundResponseFromIdp.getAuthnStatementAssertion().get()).isEqualTo(passthroughAuthnAssertion);
+        assertThat(inboundResponseFromIdp.getMatchingDatasetAssertion().get()).isEqualTo(passthroughMdsAssertion);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshallerTest.java
@@ -1,0 +1,189 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.api.CoreTransformersFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+import static uk.gov.ida.saml.core.test.builders.StatusMessageBuilder.aStatusMessage;
+
+@RunWith(OpenSAMLRunner.class)
+public class IdpIdaStatusUnmarshallerTest {
+
+    private IdpIdaStatusUnmarshaller unmarshaller;
+    private SamlStatusToIdpIdaStatusMappingsFactory statusMappingsFactory;
+    private StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer;
+
+    @Before
+    public void setUp() throws Exception {
+        unmarshaller = new IdpIdaStatusUnmarshaller(
+                new IdpIdaStatus.IdpIdaStatusFactory(),
+                new SamlStatusToIdpIdaStatusMappingsFactory()
+        );
+        CoreTransformersFactory coreTransformersFactory = new CoreTransformersFactory();
+        stringtoOpenSamlObjectTransformer = coreTransformersFactory.
+                getStringtoOpenSamlObjectTransformer(input -> {});
+    }
+
+    @Test
+    public void transform_shouldTransformSuccessWithNoSubCode() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode successStatusCode = samlObjectFactory.createStatusCode();
+        successStatusCode.setValue(StatusCode.SUCCESS);
+        originalStatus.setStatusCode(successStatusCode);
+
+        IdpIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(IdpIdaStatus.success());
+    }
+
+    @Test
+    public void transform_shouldTransformNoAuthenticationContext() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.NO_AUTHN_CONTEXT);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        originalStatus.setStatusCode(topLevelStatusCode);
+
+        IdpIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(IdpIdaStatus.noAuthenticationContext());
+    }
+
+    @Test
+    public void transform_shouldTransformAuthnFailed() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        status.setStatusCode(topLevelStatusCode);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.AUTHN_FAILED);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        IdpIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(IdpIdaStatus.authenticationFailed());
+    }
+
+    @Test
+    public void transform_shouldTransformRequesterErrorWithoutMessage() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.REQUESTER);
+        status.setStatusCode(topLevelStatusCode);
+
+        IdpIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(IdpIdaStatus.requesterError());
+    }
+
+    @Test
+    public void transform_shouldTransformRequesterErrorWithRequestDeniedSubstatus() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.REQUESTER);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.REQUEST_DENIED);
+
+        status.setStatusCode(topLevelStatusCode);
+
+        IdpIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(IdpIdaStatus.requesterError());
+    }
+
+    @Test
+    public void transform_shouldTransformRequesterErrorWithMessage() throws Exception {
+        String message = "some message";
+
+        StatusCode topLevelStatusCode = aStatusCode().withValue(StatusCode.REQUESTER).build();
+        Status status = aStatus()
+                .withStatusCode(topLevelStatusCode)
+                .withMessage(aStatusMessage().withMessage(message).build())
+                .build();
+
+        IdpIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(IdpIdaStatus.requesterError());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
+        assertThat(transformedStatus.getMessage().get()).isEqualTo(message);
+    }
+
+    @Test
+    public void shouldMapSamlStatusDetailOfAuthnCancelToAuthenticationCancelled() throws Exception {
+        String cancelXml = readXmlFile("status-cancel.xml");
+        Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(cancelXml);
+
+        IdpIdaStatus idpIdaStatus = getStatusFrom(cancelResponse);
+
+        assertThat(idpIdaStatus.getStatusCode()).isEqualTo(IdpIdaStatus.Status.AuthenticationCancelled);
+    }
+
+    @Test
+    public void shouldMapSamlStatusDetailOfLoaPendingToAuthenticationPending() throws Exception {
+        String pendingXml = readXmlFile("status-pending.xml");
+        Response pendingResponse = stringtoOpenSamlObjectTransformer.apply(pendingXml);
+
+        IdpIdaStatus idpIdaStatus = getStatusFrom(pendingResponse);
+
+        assertThat(idpIdaStatus.getStatusCode()).isEqualTo(IdpIdaStatus.Status.AuthenticationPending);
+    }
+
+    @Test
+    public void shouldRemainSuccessEvenIfStatusDetailCancelReturned() throws Exception {
+        String successWithCancelXml = readXmlFile("status-success-with-cancel.xml");
+        Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(successWithCancelXml);
+
+        IdpIdaStatus idpIdaStatus = getStatusFrom(cancelResponse);
+
+        assertThat(idpIdaStatus.getStatusCode()).isEqualTo(IdpIdaStatus.Status.Success);
+    }
+
+    @Test
+    public void shouldRemainNoAuthnContextIfStatusDetailAbsent() throws Exception {
+        String successWithCancelXml = readXmlFile("status-noauthncontext.xml");
+        Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(successWithCancelXml);
+
+        IdpIdaStatus idpIdaStatus = getStatusFrom(cancelResponse);
+
+        assertThat(idpIdaStatus.getStatusCode()).isEqualTo(IdpIdaStatus.Status.NoAuthenticationContext);
+    }
+
+
+    private String readXmlFile(String xmlFile) throws IOException, URISyntaxException {
+        Base64.Encoder encoder = Base64.getEncoder();
+        URL resource = getClass().getClassLoader().getResource(xmlFile);
+        return new String(encoder.encode(Files.readAllBytes(Paths.get(resource.toURI()))));
+    }
+
+    private IdpIdaStatus getStatusFrom(Response pendingResponse) {
+        statusMappingsFactory = new SamlStatusToIdpIdaStatusMappingsFactory();
+        IdpIdaStatusUnmarshaller idpIdaStatusUnmarshaller = new IdpIdaStatusUnmarshaller(new IdpIdaStatus.IdpIdaStatusFactory(), statusMappingsFactory);
+        return idpIdaStatusUnmarshaller.fromSaml(pendingResponse.getStatus());
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/MatchingServiceIdaStatusUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/MatchingServiceIdaStatusUnmarshallerTest.java
@@ -1,0 +1,98 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class MatchingServiceIdaStatusUnmarshallerTest {
+
+    private MatchingServiceIdaStatusUnmarshaller unmarshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        unmarshaller = new MatchingServiceIdaStatusUnmarshaller();
+    }
+
+    @Test
+    public void transform_shouldTransformMatchingServiceSuccessfulMatch() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode successStatusCode = samlObjectFactory.createStatusCode();
+        successStatusCode.setValue(StatusCode.SUCCESS);
+        originalStatus.setStatusCode(successStatusCode);
+        StatusCode matchStatusCode = samlObjectFactory.createStatusCode();
+        matchStatusCode.setValue(SamlStatusCode.MATCH);
+        successStatusCode.setStatusCode(matchStatusCode);
+
+        MatchingServiceIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(MatchingServiceIdaStatus.MatchingServiceMatch);
+    }
+
+    @Test
+    public void transform_shouldTransformNoMatchFromMatchingService() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(SamlStatusCode.NO_MATCH);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        originalStatus.setStatusCode(topLevelStatusCode);
+
+        MatchingServiceIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(MatchingServiceIdaStatus.NoMatchingServiceMatchFromMatchingService);
+    }
+
+    @Test
+    public void transform_shouldTransformRequesterErrorFromMatchingService() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.REQUESTER);
+        originalStatus.setStatusCode(topLevelStatusCode);
+
+        MatchingServiceIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(MatchingServiceIdaStatus.RequesterError);
+    }
+
+    @Test
+    public void transform_shouldTransformHealthyStatusFromMatchingService() {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.SUCCESS);
+        status.setStatusCode(topLevelStatusCode);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(SamlStatusCode.HEALTHY);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        MatchingServiceIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(MatchingServiceIdaStatus.Healthy);
+    }
+
+    @Test
+    public void shouldTransformCreateFailureCaseFromMatchingService() {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        status.setStatusCode(topLevelStatusCode);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(SamlStatusCode.CREATE_FAILURE);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        MatchingServiceIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(MatchingServiceIdaStatus.UserAccountCreationFailed);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/PassthroughAssertionUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/PassthroughAssertionUnmarshallerTest.java
@@ -1,0 +1,217 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.FraudDetectedDetails;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.extensions.EidasAuthnContext;
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.transformers.AuthnContextFactory;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextBuilder.anAuthnContext;
+import static uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder.anAuthnContextClassRef;
+import static uk.gov.ida.saml.core.test.builders.IPAddressAttributeBuilder.anIPAddress;
+import static uk.gov.ida.saml.core.test.builders.IdpFraudEventIdAttributeBuilder.anIdpFraudEventIdAttribute;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.Gpg45StatusAttributeBuilder.aGpg45StatusAttribute;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class PassthroughAssertionUnmarshallerTest {
+
+    @Mock
+    private XmlObjectToBase64EncodedStringTransformer<Assertion> assertionStringTransformer;
+    @Mock
+    private AuthnContextFactory authnContextFactory;
+
+    private PassthroughAssertionUnmarshaller unmarshaller;
+
+    @Before
+    public void setup() {
+        unmarshaller = new PassthroughAssertionUnmarshaller(assertionStringTransformer, authnContextFactory);
+    }
+
+    @Test
+    public void shouldMapEidasLoACorrectly() {
+        final AuthnContextClassRef authnContextClassRef = anAuthnContextClassRef().withAuthnContextClasRefValue(EidasAuthnContext.EIDAS_LOA_SUBSTANTIAL).build();
+        Assertion theAssertion = anAssertion()
+            .addAuthnStatement(anAuthnStatement().withAuthnContext(anAuthnContext().withAuthnContextClassRef(authnContextClassRef).build()).build())
+            .buildUnencrypted();
+        when(authnContextFactory.mapFromEidasToLoA(EidasAuthnContext.EIDAS_LOA_SUBSTANTIAL)).thenReturn(AuthnContext.LEVEL_2);
+        when(assertionStringTransformer.apply(theAssertion)).thenReturn("AUTHN_ASSERTION");
+
+        PassthroughAssertion authnStatementAssertion = unmarshaller.fromAssertion(theAssertion, true);
+        assertThat(authnStatementAssertion.getAuthnContext().isPresent()).isEqualTo(true);
+        assertThat(authnStatementAssertion.getAuthnContext().get()).isEqualTo(AuthnContext.LEVEL_2);
+    }
+
+    @Test
+    public void transform_shouldHandleFraudAuthnStatementAndSetThatAssertionIsForFraudulentEventAndSetFraudDetails() throws Exception {
+        final AuthnContextClassRef authnContextClassRef = anAuthnContextClassRef().withAuthnContextClasRefValue(IdaAuthnContext.LEVEL_X_AUTHN_CTX).build();
+        Assertion theAssertion = anAssertion()
+                .addAuthnStatement(anAuthnStatement().withAuthnContext(anAuthnContext().withAuthnContextClassRef(authnContextClassRef).build()).build())
+                .addAttributeStatement(anAttributeStatement().addAttribute(anIdpFraudEventIdAttribute().build()).addAttribute(aGpg45StatusAttribute().build()).build())
+                .buildUnencrypted();
+        when(authnContextFactory.authnContextForLevelOfAssurance(IdaAuthnContext.LEVEL_X_AUTHN_CTX)).thenReturn(AuthnContext.LEVEL_X);
+        when(assertionStringTransformer.apply(theAssertion)).thenReturn("AUTHN_ASSERTION");
+
+        PassthroughAssertion authnStatementAssertion = unmarshaller.fromAssertion(theAssertion);
+
+        assertThat(authnStatementAssertion.isFraudulent()).isEqualTo(true);
+        assertThat(authnStatementAssertion.getFraudDetectedDetails().isPresent()).isEqualTo(true);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void transform_shouldThrowExceptionWhenFraudIndicatorAuthnStatementDoesNotContainUniqueId() throws Exception {
+        Assertion theAssertion = anAssertion()
+                .addAuthnStatement(anAuthnStatement()
+                        .withAuthnContext(anAuthnContext()
+                                .withAuthnContextClassRef(
+                                        anAuthnContextClassRef()
+                                                .withAuthnContextClasRefValue(IdaAuthnContext.LEVEL_X_AUTHN_CTX)
+                                                .build())
+                                .build())
+                        .build())
+                .buildUnencrypted();
+
+        when(authnContextFactory.authnContextForLevelOfAssurance(IdaAuthnContext.LEVEL_X_AUTHN_CTX)).thenReturn(AuthnContext.LEVEL_X);
+
+        when(assertionStringTransformer.apply(theAssertion)).thenReturn("AUTHN_ASSERTION");
+
+        unmarshaller.fromAssertion(theAssertion);
+    }
+
+    @Test
+    public void transform_shouldTransformTheIdpFraudEventIdForAFraudAssertion() throws Exception {
+        String fraudEventId = "Fraud Id";
+        Assertion theAssertion = anAssertion()
+                .addAuthnStatement(anAuthnStatement()
+                        .withAuthnContext(anAuthnContext()
+                                .withAuthnContextClassRef(
+                                        anAuthnContextClassRef()
+                                                .withAuthnContextClasRefValue(IdaAuthnContext.LEVEL_X_AUTHN_CTX)
+                                                .build())
+                                .build())
+                        .build())
+                .addAttributeStatement(anAttributeStatement()
+                        .addAttribute(anIdpFraudEventIdAttribute().withValue(fraudEventId).build())
+                        .addAttribute(aGpg45StatusAttribute().build())
+                        .build())
+                .buildUnencrypted();
+
+        when(authnContextFactory.authnContextForLevelOfAssurance(IdaAuthnContext.LEVEL_X_AUTHN_CTX)).thenReturn(AuthnContext.LEVEL_X);
+
+        PassthroughAssertion passthroughAssertion = unmarshaller.fromAssertion(theAssertion);
+
+        FraudDetectedDetails fraudDetectedDetails = passthroughAssertion.getFraudDetectedDetails().get();
+        assertThat(fraudDetectedDetails.getIdpFraudEventId()).isEqualTo(fraudEventId);
+
+    }
+
+    @Test
+    public void transform_shouldTransformTheGpg45StatusIt01ForAFraudAssertion() throws Exception {
+        String gpg45Status = "IT01";
+        Assertion theAssertion = givenAFraudEventAssertion(gpg45Status);
+
+        PassthroughAssertion passthroughAssertion = unmarshaller.fromAssertion(theAssertion);
+
+        FraudDetectedDetails fraudDetectedDetails = passthroughAssertion.getFraudDetectedDetails().get();
+        assertThat(fraudDetectedDetails.getFraudIndicator()).isEqualTo(gpg45Status);
+    }
+
+    @Test
+    public void transform_shouldTransformTheGpg45StatusFi01ForAFraudAssertion() throws Exception {
+        String gpg45Status = "FI01";
+        Assertion theAssertion = givenAFraudEventAssertion(gpg45Status);
+
+        PassthroughAssertion passthroughAssertion = unmarshaller.fromAssertion(theAssertion);
+
+        FraudDetectedDetails fraudDetectedDetails = passthroughAssertion.getFraudDetectedDetails().get();
+        assertThat(fraudDetectedDetails.getFraudIndicator()).isEqualTo(gpg45Status);
+    }
+
+    @Test
+    public void transform_shouldTransformTheGpg45StatusDF01ForAFraudAssertion() throws Exception {
+        String gpg45Status = "DF01";
+        Assertion theAssertion = givenAFraudEventAssertion(gpg45Status);
+
+        PassthroughAssertion passthroughAssertion = unmarshaller.fromAssertion(theAssertion);
+
+        FraudDetectedDetails fraudDetectedDetails = passthroughAssertion.getFraudDetectedDetails().get();
+        assertThat(fraudDetectedDetails.getFraudIndicator()).isEqualTo(gpg45Status);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void transform_shouldThrowExceptionIfGpg45StatusIsNotRecognised() throws Exception {
+        String gpg45Status = "status not known";
+        Assertion theAssertion = givenAFraudEventAssertion(gpg45Status);
+
+        unmarshaller.fromAssertion(theAssertion);
+    }
+
+    @Test
+    public void transform_shouldNotSetFraudlentFlagForNotFraudulentEvent() throws Exception {
+        final AuthnContextClassRef authnContextClassRef = anAuthnContextClassRef().withAuthnContextClasRefValue(IdaAuthnContext.LEVEL_3_AUTHN_CTX).build();
+        Assertion theAssertion = anAssertion()
+                .addAuthnStatement(anAuthnStatement().withAuthnContext(anAuthnContext().withAuthnContextClassRef(authnContextClassRef).build()).build())
+                .buildUnencrypted();
+
+        when(authnContextFactory.authnContextForLevelOfAssurance(IdaAuthnContext.LEVEL_3_AUTHN_CTX)).thenReturn(AuthnContext.LEVEL_3);
+        when(assertionStringTransformer.apply(theAssertion)).thenReturn("AUTHN_ASSERTION");
+
+        PassthroughAssertion authnStatementAssertion = unmarshaller.fromAssertion(theAssertion);
+        assertThat(authnStatementAssertion.isFraudulent()).isEqualTo(false);
+        assertThat(authnStatementAssertion.getFraudDetectedDetails().isPresent()).isEqualTo(false);
+    }
+
+
+    @Test
+    public void transform_shouldTransformIpAddress() throws Exception {
+        String ipAddy = "1.2.3.4";
+        Assertion theAssertion = anAssertion()
+                .addAttributeStatement(anAttributeStatement().addAttribute(anIPAddress().withValue(ipAddy).build()).build())
+                .buildUnencrypted();
+
+        PassthroughAssertion authnStatementAssertion = unmarshaller.fromAssertion(theAssertion);
+        assertThat(authnStatementAssertion.getPrincipalIpAddressAsSeenByIdp().isPresent()).isEqualTo(true);
+        assertThat(authnStatementAssertion.getPrincipalIpAddressAsSeenByIdp().get()).isEqualTo(ipAddy);
+    }
+
+    private Assertion givenAFraudEventAssertion(final String gpg45Status) {
+        Assertion theAssertion = anAssertion()
+                .addAuthnStatement(anAuthnStatement()
+                        .withAuthnContext(anAuthnContext()
+                                .withAuthnContextClassRef(
+                                        anAuthnContextClassRef()
+                                                .withAuthnContextClasRefValue(IdaAuthnContext.LEVEL_X_AUTHN_CTX)
+                                                .build()
+                                )
+                                .build())
+                        .build())
+                .addAttributeStatement(
+                        anAttributeStatement()
+                                .addAttribute(
+                                        anIdpFraudEventIdAttribute()
+                                                .withValue("my-fraud-event-id")
+                                                .build())
+                                .addAttribute(
+                                        aGpg45StatusAttribute()
+                                                .withValue(gpg45Status)
+                                                .build())
+                                .build())
+                .buildUnencrypted();
+
+        when(authnContextFactory.authnContextForLevelOfAssurance(IdaAuthnContext.LEVEL_X_AUTHN_CTX)).thenReturn(AuthnContext.LEVEL_X);
+        return theAssertion;
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/TransactionIdaStatusUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/TransactionIdaStatusUnmarshallerTest.java
@@ -1,0 +1,107 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+
+@RunWith(OpenSAMLRunner.class)
+public class TransactionIdaStatusUnmarshallerTest {
+
+    private TransactionIdaStatusUnmarshaller unmarshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        unmarshaller = new TransactionIdaStatusUnmarshaller();
+    }
+
+    @Test
+    public void transform_shouldTransformSuccessWithNoSubCode() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode successStatusCode = samlObjectFactory.createStatusCode();
+        successStatusCode.setValue(StatusCode.SUCCESS);
+        originalStatus.setStatusCode(successStatusCode);
+
+        TransactionIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(TransactionIdaStatus.Success);
+    }
+
+    @Test
+    public void transform_shouldTransformNoAuthenticationContext() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.NO_AUTHN_CONTEXT);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        originalStatus.setStatusCode(topLevelStatusCode);
+
+        TransactionIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(TransactionIdaStatus.NoAuthenticationContext);
+    }
+
+    @Test
+    public void transform_shouldTransformNoMatchFromHub() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.SUCCESS);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(SamlStatusCode.NO_MATCH);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        originalStatus.setStatusCode(topLevelStatusCode);
+
+        TransactionIdaStatus transformedStatus = unmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(TransactionIdaStatus.NoMatchingServiceMatchFromHub);
+    }
+
+    @Test
+    public void transform_shouldTransformAuthnFailed() throws Exception {
+        OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        status.setStatusCode(topLevelStatusCode);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.AUTHN_FAILED);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        TransactionIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(TransactionIdaStatus.AuthenticationFailed);
+    }
+
+    @Test
+    public void transform_shouldTransformRequesterErrorFromIdpAsSentByHub() throws Exception {
+        Status status =
+            aStatus()
+                .withStatusCode(
+                    aStatusCode()
+                        .withValue(StatusCode.RESPONDER)
+                        .withSubStatusCode(
+                            aStatusCode()
+                            .withValue(StatusCode.REQUESTER)
+                            .build()
+                        )
+                        .build())
+                .build();
+
+
+        TransactionIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(TransactionIdaStatus.RequesterError);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestFromHubToAuthnRequestTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestFromHubToAuthnRequestTransformerTest.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.NameIDType;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.hub.domain.EidasAuthnRequestFromHub;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EidasAuthnRequestFromHubToAuthnRequestTransformerTest {
+    private EidasAuthnRequestFromHubToAuthnRequestTransformer transformer;
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+        transformer = new EidasAuthnRequestFromHubToAuthnRequestTransformer(openSamlXmlObjectFactory);
+    }
+
+    @Test
+    public void shouldApplyNameIdPolicy() {
+        EidasAuthnRequestFromHub request = new EidasAuthnRequestFromHub(
+            "theId",
+            "theIssuer",
+            DateTime.now(),
+            Arrays.asList(AuthnContext.LEVEL_2),
+            URI.create("theUri"),
+            "theProviderName"
+        );
+
+        AuthnRequest authnRequest = transformer.apply(request);
+
+        assertThat(authnRequest.getNameIDPolicy()).isNotNull();
+        assertThat(authnRequest.getNameIDPolicy().getFormat()).isEqualTo(NameIDType.PERSISTENT);
+        assertThat(authnRequest.getNameIDPolicy().getAllowCreate()).isTrue();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/EncryptedAssertionUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/EncryptedAssertionUnmarshallerTest.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.impl.EncryptedAssertionBuilder;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EncryptedAssertionUnmarshallerTest {
+
+    private static final String ENCRYPTED_ASSERTION_BLOB = "BLOB";
+
+    @Mock
+    public StringToOpenSamlObjectTransformer<EncryptedAssertion> stringToEncryptedAssertionTransformer;
+
+    @Test
+    public void shouldCreateAEncryptedAssertionObjectFromAGivenString() throws Exception {
+        EncryptedAssertionUnmarshaller encryptedAssertionUnmarshaller = new EncryptedAssertionUnmarshaller(stringToEncryptedAssertionTransformer);
+        final EncryptedAssertion expected = new EncryptedAssertionBuilder().buildObject();
+        when(stringToEncryptedAssertionTransformer.apply(ENCRYPTED_ASSERTION_BLOB)).thenReturn(expected);
+        final EncryptedAssertion encryptedAssertion = encryptedAssertionUnmarshaller.transform(ENCRYPTED_ASSERTION_BLOB);
+        assertThat(encryptedAssertion).isEqualTo(expected);
+
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/HubAssertionMarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/HubAssertionMarshallerTest.java
@@ -1,0 +1,111 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.transformers.outbound.OutboundAssertionToSubjectTransformer;
+import uk.gov.ida.saml.hub.factories.AttributeFactory_1_1;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.Cycle3DatasetBuilder.aCycle3Dataset;
+import static uk.gov.ida.saml.core.test.builders.HubAssertionBuilder.aHubAssertion;
+import static uk.gov.ida.saml.core.test.builders.SimpleStringAttributeBuilder.aSimpleStringAttribute;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class HubAssertionMarshallerTest {
+
+    private HubAssertionMarshaller marshaller;
+    @Mock
+    private AttributeFactory_1_1 attributeFactory = null;
+    @Mock
+    private OutboundAssertionToSubjectTransformer outboundAssertionToSubjectTransformer;
+
+    @Before
+    public void setup() {
+        OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+        marshaller = new HubAssertionMarshaller(openSamlXmlObjectFactory, attributeFactory, outboundAssertionToSubjectTransformer);
+    }
+
+    @Test
+    public void transform_shouldTransformAssertionSubjects() throws Exception {
+        HubAssertion assertion = aHubAssertion().build();
+
+        marshaller.toSaml(assertion);
+
+        verify(outboundAssertionToSubjectTransformer).transform(assertion);
+    }
+
+    @Test
+    public void transform_shouldTransformAssertionId() throws Exception {
+        String assertionId = "assertion-id";
+        HubAssertion assertion = aHubAssertion().withId(assertionId).build();
+
+        Assertion transformedAssertion = marshaller.toSaml(assertion);
+
+        assertThat(transformedAssertion.getID()).isEqualTo(assertionId);
+    }
+
+    @Test
+    public void transform_shouldTransformAssertionIssuer() throws Exception {
+        String assertionIssuerId = "assertion issuer";
+        HubAssertion assertion = aHubAssertion().withIssuerId(assertionIssuerId).build();
+
+        Assertion transformedAssertion = marshaller.toSaml(assertion);
+
+        assertThat(transformedAssertion.getIssuer().getValue()).isEqualTo(assertionIssuerId);
+    }
+
+    @Test
+    public void transform_shouldTransformAssertionIssuerInstance() throws Exception {
+        DateTime issueInstant = DateTime.parse("2012-12-31T12:34:56Z");
+        HubAssertion assertion = aHubAssertion().withIssueInstant(issueInstant).build();
+
+        Assertion transformedAssertion = marshaller.toSaml(assertion);
+
+        assertThat(transformedAssertion.getIssueInstant()).isEqualTo(issueInstant);
+    }
+
+    @Test
+    public void transform_shouldTransformCycle3DataAssertion() throws Exception {
+        String attributeName = "someName";
+        String value = "some value";
+        HubAssertion assertion = aHubAssertion().withCycle3Data(aCycle3Dataset().addCycle3Data(attributeName, value).build()).build();
+        Attribute expectedAttribute = aSimpleStringAttribute().build();
+        when(attributeFactory.createCycle3DataAttribute(attributeName, value)).thenReturn(expectedAttribute);
+
+        Assertion transformedAssertion = marshaller.toSaml(assertion);
+
+        List<AttributeStatement> attributeStatements = transformedAssertion.getAttributeStatements();
+        assertThat(attributeStatements.size()).isGreaterThan(0);
+        Attribute attribute = attributeStatements.get(0).getAttributes().get(0);
+        assertThat(attribute).isEqualTo(expectedAttribute);
+    }
+
+    @Test
+    public void transform_shouldTransformLevelOfCycle3DataAssertion() throws Exception {
+        String attributeName = "someName";
+        String value = "some value";
+        HubAssertion assertion = aHubAssertion().withCycle3Data(aCycle3Dataset().addCycle3Data(attributeName, value).build()).build();
+        Attribute expectedAttribute = aSimpleStringAttribute().build();
+        when(attributeFactory.createCycle3DataAttribute(attributeName, value)).thenReturn(expectedAttribute);
+
+        Assertion transformedAssertion = marshaller.toSaml(assertion);
+
+        List<AttributeStatement> attributeStatements = transformedAssertion.getAttributeStatements();
+        assertThat(attributeStatements.size()).isGreaterThan(0);
+        Attribute attribute = attributeStatements.get(0).getAttributes().get(0);
+        assertThat(attribute).isEqualTo(expectedAttribute);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/HubAttributeQueryRequestToSamlAttributeQueryTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/HubAttributeQueryRequestToSamlAttributeQueryTransformerTest.java
@@ -1,0 +1,187 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.impl.EncryptedAssertionBuilder;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+import uk.gov.ida.saml.core.transformers.outbound.OutboundAssertionToSubjectTransformer;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.hub.domain.HubAttributeQueryRequest;
+import uk.gov.ida.saml.hub.factories.AttributeFactory_1_1;
+import uk.gov.ida.saml.hub.factories.AttributeQueryAttributeFactory;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.HubAssertionBuilder.aHubAssertion;
+import static uk.gov.ida.saml.core.test.builders.PassthroughAssertionBuilder.aPassthroughAssertion;
+import static uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute.CURRENT_ADDRESS;
+import static uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute.DATE_OF_BIRTH;
+import static uk.gov.ida.saml.hub.test.builders.HubAttributeQueryRequestBuilder.aHubAttributeQueryRequest;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class HubAttributeQueryRequestToSamlAttributeQueryTransformerTest {
+
+    public static final String ENCRYPTED_MDS_ASSERTION = "encrypted-mds-assertion!";
+    public static final String AUTHN_STATEMENT_ASSERTION = "authn-statement-assertion!";
+    public static final String AUTHN_STATEMENT_ID = "AUTHEN_STATEMENT_ID";
+
+    private HubAttributeQueryRequestToSamlAttributeQueryTransformer transformer;
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+
+    @Mock
+    private IdaStatusMarshaller<?> statusMarshaller;
+    @Mock
+    private AttributeFactory_1_1 attributeFactory;
+    @Mock
+    private StringToOpenSamlObjectTransformer<Assertion> stringAssertionTransformer;
+    @Mock
+    private OutboundAssertionToSubjectTransformer outboundAssertionToSubjectTransformer;
+    @Mock
+    private AttributeQueryAttributeFactory attributeQueryAttributeFactory;
+    @Mock
+    private EncryptedAssertionUnmarshaller encryptedAssertionUnmarshaller;
+
+    @Before
+    public void setup() throws Exception {
+        openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+        HubAssertionMarshaller assertionTransformer = new HubAssertionMarshaller(openSamlXmlObjectFactory, attributeFactory, outboundAssertionToSubjectTransformer);
+        AssertionFromIdpToAssertionTransformer assertionFromIdpAssertionTransformer = new AssertionFromIdpToAssertionTransformer(stringAssertionTransformer);
+
+        when(stringAssertionTransformer.apply(anyString())).thenReturn(anAssertion().buildUnencrypted());
+        when(stringAssertionTransformer.apply(AUTHN_STATEMENT_ASSERTION)).thenReturn(anAssertion().withId(AUTHN_STATEMENT_ID).buildUnencrypted());
+
+        transformer = new HubAttributeQueryRequestToSamlAttributeQueryTransformer(
+                openSamlXmlObjectFactory,
+                assertionTransformer,
+                assertionFromIdpAssertionTransformer,
+                attributeQueryAttributeFactory,
+                encryptedAssertionUnmarshaller);
+    }
+
+    @Test
+    public void transform_shouldProperlyTransform() throws Exception {
+        PersistentId persistentId = new PersistentId("default-name-id");
+        HubAttributeQueryRequest originalQuery = aHubAttributeQueryRequest()
+                .withId("originalId")
+                .withPersistentId(persistentId)
+                .build();
+
+        AttributeQuery transformedQuery = transformer.apply(originalQuery);
+
+        assertThat(transformedQuery.getID()).isEqualTo(originalQuery.getId());
+        assertThat(transformedQuery.getSubject().getNameID().getValue()).isEqualTo(persistentId.getNameId());
+        assertThat(transformedQuery.getIssuer().getValue()).isEqualTo(originalQuery.getIssuer());
+        assertThat(transformedQuery.getVersion()).isEqualTo(SAMLVersion.VERSION_20);
+    }
+
+    @Test
+    public void transform_shouldIncludeActualAssertions() throws Exception {
+        final String authnStatementAssertion = aPassthroughAssertion().withUnderlyingAssertion(AUTHN_STATEMENT_ASSERTION).buildAuthnStatementAssertionAsString();
+        final HubAssertion cycle3DataAssertion = aHubAssertion().build();
+
+        HubAttributeQueryRequest originalQuery = aHubAttributeQueryRequest()
+                .withAuthnStatementAssertion(authnStatementAssertion)
+                .withCycle3DataAssertion(cycle3DataAssertion)
+                .build();
+
+        AttributeQuery transformedQuery = transformer.apply(originalQuery);
+
+        List<XMLObject> unknownXMLObjects = transformedQuery.getSubject().getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+        assertThat(unknownXMLObjects.size()).isEqualTo(2);
+        assertThat(((Assertion)unknownXMLObjects.get(0)).getID()).isEqualTo(AUTHN_STATEMENT_ID);
+        assertThat(((Assertion)unknownXMLObjects.get(1)).getID()).isEqualTo(cycle3DataAssertion.getId());
+    }
+
+    @Test
+    public void transform_shouldIncludeActualEncryptedMDSAssertionOnly() throws Exception {
+        final String encryptedMatchingDatasetAssertion = ENCRYPTED_MDS_ASSERTION;
+
+        HubAttributeQueryRequest originalQuery = aHubAttributeQueryRequest()
+                .withEncryptedMatchingDatasetAssertion(encryptedMatchingDatasetAssertion)
+                .build();
+
+        final EncryptedAssertion value = new EncryptedAssertionBuilder().buildObject();
+        when(encryptedAssertionUnmarshaller.transform(ENCRYPTED_MDS_ASSERTION)).thenReturn(value);
+        AttributeQuery transformedQuery = transformer.apply(originalQuery);
+
+        List<XMLObject> encryptedAssertions = transformedQuery.getSubject()
+                .getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(EncryptedAssertion.DEFAULT_ELEMENT_NAME);
+        assertThat(encryptedAssertions.size()).isEqualTo(1);
+        assertThat(((EncryptedAssertion) encryptedAssertions.get(0))).isEqualTo(value);
+
+        List<XMLObject> assertions = transformedQuery.getSubject()
+                .getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+        assertThat(assertions.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void transform_shouldSetTheSPNameQualifierAndNameQualifierToValuesThatShouldntBeThereButCurrentlyHaveNoWhereBetterToBe() throws Exception {
+        final String authnStatementAssertion = aPassthroughAssertion().withUnderlyingAssertion(AUTHN_STATEMENT_ASSERTION).buildAuthnStatementAssertionAsString();
+        final HubAssertion cycle3DataAssertion = aHubAssertion().build();
+
+        HubAttributeQueryRequest originalQuery = aHubAttributeQueryRequest()
+                .withAuthnStatementAssertion(authnStatementAssertion)
+                .withCycle3DataAssertion(cycle3DataAssertion)
+                .withAssertionConsumerServiceUrl(URI.create("/foo"))
+                .withAuthnRequestIssuerEntityId("authn-request-issuer")
+                .build();
+
+        AttributeQuery transformedQuery = transformer.apply(originalQuery);
+
+        NameID nameID = transformedQuery.getSubject().getNameID();
+
+        assertThat(nameID.getSPNameQualifier()).isEqualTo("authn-request-issuer");
+        assertThat(nameID.getNameQualifier()).isEqualTo("/foo");
+    }
+
+    @Test
+    public void transform_shouldSetAttributesToUserAccountCreationAttributes(){
+        Attribute attribute1 = openSamlXmlObjectFactory.createAttribute();
+        Attribute attribute2 = openSamlXmlObjectFactory.createAttribute();
+        when(attributeQueryAttributeFactory.createAttribute(CURRENT_ADDRESS)).thenReturn(attribute1);
+        when(attributeQueryAttributeFactory.createAttribute(DATE_OF_BIRTH)).thenReturn(attribute2);
+
+        HubAttributeQueryRequest hubAttributeQueryRequest = aHubAttributeQueryRequest()
+                .addUserAccountCreationAttribute(CURRENT_ADDRESS)
+                .addUserAccountCreationAttribute(DATE_OF_BIRTH)
+                .build();
+
+        AttributeQuery transformedQuery = transformer.apply(hubAttributeQueryRequest);
+
+        List<Attribute> transformedQueryAttributes = transformedQuery.getAttributes();
+        assertThat(transformedQueryAttributes.size()).isEqualTo(2);
+        assertThat(transformedQueryAttributes).contains(attribute1);
+        assertThat(transformedQueryAttributes).contains(attribute2);
+    }
+
+    @Test
+    public void transform_shouldNotExplodeWhenUserAccountCreationAttributesAreAbsent(){
+        HubAttributeQueryRequest hubAttributeQueryRequest = aHubAttributeQueryRequest()
+                .withoutUserAccountCreationAttributes()
+                .build();
+
+        AttributeQuery transformedQuery = transformer.apply(hubAttributeQueryRequest);
+
+        List<Attribute> transformedQueryAttributes = transformedQuery.getAttributes();
+        assertThat(transformedQueryAttributes.size()).isEqualTo(0);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/HubEidasAttributeQueryRequestToSamlAttributeQueryTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/HubEidasAttributeQueryRequestToSamlAttributeQueryTransformerTest.java
@@ -1,0 +1,201 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.impl.EncryptedAssertionBuilder;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.HubAssertion;
+import uk.gov.ida.saml.core.domain.PersistentId;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.transformers.outbound.OutboundAssertionToSubjectTransformer;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.hub.domain.HubEidasAttributeQueryRequest;
+import uk.gov.ida.saml.hub.factories.AttributeFactory_1_1;
+import uk.gov.ida.saml.hub.factories.AttributeQueryAttributeFactory;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.HubAssertionBuilder.aHubAssertion;
+import static uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute.CURRENT_ADDRESS;
+import static uk.gov.ida.saml.hub.domain.UserAccountCreationAttribute.DATE_OF_BIRTH;
+import static uk.gov.ida.saml.hub.builders.HubEidasAttributeQueryRequestBuilder.aHubEidasAttributeQueryRequest;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class HubEidasAttributeQueryRequestToSamlAttributeQueryTransformerTest {
+
+    public static final String ENCRYPTED_IDENTITY_ASSERTION = "encrypted-identity-assertion!";
+
+    private HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer transformer;
+
+    private OpenSamlXmlObjectFactory openSamlXmlObjectFactory;
+
+    @Mock
+    private AttributeFactory_1_1 attributeFactory;
+
+    @Mock
+    private StringToOpenSamlObjectTransformer<Assertion> stringAssertionTransformer;
+
+    @Mock
+    private OutboundAssertionToSubjectTransformer outboundAssertionToSubjectTransformer;
+
+    @Mock
+    private AttributeQueryAttributeFactory attributeQueryAttributeFactory;
+
+    @Mock
+    private EncryptedAssertionUnmarshaller encryptedAssertionUnmarshaller;
+
+    @Before
+    public void setup() throws Exception {
+        openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+        HubAssertionMarshaller assertionTransformer = new HubAssertionMarshaller(openSamlXmlObjectFactory, attributeFactory, outboundAssertionToSubjectTransformer);
+        AssertionFromIdpToAssertionTransformer assertionFromIdpAssertionTransformer = new AssertionFromIdpToAssertionTransformer(stringAssertionTransformer);
+
+        when(stringAssertionTransformer.apply(anyString())).thenReturn(anAssertion().buildUnencrypted());
+
+        transformer = new HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer(
+            openSamlXmlObjectFactory,
+            assertionTransformer,
+            assertionFromIdpAssertionTransformer,
+            attributeQueryAttributeFactory,
+            encryptedAssertionUnmarshaller);
+    }
+
+    @Test
+    public void shouldTransformProperly() throws Exception {
+        PersistentId persistentId = new PersistentId("default-name-id");
+        HubEidasAttributeQueryRequest hubEidasAttributeQueryRequest = aHubEidasAttributeQueryRequest()
+            .withId("originalId")
+            .withPersistentId(persistentId)
+            .build();
+
+        AttributeQuery transformedQuery = transformer.apply(hubEidasAttributeQueryRequest);
+
+        assertThat(transformedQuery.getID()).isEqualTo(hubEidasAttributeQueryRequest.getId());
+        assertThat(transformedQuery.getSubject().getNameID().getValue()).isEqualTo(persistentId.getNameId());
+        assertThat(transformedQuery.getIssuer().getValue()).isEqualTo(hubEidasAttributeQueryRequest.getIssuer());
+        assertThat(transformedQuery.getVersion()).isEqualTo(SAMLVersion.VERSION_20);
+    }
+
+    @Test
+    public void shouldIncludeCycle3Assertion() throws Exception {
+        final HubAssertion cycle3DataAssertion = aHubAssertion().build();
+
+        HubEidasAttributeQueryRequest hubEidasAttributeQueryRequest = aHubEidasAttributeQueryRequest()
+            .withCycle3DataAssertion(cycle3DataAssertion)
+            .build();
+
+        AttributeQuery transformedQuery = transformer.apply(hubEidasAttributeQueryRequest);
+
+        List<XMLObject> unknownXMLObjects = transformedQuery.getSubject().getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+        assertThat(unknownXMLObjects.size()).isEqualTo(1);
+        assertThat(((Assertion) unknownXMLObjects.get(0)).getID()).isEqualTo(cycle3DataAssertion.getId());
+    }
+
+    @Test
+    public void shouldIncludeEncryptedIdentityAssertionOnly() throws Exception {
+        HubEidasAttributeQueryRequest hubEidasAttributeQueryRequest = aHubEidasAttributeQueryRequest()
+            .withEncryptedIdentityAssertion(ENCRYPTED_IDENTITY_ASSERTION)
+            .build();
+
+        final EncryptedAssertion value = new EncryptedAssertionBuilder().buildObject();
+        when(encryptedAssertionUnmarshaller.transform(ENCRYPTED_IDENTITY_ASSERTION)).thenReturn(value);
+        AttributeQuery transformedQuery = transformer.apply(hubEidasAttributeQueryRequest);
+
+        List<XMLObject> encryptedAssertions = transformedQuery.getSubject()
+            .getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(EncryptedAssertion.DEFAULT_ELEMENT_NAME);
+        assertThat(encryptedAssertions.size()).isEqualTo(1);
+        assertThat(((EncryptedAssertion) encryptedAssertions.get(0))).isEqualTo(value);
+
+        List<XMLObject> assertions = transformedQuery.getSubject()
+            .getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+        assertThat(assertions.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldIncludeEncryptedIdentityAssertionAndCycle3Assertion() throws Exception {
+        final HubAssertion cycle3DataAssertion = aHubAssertion().build();
+
+        HubEidasAttributeQueryRequest hubEidasAttributeQueryRequest = aHubEidasAttributeQueryRequest()
+            .withEncryptedIdentityAssertion(ENCRYPTED_IDENTITY_ASSERTION)
+            .withCycle3DataAssertion(cycle3DataAssertion)
+            .build();
+
+        final EncryptedAssertion value = new EncryptedAssertionBuilder().buildObject();
+        when(encryptedAssertionUnmarshaller.transform(ENCRYPTED_IDENTITY_ASSERTION)).thenReturn(value);
+        AttributeQuery transformedQuery = transformer.apply(hubEidasAttributeQueryRequest);
+
+        List<XMLObject> encryptedAssertions = transformedQuery.getSubject()
+            .getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(EncryptedAssertion.DEFAULT_ELEMENT_NAME);
+        assertThat(encryptedAssertions.size()).isEqualTo(1);
+        assertThat(((EncryptedAssertion) encryptedAssertions.get(0))).isEqualTo(value);
+
+        List<XMLObject> assertions = transformedQuery.getSubject()
+            .getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(Assertion.DEFAULT_ELEMENT_NAME);
+        assertThat(assertions.size()).isEqualTo(1);
+        assertThat(((Assertion) assertions.get(0)).getID()).isEqualTo(cycle3DataAssertion.getId());
+    }
+
+    @Test
+    public void shouldSetTheSPNameQualifierAndNameQualifierToValuesThatShouldntBeThereButCurrentlyHaveNoWhereBetterToBe() throws Exception {
+        final HubAssertion cycle3DataAssertion = aHubAssertion().build();
+
+        HubEidasAttributeQueryRequest hubEidasAttributeQueryRequest = aHubEidasAttributeQueryRequest()
+            .withCycle3DataAssertion(cycle3DataAssertion)
+            .withAssertionConsumerServiceUrl(URI.create("/foo"))
+            .withAuthnRequestIssuerEntityId("authn-request-issuer")
+            .build();
+
+        AttributeQuery transformedQuery = transformer.apply(hubEidasAttributeQueryRequest);
+
+        NameID nameID = transformedQuery.getSubject().getNameID();
+
+        assertThat(nameID.getSPNameQualifier()).isEqualTo("authn-request-issuer");
+        assertThat(nameID.getNameQualifier()).isEqualTo("/foo");
+    }
+
+    @Test
+    public void shouldSetAttributesToUserAccountCreationAttributes() {
+        Attribute attribute1 = openSamlXmlObjectFactory.createAttribute();
+        Attribute attribute2 = openSamlXmlObjectFactory.createAttribute();
+        when(attributeQueryAttributeFactory.createAttribute(CURRENT_ADDRESS)).thenReturn(attribute1);
+        when(attributeQueryAttributeFactory.createAttribute(DATE_OF_BIRTH)).thenReturn(attribute2);
+
+        HubEidasAttributeQueryRequest hubEidasAttributeQueryRequest = aHubEidasAttributeQueryRequest()
+            .addUserAccountCreationAttribute(CURRENT_ADDRESS)
+            .addUserAccountCreationAttribute(DATE_OF_BIRTH)
+            .build();
+
+        AttributeQuery transformedQuery = transformer.apply(hubEidasAttributeQueryRequest);
+
+        List<Attribute> transformedQueryAttributes = transformedQuery.getAttributes();
+        assertThat(transformedQueryAttributes.size()).isEqualTo(2);
+        assertThat(transformedQueryAttributes).contains(attribute1);
+        assertThat(transformedQueryAttributes).contains(attribute2);
+    }
+
+    @Test
+    public void shouldNotExplodeWhenUserAccountCreationAttributesAreAbsent() {
+        HubEidasAttributeQueryRequest hubEidasAttributeQueryRequest = aHubEidasAttributeQueryRequest()
+            .withoutUserAccountCreationAttributes()
+            .build();
+
+        AttributeQuery transformedQuery = transformer.apply(hubEidasAttributeQueryRequest);
+
+        List<Attribute> transformedQueryAttributes = transformedQuery.getAttributes();
+        assertThat(transformedQueryAttributes.size()).isEqualTo(0);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/IdaAuthnRequestFromHubToAuthnRequestTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/IdaAuthnRequestFromHubToAuthnRequestTransformerTest.java
@@ -1,0 +1,302 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AuthnContextClassRef;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Extensions;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.core.impl.AttributeImpl;
+import org.opensaml.security.SecurityException;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.extensions.IdaAuthnContext;
+import uk.gov.ida.saml.core.extensions.RequestedAttribute;
+import uk.gov.ida.saml.core.extensions.RequestedAttributes;
+import uk.gov.ida.saml.core.extensions.SPType;
+import uk.gov.ida.saml.core.extensions.impl.RequestedAttributeImpl;
+import uk.gov.ida.saml.core.extensions.impl.SPTypeImpl;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.hub.domain.EidasAuthnRequestFromHub;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+import uk.gov.ida.saml.hub.domain.LevelOfAssurance;
+
+import javax.xml.namespace.QName;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.jodatime.api.Assertions.assertThat;
+import static uk.gov.ida.saml.hub.test.builders.EidasAuthnRequestBuilder.anEidasAuthnRequest;
+import static uk.gov.ida.saml.hub.test.builders.IdaAuthnRequestBuilder.anIdaAuthnRequest;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class IdaAuthnRequestFromHubToAuthnRequestTransformerTest {
+
+    public static final String A_PROVIDER = "A_PROVIDER";
+    public static final String HTTP_ISSUER_ENTITY_ID_COM = "http://issuer-entity-id.com";
+    private IdaAuthnRequestFromHubToAuthnRequestTransformer transformer;
+    private EidasAuthnRequestFromHubToAuthnRequestTransformer eidasTransformer;
+
+    private static final String EIDAS_SSO_LOCATION = "http://eidas/ssoLocation";
+    private static final String AUTHN_REQUEST_ID = "aTestId";
+
+    @Before
+    public void setup() {
+        transformer = new IdaAuthnRequestFromHubToAuthnRequestTransformer(new OpenSamlXmlObjectFactory());
+        eidasTransformer = new EidasAuthnRequestFromHubToAuthnRequestTransformer(new OpenSamlXmlObjectFactory());
+    }
+
+    @Test
+    public void shouldUseTheOriginalRequestIdForTheTransformedRequest() throws Exception {
+        String originalRequestId = UUID.randomUUID().toString();
+        IdaAuthnRequestFromHub originalRequestFromHub = anIdaAuthnRequest().withId(originalRequestId).buildFromHub();
+
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromHub);
+
+        assertThat(transformedRequest.getID()).isEqualTo(originalRequestId);
+    }
+
+    @Test
+    public void shouldUseTheOriginalExpiryTimestampToSetTheNotOnOrAfter() throws Exception {
+        DateTime sessionExpiry = DateTime.now().plusHours(2);
+        IdaAuthnRequestFromHub originalRequestFromHub = anIdaAuthnRequest().withSessionExpiryTimestamp(sessionExpiry).buildFromHub();
+
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromHub);
+        assertThat(transformedRequest.getConditions().getNotOnOrAfter()).isEqualTo(sessionExpiry);
+    }
+
+    @Test
+    public void shouldUseTheOriginalRequestIssuerIdForTheTransformedRequest() throws Exception {
+        String originalIssuerId = UUID.randomUUID().toString();
+        IdaAuthnRequestFromHub originalRequestFromHub = anIdaAuthnRequest().withIssuer(originalIssuerId).buildFromHub();
+
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromHub);
+
+        assertThat(transformedRequest.getIssuer().getValue()).isEqualTo(originalIssuerId);
+    }
+
+    @Test
+    public void shouldCreateAProxyElementWithAProxyCountOfZeroInTheTransformedRequest() throws Exception {
+        AuthnRequest transformedRequest = transformer.apply(anIdaAuthnRequest().buildFromHub());
+
+        assertThat(transformedRequest.getScoping().getProxyCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldCreateANameIdPolicyElementWithAFormatOfPersistentInTheTransformedRequest() throws Exception {
+        AuthnRequest transformedRequest = transformer.apply(anIdaAuthnRequest().buildFromHub());
+
+        assertThat(transformedRequest.getNameIDPolicy().getFormat()).isEqualTo(NameIDType.PERSISTENT);
+    }
+    
+    @Test
+    public void shouldCorrectlyMapLevelsOfAssurance() {
+        List<AuthnContext> levelsOfAssurance = Arrays.asList(AuthnContext.LEVEL_1, AuthnContext.LEVEL_2);
+        List<String> expected = Arrays.asList(IdaAuthnContext.LEVEL_1_AUTHN_CTX, IdaAuthnContext.LEVEL_2_AUTHN_CTX);
+
+
+        IdaAuthnRequestFromHub originalRequestFromHub = anIdaAuthnRequest()
+                .withLevelsOfAssurance(levelsOfAssurance).buildFromHub();
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromHub);
+        RequestedAuthnContext requestedAuthnContext = transformedRequest.getRequestedAuthnContext();
+
+        List<String> actual = requestedAuthnContext.getAuthnContextClassRefs().stream()
+                .map(AuthnContextClassRef::getAuthnContextClassRef)
+                .collect(Collectors.toList());
+
+        assertThat(actual).containsAll(expected);
+    }
+
+    @Test
+    public void shouldPropagateComparisonType() {
+        IdaAuthnRequestFromHub originalRequestFromHub = anIdaAuthnRequest()
+                .withComparisonType(AuthnContextComparisonTypeEnumeration.MINIMUM)
+                .buildFromHub();
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromHub);
+
+        RequestedAuthnContext requestedAuthnContext = transformedRequest.getRequestedAuthnContext();
+
+        assertThat(requestedAuthnContext.getComparison()).isEqualTo(AuthnContextComparisonTypeEnumeration.MINIMUM);
+    }
+
+    @Test
+    public void shouldMaintainTheAuthnContextsInPreferenceOrder() throws Exception {
+        IdaAuthnRequestFromHub originalRequestFromHub = anIdaAuthnRequest()
+                .withLevelsOfAssurance(Arrays.asList(AuthnContext.LEVEL_1, AuthnContext.LEVEL_2))
+                .buildFromHub();
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromHub);
+
+        RequestedAuthnContext requestedAuthnContext = transformedRequest.getRequestedAuthnContext();
+
+        List<AuthnContextClassRef> authnContextClassRefs = requestedAuthnContext.getAuthnContextClassRefs();
+        List<String> authnContexts = authnContextClassRefs.stream()
+                .map(AuthnContextClassRef::getAuthnContextClassRef).collect(Collectors.toList());
+
+        assertThat(authnContexts).containsSequence(IdaAuthnContext.LEVEL_1_AUTHN_CTX, IdaAuthnContext.LEVEL_2_AUTHN_CTX);
+    }
+
+    @Test
+    public void shouldSetAllowCreateToTrue() {
+        IdaAuthnRequestFromHub originalRequestFromHub = anIdaAuthnRequest().buildFromHub();
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromHub);
+
+        NameIDPolicy nameIDPolicy = transformedRequest.getNameIDPolicy();
+
+        assertThat(nameIDPolicy.getAllowCreate()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldSetForceAuthnToTrue() throws Exception {
+        IdaAuthnRequestFromHub originalRequestFromTransaction = anIdaAuthnRequest()
+                .withForceAuthentication(ofNullable(true))
+                .buildFromHub();
+
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromTransaction);
+
+        assertThat(transformedRequest.isForceAuthn()).isEqualTo(true);
+
+    }
+
+    @Test
+    public void shouldSetForceAuthnToFalse() throws Exception {
+        IdaAuthnRequestFromHub originalRequestFromTransaction = anIdaAuthnRequest()
+                .withForceAuthentication(ofNullable(false))
+                .buildFromHub();
+
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromTransaction);
+
+        assertThat(transformedRequest.isForceAuthn()).isEqualTo(false);
+
+        originalRequestFromTransaction = anIdaAuthnRequest()
+                .withForceAuthentication(Optional.empty())
+                .buildFromHub();
+
+        transformedRequest = transformer.apply(originalRequestFromTransaction);
+
+        assertThat(transformedRequest.isForceAuthn()).isEqualTo(false);
+
+    }
+
+    @Test
+    public void shouldSetProtocolBindingToPost() throws Exception {
+        IdaAuthnRequestFromHub originalRequestFromTransaction = anIdaAuthnRequest()
+            .buildFromHub();
+
+        AuthnRequest transformedRequest = transformer.apply(originalRequestFromTransaction);
+
+        assertThat(transformedRequest.getProtocolBinding()).isEqualTo(SAMLConstants.SAML2_POST_BINDING_URI);
+    }
+
+    @Test
+    public void shouldCreateAnEidasAuthnRequest() throws Exception {
+        List<AuthnContext> authnContexts = Collections.singletonList(AuthnContext.LEVEL_3);
+        EidasAuthnRequestFromHub originalRequestFromTransaction = anEidasAuthnRequestFromHub(A_PROVIDER, HTTP_ISSUER_ENTITY_ID_COM, authnContexts);
+
+        AuthnRequest transformedRequest = eidasTransformer.apply(originalRequestFromTransaction);
+
+        assertThat(transformedRequest.getProtocolBinding()).isEqualTo(SAMLConstants.SAML2_POST_BINDING_URI);
+        Assert.assertNotNull(transformedRequest);
+        Assert.assertNotNull(transformedRequest.getIssueInstant());
+        Assert.assertEquals(EIDAS_SSO_LOCATION, transformedRequest.getDestination());
+        Assert.assertEquals(AUTHN_REQUEST_ID, transformedRequest.getID());
+
+        Assert.assertEquals(StatusResponseType.UNSPECIFIED_CONSENT, transformedRequest.getConsent());
+        Assert.assertEquals(true, transformedRequest.isForceAuthn());
+        Assert.assertEquals(false, transformedRequest.isPassive());
+        Assert.assertEquals(SAMLVersion.VERSION_20, transformedRequest.getVersion());
+
+        Assert.assertEquals(A_PROVIDER, transformedRequest.getProviderName());
+
+        Assert.assertEquals(HTTP_ISSUER_ENTITY_ID_COM, transformedRequest.getIssuer().getValue());
+
+        NameIDPolicy nameIDPolicy = transformedRequest.getNameIDPolicy();
+        Assert.assertEquals(true, nameIDPolicy.getAllowCreate());
+        Assert.assertEquals(NameIDType.PERSISTENT, nameIDPolicy.getFormat());
+
+        RequestedAuthnContext requestedAuthnContext = transformedRequest.getRequestedAuthnContext();
+        Assert.assertEquals(AuthnContextComparisonTypeEnumeration.MINIMUM, requestedAuthnContext.getComparison());
+        AuthnContextClassRef authnContextClassRef = requestedAuthnContext.getAuthnContextClassRefs().get(0);
+        Assert.assertEquals(LevelOfAssurance.HIGH.toString(), authnContextClassRef.getAuthnContextClassRef());
+    }
+
+    private EidasAuthnRequestFromHub anEidasAuthnRequestFromHub(String A_PROVIDER, String HTTP_ISSUER_ENTITY_ID_COM, List<AuthnContext> authnContexts) {
+        return anEidasAuthnRequest()
+            .withDestination(EIDAS_SSO_LOCATION)
+            .withId(AUTHN_REQUEST_ID)
+            .withProviderName(A_PROVIDER)
+            .withIssuer(HTTP_ISSUER_ENTITY_ID_COM)
+            .withLevelsOfAssurance(authnContexts)
+            .buildFromHub();
+    }
+
+    @Test
+    public void shouldGenerateAnEidasAuthnRequestExtensions() throws MarshallingException, SignatureException, SecurityException {
+        List<AuthnContext> authnContexts = Collections.singletonList(AuthnContext.LEVEL_3);
+        EidasAuthnRequestFromHub originalRequestFromTransaction = anEidasAuthnRequestFromHub(A_PROVIDER, HTTP_ISSUER_ENTITY_ID_COM, authnContexts);
+
+        AuthnRequest transformedRequest = eidasTransformer.apply(originalRequestFromTransaction);
+        Extensions extensions = transformedRequest.getExtensions();
+
+        Assert.assertNotNull(extensions);
+        Optional<XMLObject> spType = extensions
+            .getUnknownXMLObjects(SPType.DEFAULT_ELEMENT_NAME)
+            .stream().findFirst();
+        Assert.assertTrue("There should be at least one eidas:SPType element", spType.isPresent());
+        XMLObject xmlObject = spType.get();
+        Assert.assertTrue("Should be an instance of SPType", xmlObject.getClass().equals(SPTypeImpl.class));
+        Assert.assertEquals("public", ((SPTypeImpl) xmlObject).getValue());
+
+        Optional<XMLObject> requestedAttributes = extensions
+            .getUnknownXMLObjects(RequestedAttributes.DEFAULT_ELEMENT_NAME)
+            .stream().findFirst();
+
+        Assert.assertTrue("There should be at least one eidas:RequestedAttributes", requestedAttributes.isPresent());
+
+        List<XMLObject> requestedAttributeList = requestedAttributes.get().getOrderedChildren();
+        Assert.assertTrue("There should be at least one eidas:RequestedAttribute", requestedAttributeList.size() > 0);
+
+        Map<String, RequestedAttributeImpl> reqAttrMap = getRequestedAttributesByFriendlyName(requestedAttributeList);
+
+        RequestedAttributeImpl firstNameRequestedAttribute = reqAttrMap.get("FirstName");
+        QName elementQName = firstNameRequestedAttribute.getElementQName();
+        Assert.assertEquals(RequestedAttribute.DEFAULT_ELEMENT_LOCAL_NAME, elementQName.getLocalPart());
+        Assert.assertEquals("http://eidas.europa.eu/saml-extensions", elementQName.getNamespaceURI());
+        Assert.assertEquals("eidas", elementQName.getPrefix());
+
+        Assert.assertNotNull(firstNameRequestedAttribute);
+        Assert.assertEquals(EidasAuthnRequestToAuthnRequestTransformer.NATURAL_PERSON_NAME_PREFIX + "CurrentGivenName", firstNameRequestedAttribute.getName());
+        Assert.assertEquals(Attribute.URI_REFERENCE, firstNameRequestedAttribute.getNameFormat());
+        Assert.assertEquals(true, firstNameRequestedAttribute.isRequired());
+
+        Assert.assertNotNull(reqAttrMap.get("FamilyName"));
+        Assert.assertNotNull(reqAttrMap.get("CurrentAddress"));
+        Assert.assertNotNull(reqAttrMap.get("DateOfBirth"));
+        Assert.assertNotNull(reqAttrMap.get("PersonIdentifier"));
+    }
+
+    private Map<String, RequestedAttributeImpl> getRequestedAttributesByFriendlyName(List<XMLObject> requestedAttributes) {
+        return requestedAttributes.stream()
+            .map(x -> (RequestedAttributeImpl)x)
+            .collect(Collectors.toMap(AttributeImpl::getFriendlyName, x -> x));
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/IdpIdaStatusMarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/IdpIdaStatusMarshallerTest.java
@@ -1,0 +1,112 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.IdaSamlBootstrap;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+import uk.gov.ida.saml.core.extensions.StatusValue;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class IdpIdaStatusMarshallerTest {
+
+    private final IdpIdaStatusMarshaller marshaller = new IdpIdaStatusMarshaller(new OpenSamlXmlObjectFactory());
+
+
+    @Before
+    public void setUp() throws Exception {
+        IdaSamlBootstrap.bootstrap();
+    }
+
+    @Test
+    public void transform_shouldTransformSuccess() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(IdpIdaStatus.success());
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
+    }
+
+    @Test
+    public void transform_shouldTransformNoAuthenticationContext() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(IdpIdaStatus.noAuthenticationContext());
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.NO_AUTHN_CONTEXT);
+    }
+
+    @Test
+    public void transform_shouldTransformAuthenticationPending() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(IdpIdaStatus.authenticationPending());
+        StatusValue actual = (StatusValue) transformedStatus.getStatusDetail().getOrderedChildren().get(0);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.NO_AUTHN_CONTEXT);
+        assertThat(actual.getValue()).isEqualTo(StatusValue.PENDING);
+    }
+
+    @Test
+    public void transform_shouldTransformAuthnFailedWithNoSubStatus() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(IdpIdaStatus.authenticationFailed());
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.AUTHN_FAILED);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getStatusCode()).isNull();
+    }
+
+    @Test
+    public void transform_shouldTransformRequesterError() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(IdpIdaStatus.requesterError());
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.REQUESTER);
+    }
+
+    @Test
+    public void transform_shouldTransformRequesterErrorWithMessage() throws Exception {
+        String message = "Oh dear";
+        Status transformedStatus = marshaller.toSamlStatus(IdpIdaStatus.requesterError(Optional.of(message)));
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.REQUESTER);
+        assertThat(transformedStatus.getStatusMessage().getMessage()).isEqualTo(message);
+    }
+
+    @Test
+    public void shouldMarshallStatusDetailElementWhenInCancelStatus() {
+        Status status = marshaller.toSamlStatus(IdpIdaStatus.authenticationCancelled());
+
+        assertThat(status.getStatusDetail()).isNotNull();
+    }
+
+    @Test
+    public void shouldMarshallStatusDetailWithStatusValueContainingAuthnCancelInCaseOfAuthenticationCancelled() {
+        Status status = marshaller.toSamlStatus(IdpIdaStatus.authenticationCancelled());
+
+        StatusValue actual = (StatusValue) status.getStatusDetail().getOrderedChildren().get(0);
+
+        assertThat(actual.getNamespaces()).isEmpty();
+        assertThat(actual.getValue()).isEqualTo(StatusValue.CANCEL);
+    }
+
+    @Test
+    public void shouldMarshallStatusDetailWithStatusValueContainingUpliftFailed() {
+        Status status = marshaller.toSamlStatus(IdpIdaStatus.upliftFailed());
+
+        StatusValue actual = (StatusValue) status.getStatusDetail().getOrderedChildren().get(0);
+
+        assertThat(actual.getNamespaces()).isEmpty();
+        assertThat(actual.getValue()).isEqualTo(StatusValue.UPLIFT_FAILED);
+    }
+
+    @Test
+    public void shouldMarshallStatusDetailWithASingleStatusValueElementInCaseOfAuthenticationCancelled() {
+        Status status = marshaller.toSamlStatus(IdpIdaStatus.authenticationCancelled());
+
+        assertThat(status.getStatusDetail().getOrderedChildren()).hasSize(1);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/MatchingServiceIdaStatusToSamlStatusMarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/MatchingServiceIdaStatusToSamlStatusMarshallerTest.java
@@ -1,0 +1,49 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.MatchingServiceIdaStatus;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class MatchingServiceIdaStatusToSamlStatusMarshallerTest {
+
+    private MatchingServiceIdaStatusMarshaller marshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        marshaller = new MatchingServiceIdaStatusMarshaller(new OpenSamlXmlObjectFactory());
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformMatchingServiceMatch() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(MatchingServiceIdaStatus.MatchingServiceMatch);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
+        assertThat(transformedStatus.getStatusCode().getStatusCode()).isNotNull();
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(SamlStatusCode.MATCH);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformNoMatchingServiceMatch() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(MatchingServiceIdaStatus.NoMatchingServiceMatchFromMatchingService);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode()).isNotNull();
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(SamlStatusCode.NO_MATCH);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformRequesterError() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(MatchingServiceIdaStatus.RequesterError);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.REQUESTER);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformerTest.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.PassthroughAssertion;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.PassthroughAssertionBuilder.aPassthroughAssertion;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.core.test.builders.ResponseForHubBuilder.anAuthnResponse;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class OutboundResponseFromHubToSamlResponseTransformerTest {
+    @Mock
+    private TransactionIdaStatusMarshaller statusMarshaller = null;
+    @Mock
+    private AssertionFromIdpToAssertionTransformer assertionTransformer = null;
+    private OutboundResponseFromHubToSamlResponseTransformer transformer;
+
+    @Before
+    public void setup() {
+        OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+        transformer = new OutboundResponseFromHubToSamlResponseTransformer(statusMarshaller, openSamlXmlObjectFactory, assertionTransformer);
+    }
+
+    @Test
+    public void transformAssertions_shouldTransformMatchingServiceAssertions() throws Exception {
+        PassthroughAssertion matchingServiceAssertion = aPassthroughAssertion().buildMatchingServiceAssertion();
+        Response transformedResponse = aResponse().build();
+        Assertion transformedMatchingDatasetAssertion = anAssertion().buildUnencrypted();
+        when(assertionTransformer.transform(matchingServiceAssertion.getUnderlyingAssertionBlob())).thenReturn(transformedMatchingDatasetAssertion);
+
+        transformer.transformAssertions(anAuthnResponse().withMatchingServiceAssertion(matchingServiceAssertion.getUnderlyingAssertionBlob()).buildOutboundResponseFromHub(), transformedResponse);
+
+        assertThat(transformedResponse.getAssertions().size()).isEqualTo(1);
+        assertThat(transformedResponse.getAssertions().get(0)).isEqualTo(transformedMatchingDatasetAssertion);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/SamlProfileTransactionIdaStatusMarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/SamlProfileTransactionIdaStatusMarshallerTest.java
@@ -1,0 +1,65 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class SamlProfileTransactionIdaStatusMarshallerTest {
+
+    private SamlProfileTransactionIdaStatusMarshaller marshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        marshaller = new SamlProfileTransactionIdaStatusMarshaller(new OpenSamlXmlObjectFactory());
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformSuccess() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.Success);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformNoAuthenticationContext() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.NoAuthenticationContext);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.NO_AUTHN_CONTEXT);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformAuthnFailedWithNoSubStatus() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.AuthenticationFailed);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.AUTHN_FAILED);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getStatusCode()).isNull();
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformRequesterError() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.RequesterError);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.REQUESTER);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformNoMatchingServiceMatchMayRetry() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.NoMatchingServiceMatchFromHub);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode()).isNotNull();
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(SamlStatusCode.NO_MATCH);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileTransactionIdaStatusMarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileTransactionIdaStatusMarshallerTest.java
@@ -1,0 +1,65 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class SimpleProfileTransactionIdaStatusMarshallerTest {
+
+    private SimpleProfileTransactionIdaStatusMarshaller marshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        marshaller = new SimpleProfileTransactionIdaStatusMarshaller(new OpenSamlXmlObjectFactory());
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformSuccess() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.Success);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformNoAuthenticationContext() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.NoAuthenticationContext);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.NO_AUTHN_CONTEXT);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformAuthnFailedWithNoSubStatus() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.AuthenticationFailed);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.AUTHN_FAILED);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getStatusCode()).isNull();
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformRequesterError() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.RequesterError);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.REQUESTER);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformNoMatchingServiceMatchMayRetry() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.NoMatchingServiceMatchFromHub);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode()).isNotNull();
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(SamlStatusCode.NO_MATCH);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/TransactionIdaStatusMarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/TransactionIdaStatusMarshallerTest.java
@@ -1,0 +1,65 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class TransactionIdaStatusMarshallerTest {
+
+    private TransactionIdaStatusMarshaller marshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        marshaller = new TransactionIdaStatusMarshaller(new OpenSamlXmlObjectFactory());
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformSuccess() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.Success);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformNoAuthenticationContext() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.NoAuthenticationContext);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.NO_AUTHN_CONTEXT);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformAuthnFailedWithNoSubStatus() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.AuthenticationFailed);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.AUTHN_FAILED);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getStatusCode()).isNull();
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformRequesterError() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.RequesterError);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(StatusCode.REQUESTER);
+    }
+
+    @Test
+    public void toSamlStatus_shouldTransformNoMatchingServiceMatchMayRetry() throws Exception {
+        Status transformedStatus = marshaller.toSamlStatus(TransactionIdaStatus.NoMatchingServiceMatchFromHub);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
+        assertThat(transformedStatus.getStatusCode().getStatusCode()).isNotNull();
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(SamlStatusCode.NO_MATCH);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/UnknownUserCreationIdaStatusMarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/UnknownUserCreationIdaStatusMarshallerTest.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.msa.test.domain.UnknownUserCreationIdaStatus;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.msa.test.outbound.UnknownUserCreationIdaStatusMarshaller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLRunner.class)
+public class UnknownUserCreationIdaStatusMarshallerTest {
+
+    private UnknownUserCreationIdaStatusMarshaller unknownUserCreationIdaStatusToSamlStatusMarshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        unknownUserCreationIdaStatusToSamlStatusMarshaller = new UnknownUserCreationIdaStatusMarshaller(new OpenSamlXmlObjectFactory());
+    }
+
+    @Test
+    public void transform_shouldTransformUnknownUserCreationSuccess() throws Exception {
+
+        Status transformedStatus = unknownUserCreationIdaStatusToSamlStatusMarshaller.toSamlStatus(UnknownUserCreationIdaStatus.Success);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(SamlStatusCode.CREATED);
+    }
+
+    @Test
+    public void transform_shouldTransformUnknownUserCreationFailure() throws Exception {
+
+        Status transformedStatus = unknownUserCreationIdaStatusToSamlStatusMarshaller.toSamlStatus(UnknownUserCreationIdaStatus.CreateFailure);
+
+        assertThat(transformedStatus.getStatusCode().getValue()).isEqualTo(StatusCode.RESPONDER);
+        assertThat(transformedStatus.getStatusCode().getStatusCode()).isNotNull();
+        assertThat(transformedStatus.getStatusCode().getStatusCode().getValue()).isEqualTo(SamlStatusCode.CREATE_FAILURE);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSignerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSignerTest.java
@@ -1,0 +1,115 @@
+package uk.gov.ida.saml.hub.transformers.outbound.decorators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.security.credential.Credential;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.PrivateKeyStoreFactory;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder.anAttributeQuery;
+import static uk.gov.ida.saml.core.test.builders.AttributeStatementBuilder.anAttributeStatement;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.SimpleStringAttributeBuilder.aSimpleStringAttribute;
+import static uk.gov.ida.saml.core.test.builders.SubjectBuilder.aSubject;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationBuilder.aSubjectConfirmation;
+import static uk.gov.ida.saml.core.test.builders.SubjectConfirmationDataBuilder.aSubjectConfirmationData;
+import static uk.gov.ida.saml.hub.transformers.outbound.decorators.StringEncoding.toBase64Encoded;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SamlAttributeQueryAssertionSignatureSignerTest {
+
+    private OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
+
+    @Mock
+    private IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever;
+    public SamlAttributeQueryAssertionSignatureSigner assertionSignatureSigner;
+
+    @Before
+    public void setUp() throws Exception {
+        assertionSignatureSigner = new SamlAttributeQueryAssertionSignatureSigner(
+                keyStoreCredentialRetriever,
+                samlObjectFactory,
+                TestEntityIds.HUB_ENTITY_ID);
+    }
+
+    @Test
+    public void decorate_shouldSetSignatureOnAssertionIssuedByTheHub() {
+        Credential hubSigningCredential = createHubSigningCredential();
+        when(keyStoreCredentialRetriever.getSigningCredential()).thenReturn(hubSigningCredential);
+        AttributeQuery inputAttributeQuery = anAttributeQueryWithHubSignature();
+
+        AttributeQuery attributeQuery = assertionSignatureSigner.signAssertions(inputAttributeQuery);
+
+        final Credential assertionSigningCredential = getAssertionSigningCredential(attributeQuery);
+        assertThat(assertionSigningCredential).isSameAs(hubSigningCredential);
+        verify(keyStoreCredentialRetriever, times(1)).getSigningCredential();
+        verifyNoMoreInteractions(keyStoreCredentialRetriever);
+    }
+
+    private Credential createHubSigningCredential() {
+        return new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT, toBase64Encoded(
+                new PrivateKeyStoreFactory().create(TestEntityIds.HUB_ENTITY_ID).getSigningPrivateKey()
+                        .getEncoded()
+        )).getSigningCredential();
+    }
+
+    private Credential getAssertionSigningCredential(final AttributeQuery attributeQuery) {
+        Assertion cycle3DatasetAssertion = (Assertion) attributeQuery.getSubject().getSubjectConfirmations().get(0).getSubjectConfirmationData().getUnknownXMLObjects(Assertion.TYPE_NAME).get(0);
+        return cycle3DatasetAssertion.getSignature().getSigningCredential();
+    }
+
+    private AttributeQuery anAttributeQueryWithHubSignature() {
+        return anAttributeQuery()
+                .withSubject(
+                        aSubject()
+                                .withSubjectConfirmation(
+                                        aSubjectConfirmation()
+                                                .withSubjectConfirmationData(
+                                                        aSubjectConfirmationData()
+                                                                .addAssertion(
+                                                                        unencyptedCycle3DatasetAssertion()
+                                                                ).build()
+                                                ).build()
+                                ).build()
+                ).build();
+    }
+
+    private Assertion unencyptedCycle3DatasetAssertion() {
+        return anAssertion()
+                .withIssuer(
+                        hubIssuer()
+                )
+                .addAttributeStatement(
+                        anAttributeStatement()
+                                .addAttribute(
+                                        aSimpleStringAttribute()
+                                                .withName(
+                                                        "NINO"
+                                                )
+                                                .withSimpleStringValue(
+                                                        "MyNINO"
+                                                )
+                                                .build()
+                                )
+                                .build()
+                )
+                .buildUnencrypted();
+    }
+
+    private Issuer hubIssuer() {
+        return anIssuer().withIssuerId(TestEntityIds.HUB_ENTITY_ID).build();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SigningRequestAbstractTypeSignatureCreatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SigningRequestAbstractTypeSignatureCreatorTest.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.saml.hub.transformers.outbound.decorators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.AttributeQuery;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.saml.security.SignatureFactory;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SigningRequestAbstractTypeSignatureCreatorTest {
+
+    private SigningRequestAbstractTypeSignatureCreator<AttributeQuery> signatureCreator;
+    @Mock
+    private SignatureFactory signatureFactory;
+    private static final String id = "response-id";
+    @Before
+    public void setup() {
+        String id = "response-id";
+        signatureCreator = new SigningRequestAbstractTypeSignatureCreator<>(signatureFactory);
+    }
+
+    @Test
+    public void decorate_shouldGetSignatureAndAssignIt() {
+        AttributeQuery response = mock(AttributeQuery.class);
+        Issuer issuer = mock(Issuer.class);
+        String issuerId = "some-issuer-id";
+        when(issuer.getValue()).thenReturn(issuerId);
+        when(response.getIssuer()).thenReturn(issuer);
+        when(response.getID()).thenReturn(id);
+
+        signatureCreator.addUnsignedSignatureTo(response);
+
+        verify(signatureFactory).createSignature(id);
+    }
+
+    @Test
+    public void decorate_shouldAssignSignatureToResponse() {
+        AttributeQuery response = mock(AttributeQuery.class);
+        Signature signature = mock(Signature.class);
+        when(response.getIssuer()).thenReturn(mock(Issuer.class));
+        when(response.getID()).thenReturn(id);
+        when(signatureFactory.createSignature(id)).thenReturn(signature);
+
+        signatureCreator.addUnsignedSignatureTo(response);
+
+        verify(response).setSignature(signature);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/StringEncoding.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/StringEncoding.java
@@ -1,0 +1,12 @@
+package uk.gov.ida.saml.hub.transformers.outbound.decorators;
+
+import org.apache.commons.codec.binary.Base64;
+
+import static org.apache.commons.codec.binary.StringUtils.newStringUtf8;
+
+public abstract class StringEncoding {
+
+    public static String toBase64Encoded(byte[] bytes) {
+        return newStringUtf8(Base64.encodeBase64(bytes));
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestFromTransactionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestFromTransactionValidatorTest.java
@@ -1,0 +1,267 @@
+package uk.gov.ida.saml.hub.validators.authnrequest;
+
+import io.dropwizard.util.Duration;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.NameIDType;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.hub.configuration.SamlAuthnRequestValidityDurationConfiguration;
+import uk.gov.ida.saml.hub.configuration.SamlDuplicateRequestValidationConfiguration;
+import uk.gov.ida.saml.hub.exception.SamlDuplicateRequestIdException;
+import uk.gov.ida.saml.hub.exception.SamlRequestTooOldException;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.IdaConstants.SAML_VERSION_NUMBER;
+import static uk.gov.ida.saml.core.test.AuthnRequestIdGenerator.generateRequestId;
+import static uk.gov.ida.saml.core.test.builders.AuthnRequestBuilder.anAuthnRequest;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.NameIdPolicyBuilder.aNameIdPolicy;
+import static uk.gov.ida.saml.core.test.builders.ScopingBuilder.aScoping;
+
+@RunWith(OpenSAMLRunner.class)
+public class AuthnRequestFromTransactionValidatorTest {
+
+    private AuthnRequestFromTransactionValidator validator;
+
+    @Before
+    public void setup() {
+        SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration = new SamlDuplicateRequestValidationConfiguration() {
+            @Override
+            public Duration getAuthnRequestIdExpirationDuration() {
+                return Duration.hours(2);
+            }
+        };
+        SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration = new SamlAuthnRequestValidityDurationConfiguration() {
+            @Override
+            public Duration getAuthnRequestValidityDuration() {
+                return Duration.minutes(5);
+            }
+        };
+        validator = new AuthnRequestFromTransactionValidator(
+                new IssuerValidator(),
+                new DuplicateAuthnRequestValidator(new ConcurrentHashMap<AuthnRequestIdKey, DateTime>(), samlDuplicateRequestValidationConfiguration),
+                new AuthnRequestIssueInstantValidator(samlAuthnRequestValidityDurationConfiguration)
+        );
+    }
+
+    @After
+    public void unfreezeTime() {
+        DateTimeFreezer.unfreezeTime();
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfIdIsInvalid() throws Exception {
+        validateThrows(
+                anAuthnRequest().withId("6135ce2c-fe0d-413a-9d12-2ae1063153bd").build(),
+                SamlTransformationErrorFactory.invalidRequestID()
+        );
+
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfIdIsValid() throws Exception {
+        validator.validate(anAuthnRequest().withId("a43qif88dsfv").build());
+
+        validator.validate(anAuthnRequest().withId("_443qif88dsfv").build());
+    }
+
+    @Test
+    public void validateRequest_shouldDoNothingIfRequestIsSigned() throws Exception {
+
+        validator.validate(anAuthnRequest().build());
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validateRequest_shouldThrowExceptionIfRequestDoesNotContainASignature() throws Exception {
+
+        validateThrows(
+                anAuthnRequest().withoutSignatureElement().build(),
+                SamlTransformationErrorFactory.missingSignature()
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validateRequest_shouldThrowExceptionIfRequestIsNotSigned() throws Exception {
+        validateThrows(
+                anAuthnRequest().withoutSigning().build(),
+                SamlTransformationErrorFactory.signatureNotSigned()
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validateIssuer_shouldThrowExceptionIfFormatAttributeHasInvalidValue() throws Exception {
+        String invalidFormat = "goo";
+
+        validateThrows(
+                anAuthnRequest().withIssuer(anIssuer().withFormat(invalidFormat).build()).build(),
+                SamlTransformationErrorFactory.illegalIssuerFormat(invalidFormat, NameIDType.ENTITY)
+        );
+    }
+
+    @Test
+    public void validateIssuer_shouldDoNothingIfFormatAttributeIsMissing() throws Exception {
+        validator.validate(anAuthnRequest().withIssuer(anIssuer().withFormat(null).build()).build());
+
+    }
+
+    @Test
+    public void validateIssuer_shouldDoNothingIfFormatAttributeHasValidValue() throws Exception {
+        validator.validate(anAuthnRequest().withIssuer(anIssuer().withFormat(NameIDType.ENTITY).build()).build());
+
+    }
+
+    @Test
+    public void validateNameIdPolicy_shouldDoNothingIfNameIdPolicyIsMissing() throws Exception {
+        validator.validate(anAuthnRequest().build());
+
+    }
+
+    @Test
+    public void validateNameIdPolicy_shouldDoNothingIfNameIdPolicyFormatHasValidValue() throws Exception {
+        validator.validate(anAuthnRequest().withNameIdPolicy(aNameIdPolicy().withFormat(NameIDType.PERSISTENT).build()).build());
+
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validateRequest_shouldThrowExceptionIfScopingIsPresent() throws Exception {
+        validateThrows(
+                anAuthnRequest().withScoping(aScoping().build()).build(),
+                SamlTransformationErrorFactory.scopingNotAllowed()
+        );
+    }
+
+    @Test
+    public void validateProtocolBinding_shouldDoNothingIfProtocolBindingHasValidValue() throws Exception {
+        validator.validate(anAuthnRequest().withProtocolBinding(SAMLConstants.SAML2_POST_BINDING_URI).build());
+
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validateProtocolBinding_shouldThrowExceptionIfProtocolBindingHasInvalidValue() throws Exception {
+        String invalidValue = "goo";
+        validateThrows(
+                anAuthnRequest().withProtocolBinding(invalidValue).build(),
+                SamlTransformationErrorFactory.illegalProtocolBindingError(invalidValue, SAMLConstants.SAML2_POST_BINDING_URI)
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validateRequest_shouldThrowExceptionIfIsPassiveIsPresent() throws Exception {
+        validateThrows(
+                anAuthnRequest().withIsPassive(true).build(),
+                SamlTransformationErrorFactory.isPassiveNotAllowed()
+        );
+    }
+
+    @Test(expected = SamlDuplicateRequestIdException.class)
+    public void validateRequest_shouldThrowExceptionIfIsDuplicateRequestIdIsPresent() throws Exception {
+        final String requestId = generateRequestId();
+        final String oneIssuerId = "some-issuer-id";
+        final String anotherIssuerId = "some-other-issuer-id";
+        final AuthnRequest authnRequest = anAuthnRequest().withId(requestId).withIssuer(anIssuer().withIssuerId(oneIssuerId).build()).build();
+
+        validator.validate(authnRequest);
+
+        final AuthnRequest duplicateIdAuthnRequest = anAuthnRequest().withId(requestId).withIssuer(anIssuer().withIssuerId(anotherIssuerId).build()).build();
+        validateThrows(
+                duplicateIdAuthnRequest,
+                SamlTransformationErrorFactory.duplicateRequestId(requestId, duplicateIdAuthnRequest.getIssuer().getValue())
+        );
+    }
+
+    @Test(expected = SamlRequestTooOldException.class)
+    public void validateRequest_shouldThrowExceptionIfRequestIsTooOld() throws Exception {
+        DateTimeFreezer.freezeTime();
+
+        String requestId = generateRequestId();
+        DateTime issueInstant = DateTime.now().minusMinutes(5).minusSeconds(1);
+
+        final AuthnRequest authnRequest = anAuthnRequest().withId(requestId).withIssueInstant(issueInstant).build();
+
+        SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.requestTooOld(requestId, issueInstant.withZone(DateTimeZone.UTC), DateTime.now());
+
+        validateThrows(
+                authnRequest,
+                failure
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+        validateThrows(
+                anAuthnRequest().withId(null).build(),
+                SamlTransformationErrorFactory.missingRequestId()
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfIssuerElementIsMissing() throws Exception {
+        validateThrows(
+                anAuthnRequest().withIssuer(null).build(),
+                SamlTransformationErrorFactory.missingIssuer()
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfIssuerIdIsMissing() throws Exception {
+        validateThrows(
+                anAuthnRequest().withIssuer(anIssuer().withIssuerId(null).build()).build(),
+                SamlTransformationErrorFactory.emptyIssuer()
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
+        AuthnRequest authnRequest = anAuthnRequest().withIssueInstant(null).build();
+        validateThrows(
+                authnRequest,
+                SamlTransformationErrorFactory.missingRequestIssueInstant(authnRequest.getID())
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfVersionNumberIsMissing() throws Exception {
+        AuthnRequest authnRequest = anAuthnRequest().withVersionNumber(null).build();
+
+        validateThrows(
+                authnRequest,
+                SamlTransformationErrorFactory.missingRequestVersion(authnRequest.getID())
+        );
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfVersionNumberIsNotTwoPointZero() throws Exception {
+        validateThrows(
+                anAuthnRequest().withVersionNumber("1.0").build(),
+                SamlTransformationErrorFactory.illegalRequestVersionNumber()
+        );
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfVersionNumberIsTwoPointZero() throws Exception {
+        validator.validate(anAuthnRequest().withVersionNumber(SAML_VERSION_NUMBER).build());
+    }
+
+    private void validateThrows(AuthnRequest authnRequest, SamlValidationSpecificationFailure samlValidationSpecificationFailure) {
+        try {
+            validator.validate(authnRequest);
+        } catch (SamlTransformationErrorException e) {
+            assertThat(e.getMessage()).isEqualTo(samlValidationSpecificationFailure.getErrorMessage());
+            assertThat(e.getLogLevel()).isEqualTo(samlValidationSpecificationFailure.getLogLevel());
+            throw e;
+        }
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIssueInstantValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIssueInstantValidatorTest.java
@@ -1,0 +1,66 @@
+package uk.gov.ida.saml.hub.validators.authnrequest;
+
+import io.dropwizard.util.Duration;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.ida.saml.hub.configuration.SamlAuthnRequestValidityDurationConfiguration;
+import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthnRequestIssueInstantValidatorTest {
+
+    AuthnRequestIssueInstantValidator authnRequestIssueInstantValidator = null;
+    private final int AUTHN_REQUEST_VALIDITY_MINS = 5;
+
+    @Before
+    public void setup() {
+        SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration = new SamlAuthnRequestValidityDurationConfiguration() {
+            @Override
+            public Duration getAuthnRequestValidityDuration() {
+                return Duration.minutes(AUTHN_REQUEST_VALIDITY_MINS);
+            }
+        };
+
+        authnRequestIssueInstantValidator = new AuthnRequestIssueInstantValidator(samlAuthnRequestValidityDurationConfiguration);
+    }
+    @After
+    public void unfreezeTime() {
+        DateTimeFreezer.unfreezeTime();
+    }
+
+    @Test
+    public void validate_shouldReturnFalseIfIssueInstantMoreThan5MinutesAgo() {
+        DateTimeFreezer.freezeTime();
+
+        DateTime issueInstant = DateTime.now().minusMinutes(AUTHN_REQUEST_VALIDITY_MINS).minusSeconds(1);
+
+        boolean validity = authnRequestIssueInstantValidator.isValid(issueInstant);
+
+        assertThat(validity).isEqualTo(false);
+    }
+
+    @Test
+    public void validate_shouldReturnTrueIfIssueInstant5MinsAgo() {
+        DateTimeFreezer.freezeTime();
+
+        DateTime issueInstant = DateTime.now().minusMinutes(AUTHN_REQUEST_VALIDITY_MINS);
+
+        boolean validity = authnRequestIssueInstantValidator.isValid(issueInstant);
+
+        assertThat(validity).isEqualTo(true);
+    }
+
+    @Test
+    public void validate_shouldReturnTrueIfIssueInstantLessThan5MinsAgo() {
+        DateTimeFreezer.freezeTime();
+
+        DateTime issueInstant = DateTime.now().minusMinutes(AUTHN_REQUEST_VALIDITY_MINS).plusSeconds(1);
+
+        boolean validity = authnRequestIssueInstantValidator.isValid(issueInstant);
+
+        assertThat(validity).isEqualTo(true);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidatorTest.java
@@ -1,0 +1,85 @@
+package uk.gov.ida.saml.hub.validators.authnrequest;
+
+import io.dropwizard.util.Duration;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.hub.configuration.SamlDuplicateRequestValidationConfiguration;
+import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class DuplicateAuthnRequestValidatorTest {
+
+    private DuplicateAuthnRequestValidator duplicateAuthnRequestValidator;
+    private final int EXPIRATION_HOURS = 2;
+
+    @Before
+    public void initialiseTestSubject() {
+        SamlDuplicateRequestValidationConfiguration samlEngineConfiguration = new SamlDuplicateRequestValidationConfiguration() {
+            @Override
+            public Duration getAuthnRequestIdExpirationDuration() {
+                return Duration.hours(EXPIRATION_HOURS);
+            }
+        };
+        ConcurrentMap<AuthnRequestIdKey, DateTime> duplicateIds = new ConcurrentHashMap<>();
+        duplicateAuthnRequestValidator = new DuplicateAuthnRequestValidator(duplicateIds, samlEngineConfiguration);
+    }
+
+    @Before
+    public void freezeTime() {
+        DateTimeFreezer.freezeTime();
+    }
+
+    @After
+    public void unfreezeTime() {
+        DateTimeFreezer.unfreezeTime();
+    }
+
+    @Test
+    public void valid_shouldThrowAnExceptionIfTheAuthnRequestIsADuplicateOfAPreviousOne() throws Exception {
+        final String duplicateRequestId = "duplicate-id";
+        duplicateAuthnRequestValidator.valid(duplicateRequestId);
+
+        boolean isValid = duplicateAuthnRequestValidator.valid(duplicateRequestId);
+        assertThat(isValid).isEqualTo(false);
+    }
+
+    @Test
+    public void valid_shouldPassIfTheAuthnRequestIsNotADuplicateOfAPreviousOne() throws Exception {
+        duplicateAuthnRequestValidator.valid("some-request-id");
+
+        boolean isValid = duplicateAuthnRequestValidator.valid("another-request-id");
+        assertThat(isValid).isEqualTo(true);
+    }
+
+
+    @Test
+    public void valid_shouldPassIfTwoAuthnRequestsHaveTheSameIdButTheFirstAssertionHasExpired() throws Exception {
+        final String duplicateRequestId = "duplicate-id";
+        duplicateAuthnRequestValidator.valid(duplicateRequestId);
+
+        DateTimeFreezer.freezeTime(DateTime.now().plusHours(EXPIRATION_HOURS).plusMinutes(1));
+
+        boolean isValid = duplicateAuthnRequestValidator.valid(duplicateRequestId);
+        assertThat(isValid).isEqualTo(true);
+    }
+
+    @Test
+    public void valid_shouldFailIfAuthnRequestsReceivedWithSameIdAndFirstIdHasNotExpired() throws Exception {
+        final String duplicateRequestId = "duplicate-id";
+        duplicateAuthnRequestValidator.valid(duplicateRequestId);
+
+        DateTimeFreezer.freezeTime(DateTime.now().plusHours(EXPIRATION_HOURS).minusMinutes(1));
+
+        boolean isValid = duplicateAuthnRequestValidator.valid(duplicateRequestId);
+        assertThat(isValid).isEqualTo(false);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/helpers/ResponseValidatorTestHelper.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/helpers/ResponseValidatorTestHelper.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.hub.validators.response.helpers;
+
+import org.assertj.core.util.Strings;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.test.builders.ResponseBuilder;
+import uk.gov.ida.saml.core.test.builders.StatusCodeBuilder;
+
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+
+public class ResponseValidatorTestHelper {
+    public static StatusCode createSubStatusCode() {
+        return createSubStatusCode(null);
+    }
+
+    public static StatusCode createSubStatusCode(String subStatusCodeValue) {
+        StatusCodeBuilder subStatusCodeBuilder = aStatusCode();
+
+        return Strings.isNullOrEmpty(subStatusCodeValue)
+            ? subStatusCodeBuilder.build()
+            : subStatusCodeBuilder.withValue(subStatusCodeValue).build();
+    }
+
+    public static Status createStatus(String statusCodeValue) {
+        return createStatus(statusCodeValue, null);
+    }
+
+    public static Status createStatus(String statusCodeValue, StatusCode subStatusCode) {
+        StatusCodeBuilder statusCodeBuilder = aStatusCode().withValue(statusCodeValue);
+
+        StatusCode statusCode = subStatusCode == null
+            ? statusCodeBuilder.build()
+            : statusCodeBuilder.withSubStatusCode(subStatusCode).build();
+
+        return aStatus().withStatusCode(statusCode).build();
+    }
+
+    public static ResponseBuilder getResponseBuilderWithTwoAssertions() {
+        return aResponse()
+            .addEncryptedAssertion(anAssertion().build())
+            .addEncryptedAssertion(anAssertion().build());
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidatorTest.java
@@ -1,0 +1,88 @@
+package uk.gov.ida.saml.hub.validators.response.idp;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import uk.gov.ida.saml.core.validators.DestinationValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdpResponseValidatorTest {
+
+    @Mock
+    private SamlResponseSignatureValidator samlResponseSignatureValidator;
+    @Mock
+    private AssertionDecrypter assertionDecrypter;
+    @Mock
+    private SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+    @Mock
+    private EncryptedResponseFromIdpValidator encryptedResponseFromIdpValidator;
+    @Mock
+    private DestinationValidator responseDestinationValidator;
+    @Mock
+    private ResponseAssertionsFromIdpValidator responseAssertionsFromIdpValidator;
+    @Mock
+    private Response response;
+
+    private IdpResponseValidator validator;
+
+    @Before
+    public void setUp() {
+        validator = new IdpResponseValidator(
+            samlResponseSignatureValidator,
+            assertionDecrypter,
+            samlAssertionsSignatureValidator,
+            encryptedResponseFromIdpValidator,
+            responseDestinationValidator,
+            responseAssertionsFromIdpValidator);
+    }
+
+    @Test
+    public void shouldValidateResponseIsEncrypted() {
+        validator.validate(response);
+        verify(encryptedResponseFromIdpValidator).validate(response);
+    }
+
+    @Test
+    public void shouldValidateResponseDestination() {
+        validator.validate(response);
+        verify(responseDestinationValidator).validate(response.getDestination());
+    }
+
+    @Test
+    public void shouldValidateSamlResponseSignature() {
+        validator.validate(response);
+        verify(samlResponseSignatureValidator).validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+    @Test
+    public void shouldValidateSamlAssertionSignature() {
+        Assertion assertion = mock(Assertion.class);
+        List<Assertion> assertions = ImmutableList.of(assertion);
+        ValidatedResponse validatedResponse = mock(ValidatedResponse.class);
+
+        when(samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME)).thenReturn(validatedResponse);
+        when(assertionDecrypter.decryptAssertions(validatedResponse)).thenReturn(assertions);
+
+        validator.validate(response);
+
+        verify(samlAssertionsSignatureValidator).validate(assertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidatorTest.java
@@ -1,0 +1,239 @@
+package uk.gov.ida.saml.hub.validators.response.idp.components;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.*;
+import static uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper.validateFail;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+import static uk.gov.ida.saml.hub.validators.response.helpers.ResponseValidatorTestHelper.createStatus;
+import static uk.gov.ida.saml.hub.validators.response.helpers.ResponseValidatorTestHelper.createSubStatusCode;
+import static uk.gov.ida.saml.hub.validators.response.helpers.ResponseValidatorTestHelper.getResponseBuilderWithTwoAssertions;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class EncryptedResponseFromIdpValidatorTest {
+
+    private EncryptedResponseFromIdpValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new EncryptedResponseFromIdpValidator(new SamlStatusToIdpIdaStatusMappingsFactory());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+        Response response = aResponse().withId(null).build();
+
+        assertValidationFailure(response, missingId());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIssuerElementIsMissing() throws Exception {
+        Response response = aResponse().withIssuer(null).build();
+
+        assertValidationFailure(response, missingIssuer());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIssuerIdIsMissing() throws Exception {
+        Issuer issuer = anIssuer().withIssuerId(null).build();
+        Response response = aResponse().withIssuer(issuer).build();
+
+        assertValidationFailure(response, emptyIssuer());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIssueInstantIsMissing() throws Exception {
+        String responseId = "test";
+        Response response = aResponse().withId(responseId).withIssueInstant(null).build();
+
+        assertValidationFailure(response, missingIssueInstant(responseId));
+    }
+
+    @Test
+    public void validateRequest_shouldNotErrorIfRequestIsSigned() throws Exception {
+        Response response = getResponseBuilderWithTwoAssertions().build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateRequest_shouldThrowExceptionIfResponseDoesNotContainASignature() throws Exception {
+        Response response = aResponse().withoutSignatureElement().build();
+
+        assertValidationFailure(response, missingSignature());
+    }
+
+    @Test
+    public void validateRequest_shouldThrowExceptionIfResponseIsNotSigned() throws Exception {
+        Response response = aResponse().withoutSigning().build();
+
+        assertValidationFailure(response, signatureNotSigned());
+    }
+
+    @Test
+    public void validateIssuer_shouldThrowExceptionIfFormatAttributeHasInvalidValue() throws Exception {
+        String invalidFormat = "goo";
+        Issuer issuer = anIssuer().withFormat(invalidFormat).build();
+        Response response = aResponse().withIssuer(issuer).build();
+
+        assertValidationFailure(response, illegalIssuerFormat(
+            invalidFormat,
+            NameIDType.ENTITY
+        ));
+    }
+
+    @Test
+    public void validateIssuer_shouldNotErrorIfFormatAttributeIsMissing() throws Exception {
+        Issuer issuer = anIssuer().withFormat(null).build();
+        Response response = getResponseBuilderWithTwoAssertions().withIssuer(issuer).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateIssuer_shouldNotErrorIfFormatAttributeHasValidValue() throws Exception {
+        Issuer issuer = anIssuer().withFormat(NameIDType.ENTITY).build();
+        Response response = getResponseBuilderWithTwoAssertions().withIssuer(issuer).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionIfResponseHasUnencryptedAssertion() throws Exception {
+        Response response = aResponse().addAssertion(anAssertion().buildUnencrypted()).build();
+
+        assertValidationFailure(response, SamlTransformationErrorFactory.unencryptedAssertion());
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionForSuccessResponsesWithNoAssertions() throws Exception {
+        Response response = aResponse().withNoDefaultAssertion().build();
+
+        assertValidationFailure(response, SamlTransformationErrorFactory.missingSuccessUnEncryptedAssertions());
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionForFailureResponsesWithAssertions() throws Exception {
+        Status status = createStatus(StatusCode.RESPONDER, createSubStatusCode(StatusCode.AUTHN_FAILED));
+        Response response = aResponse().withStatus(status).build();
+
+        assertValidationFailure(response, nonSuccessHasUnEncryptedAssertions());
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionIfThereIsNoInResponseToAttribute() throws Exception {
+        Response response = aResponse().withInResponseTo(null).build();
+
+        assertValidationFailure(response, SamlTransformationErrorFactory.missingInResponseTo());
+    }
+
+    @Test
+    public void validateStatus_shouldNotErrorIfStatusIsResponderWithSubStatusAuthnFailed() throws Exception {
+        Status status = createStatus(StatusCode.RESPONDER, createSubStatusCode(StatusCode.AUTHN_FAILED));
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateStatus_shouldNotErrorIfStatusIsResponderWithSubStatusNoAuthnContext() throws Exception {
+        Status status = createStatus(StatusCode.RESPONDER, createSubStatusCode(StatusCode.NO_AUTHN_CONTEXT));
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateStatus_shouldNotErrorIfStatusIsRequesterWithNoSubStatus() throws Exception {
+        Status status = createStatus(StatusCode.REQUESTER);
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateStatus_shouldNotErrorIfStatusIsSuccessWithNoSubStatus() throws Exception {
+        Status status = createStatus(StatusCode.SUCCESS);
+        Response response = getResponseBuilderWithTwoAssertions().withStatus(status).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateStatus_shouldThrowExceptionIfTheStatusIsInvalid() throws Exception {
+        String anInvalidStatusCode = "This is wrong";
+        Status status = createStatus(anInvalidStatusCode);
+        Response response = aResponse().withStatus(status).build();
+
+        assertValidationFailure(response, invalidStatusCode(anInvalidStatusCode));
+    }
+
+    @Test
+    public void validateStatus_shouldThrowExceptionIfSuccessHasASubStatus() throws Exception {
+        StatusCode subStatusCode = createSubStatusCode();
+        Status status = createStatus(StatusCode.SUCCESS, subStatusCode);
+        Response response = aResponse().withStatus(status).build();
+
+        assertValidationFailure(response, invalidSubStatusCode(subStatusCode.getValue(), StatusCode.SUCCESS));
+    }
+
+    @Test
+    public void validateStatus_shouldThrowExceptionIfRequesterHasASubStatus() throws Exception {
+        StatusCode subStatusCode = createSubStatusCode();
+        Status status = createStatus(StatusCode.REQUESTER, subStatusCode);
+        Response response = aResponse().withStatus(status).build();
+
+        assertValidationFailure(response, invalidSubStatusCode(subStatusCode.getValue(), StatusCode.REQUESTER));
+    }
+
+    @Test
+    public void validateStatus_shouldThrowExceptionIfAuthnFailedHasASubSubStatus() throws Exception {
+        StatusCode subStatusCode = aStatusCode()
+            .withValue(StatusCode.AUTHN_FAILED)
+            .withSubStatusCode(createSubStatusCode())
+            .build();
+
+        Status status = createStatus(StatusCode.RESPONDER, subStatusCode);
+        Response response = aResponse().withStatus(status).build();
+
+        assertValidationFailure(response, nestedSubStatusCodesBreached(1));
+    }
+
+    @Test
+    public void validate_shouldThrowIfResponseContainsTooManyAssertions() throws Exception {
+        EncryptedAssertion assertion = anAssertion().build();
+        Response response = getResponseBuilderWithTwoAssertions().addEncryptedAssertion(assertion).build();
+
+        assertValidationFailure(response, unexpectedNumberOfAssertions(2, 3));
+    }
+
+    @Test
+    public void validate_shouldThrowIfResponseContainsTooFewAssertions() throws Exception {
+        EncryptedAssertion assertion = anAssertion().build();
+        Response response = aResponse().addEncryptedAssertion(assertion).build();
+
+        assertValidationFailure(response, unexpectedNumberOfAssertions(2, 1));
+    }
+
+    private void assertValidationFailure(Response response, SamlValidationSpecificationFailure failure) {
+        validateFail(() -> validator.validate(response), failure);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/components/ResponseAssertionsFromIdpValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/components/ResponseAssertionsFromIdpValidatorTest.java
@@ -1,0 +1,143 @@
+package uk.gov.ida.saml.hub.validators.response.idp.components;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validators.assertion.AuthnStatementAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.IPAddressValidator;
+import uk.gov.ida.saml.core.validators.assertion.IdentityProviderAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.MatchingDatasetAssertionValidator;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.MatchingDatasetAttributeStatementBuilder_1_1.aMatchingDatasetAttributeStatement_1_1;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class ResponseAssertionsFromIdpValidatorTest {
+
+    @Mock
+    private IdentityProviderAssertionValidator assertionValidator;
+    @Mock
+    private MatchingDatasetAssertionValidator matchingDatasetAssertionValidator;
+    @Mock
+    private AuthnStatementAssertionValidator authnStatementValidator;
+    @Mock
+    private IPAddressValidator ipAddressValidator;
+
+    private ResponseAssertionsFromIdpValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new ResponseAssertionsFromIdpValidator(
+                assertionValidator,
+                matchingDatasetAssertionValidator,
+                authnStatementValidator,
+                ipAddressValidator,
+                TestEntityIds.HUB_ENTITY_ID
+        );
+    }
+
+    @Test
+    public void validate_shouldDelegateAuthnStatementAssertionValidation() throws Exception {
+        Response response = aResponse()
+                .addEncryptedAssertion(anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).build())
+                .addEncryptedAssertion(anAssertion().build())
+                .build();
+        Assertion authNAssertion = anAssertion().buildUnencrypted();
+        Assertion mdsAssertion = anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).buildUnencrypted();
+        List<Assertion> assertions = asList(mdsAssertion, authNAssertion);
+
+        validator.validate(new ValidatedResponse(response), new ValidatedAssertions(assertions));
+
+        verify(authnStatementValidator).validate(authNAssertion);
+    }
+
+    @Test
+    public void validate_shouldDelegateMatchingDatasetAssertionValidation() throws Exception {
+        Response response = aResponse()
+                .addEncryptedAssertion(anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).build())
+                .addEncryptedAssertion(anAssertion().build())
+                .build();
+        Assertion authNAssertion = anAssertion().buildUnencrypted();
+        Assertion mdsAssertion = anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).buildUnencrypted();
+        List<Assertion> assertions = asList(mdsAssertion, authNAssertion);
+
+        validator.validate(new ValidatedResponse(response), new ValidatedAssertions(assertions));
+
+        verify(matchingDatasetAssertionValidator).validate(mdsAssertion, response.getIssuer().getValue());
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfMatchingDatasetStatementElementIsMissing() throws Exception {
+        final Response response = aResponse()
+                .addEncryptedAssertion(anAssertion().addAuthnStatement(anAuthnStatement().build()).build())
+                .addEncryptedAssertion(anAssertion().build()).build();
+        List<Assertion> assertions = asList(anAssertion().addAuthnStatement(anAuthnStatement().build()).buildUnencrypted(), anAssertion().buildUnencrypted());
+
+        validateThrows(response, assertions, SamlTransformationErrorFactory.missingMatchingMds());
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfAuthnStatementAssertionIsMissing() throws Exception {
+        Response response = aResponse()
+                .addEncryptedAssertion(anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).build())
+                .addEncryptedAssertion(anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).build())
+                .build();
+        List<Assertion> assertions = asList(
+                anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).buildUnencrypted(),
+                anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).buildUnencrypted()
+        );
+        validateThrows(response, assertions, SamlTransformationErrorFactory.missingAuthnStatement());
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfThereAreMultipleAuthnStatementsWithinTheAuthnStatementAssertionPresent() throws Exception {
+        Response response = aResponse()
+                .addEncryptedAssertion(anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).build())
+                .addEncryptedAssertion(anAssertion().addAuthnStatement(anAuthnStatement().build()).addAuthnStatement(anAuthnStatement().build()).build())
+                .build();
+        List<Assertion> assertions = asList(
+                anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).buildUnencrypted(),
+                anAssertion().addAuthnStatement(anAuthnStatement().build()).addAuthnStatement(anAuthnStatement().build()).buildUnencrypted()
+        );
+        validateThrows(response, assertions, SamlTransformationErrorFactory.multipleAuthnStatements());
+    }
+
+    @Test
+    public void validate_shouldDelegateToIpAddressValidator() throws Exception {
+        Assertion authnStatementAssertion = anAssertion().addAuthnStatement(anAuthnStatement().build()).buildUnencrypted();
+        Response response = aResponse()
+                .addEncryptedAssertion(anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).build())
+                .addEncryptedAssertion(anAssertion().addAuthnStatement(anAuthnStatement().build()).build())
+                .build();
+        List<Assertion> assertions = asList(anAssertion().addAttributeStatement(aMatchingDatasetAttributeStatement_1_1().build()).buildUnencrypted(), authnStatementAssertion);
+        validator.validate(new ValidatedResponse(response), new ValidatedAssertions(assertions));
+        verify(ipAddressValidator).validate(authnStatementAssertion);
+    }
+
+    private void validateThrows(Response response, List<Assertion> assertions, SamlValidationSpecificationFailure samlValidationSpecificationFailure) {
+        try {
+            validator.validate(new ValidatedResponse(response), new ValidatedAssertions(assertions));
+        } catch (SamlTransformationErrorException e) {
+            assertThat(e.getMessage()).isEqualTo(samlValidationSpecificationFailure.getErrorMessage());
+            assertThat(e.getLogLevel()).isEqualTo(samlValidationSpecificationFailure.getLogLevel());
+            throw e;
+        }
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/matchingservice/EncryptedResponseFromMatchingServiceValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/matchingservice/EncryptedResponseFromMatchingServiceValidatorTest.java
@@ -1,0 +1,204 @@
+package uk.gov.ida.saml.hub.validators.response.matchingservice;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.*;
+import static uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper.validateFail;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+import static uk.gov.ida.saml.hub.validators.response.helpers.ResponseValidatorTestHelper.createStatus;
+import static uk.gov.ida.saml.hub.validators.response.helpers.ResponseValidatorTestHelper.createSubStatusCode;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class EncryptedResponseFromMatchingServiceValidatorTest {
+
+    private Status happyStatus;
+
+    private EncryptedResponseFromMatchingServiceValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        happyStatus = createStatus(StatusCode.SUCCESS, createSubStatusCode(SamlStatusCode.MATCH));
+        validator = new EncryptedResponseFromMatchingServiceValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+        Response response = aResponse().withId(null).build();
+
+        assertValidationFailure(response, missingId());
+    }
+
+    @Test
+    public void validate_shouldThrowInvalidSamlExceptionIfIssuerElementIsMissing() throws Exception {
+        Response response = aResponse().withIssuer(null).build();
+
+        assertValidationFailure(response, missingIssuer());
+    }
+
+    @Test
+    public void validate_shouldThrowInvalidSamlExceptionIfIssuerIdIsMissing() throws Exception {
+        Issuer issuer = anIssuer().withIssuerId(null).build();
+        Response response = aResponse().withIssuer(issuer).build();
+
+        assertValidationFailure(response, emptyIssuer());
+    }
+
+    @Test
+    public void validateRequest_shouldDoNothingIfResponseIsSigned() throws Exception {
+        Response response = aResponse().withStatus(happyStatus).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateRequest_shouldThrowExceptionIfResponseDoesNotContainASignature() throws Exception {
+        Response response = aResponse().withoutSignatureElement().build();
+
+        assertValidationFailure(response, missingSignature());
+    }
+
+    @Test
+    public void validateRequest_shouldThrowExceptionIfResponseIsNotSigned() throws Exception {
+        Response response = aResponse().withoutSigning().build();
+
+        assertValidationFailure(response, signatureNotSigned());
+    }
+
+    @Test
+    public void validateIssuer_shouldThrowExceptionIfFormatAttributeHasInvalidValue() throws Exception {
+        String invalidFormat = "goo";
+        Response response = aResponse().withIssuer(anIssuer().withFormat(invalidFormat).build()).build();
+
+        assertValidationFailure(response, illegalIssuerFormat(invalidFormat, NameIDType.ENTITY));
+    }
+
+    @Test
+    public void validateIssuer_shouldDoNothingIfFormatAttributeIsMissing() throws Exception {
+        Issuer issuer = anIssuer().withFormat(null).build();
+        Response response = aResponse().withIssuer(issuer).withStatus(happyStatus).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateIssuer_shouldDoNothingIfFormatAttributeHasValidValue() throws Exception {
+        Issuer issuer = anIssuer().withFormat(NameIDType.ENTITY).build();
+        Response response = aResponse().withIssuer(issuer).withStatus(happyStatus).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionIfResponseHasUnencryptedAssertion() throws Exception {
+        Assertion assertion = anAssertion().buildUnencrypted();
+        Response response = aResponse().withStatus(happyStatus).addAssertion(assertion).build();
+
+        assertValidationFailure(response, unencryptedAssertion());
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionForSuccessResponsesWithNoAssertions() throws Exception {
+        Response response = aResponse().withStatus(happyStatus).withNoDefaultAssertion().build();
+
+        assertValidationFailure(response, missingSuccessUnEncryptedAssertions());
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionForFailureResponsesWithAssertions() throws Exception {
+        Status status = createStatus(StatusCode.RESPONDER, createSubStatusCode(SamlStatusCode.NO_MATCH));
+        Response response = aResponse().withStatus(status).build();
+
+        assertValidationFailure(response, nonSuccessHasUnEncryptedAssertions());
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionIfThereIsNoInResponseToAttribute() throws Exception {
+        Response response = aResponse().withInResponseTo(null).build();
+
+        assertValidationFailure(response, missingInResponseTo());
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSuccessResponseDoesNotContainSubStatusOfMatchOrNoMatchOrCreated() throws Exception {
+        Status status = createStatus(StatusCode.SUCCESS, createSubStatusCode(SamlStatusCode.MULTI_MATCH));
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        assertValidationFailure(response, subStatusMustBeOneOf("Success", "Match", "No Match", "Created"));
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfAResponderStatusContainsASubStatusOfNoMatch() throws Exception {
+        Status status = createStatus(StatusCode.RESPONDER, createSubStatusCode(SamlStatusCode.NO_MATCH));
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfASuccessStatusContainsASubStatusOfMatch() throws Exception {
+        Response response = aResponse().withStatus(happyStatus).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfASuccessStatusContainsASubStatusOfNoMatch() throws Exception {
+        Status status = createStatus(StatusCode.SUCCESS, createSubStatusCode(SamlStatusCode.NO_MATCH));
+        Response response = aResponse().withStatus(status).build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validate_shouldDoNothingIfAResponderStatusContainsASubStatusOfMultiMatch() throws Exception {
+        Status status = createStatus(StatusCode.RESPONDER, createSubStatusCode(SamlStatusCode.MULTI_MATCH));
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        validator.validate(response);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAResponderStatusContainsAnInvalidSubStatus() throws Exception {
+        Status status = createStatus(StatusCode.RESPONDER, createSubStatusCode("invalid, yo."));
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        assertValidationFailure(response, subStatusMustBeOneOf("Responder", "No Match", "Multi Match", "Create Failure"));
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubStatusIsNull() throws Exception {
+        Response response = aResponse().withStatus(createStatus(StatusCode.SUCCESS)).build();
+
+        assertValidationFailure(response, SamlTransformationErrorFactory.missingSubStatus());
+    }
+
+    @Test
+    public void validate_shouldThrowIfResponseContainsTooManyAssertions() throws Exception {
+        Response response = aResponse().withStatus(happyStatus)
+            .addEncryptedAssertion(anAssertion().build())
+            .addEncryptedAssertion(anAssertion().build())
+            .build();
+
+        assertValidationFailure(response, unexpectedNumberOfAssertions(1, 2));
+    }
+
+    private void assertValidationFailure(Response response, SamlValidationSpecificationFailure failure) {
+        validateFail(() -> validator.validate(response), failure);
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/matchingservice/HealthCheckResponseFromMatchingServiceValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/matchingservice/HealthCheckResponseFromMatchingServiceValidatorTest.java
@@ -1,0 +1,132 @@
+package uk.gov.ida.saml.hub.validators.response.matchingservice;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.domain.SamlStatusCode;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class HealthCheckResponseFromMatchingServiceValidatorTest {
+
+    private HealthCheckResponseFromMatchingServiceValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new HealthCheckResponseFromMatchingServiceValidator();
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfIdIsMissing() throws Exception {
+        Response response = aResponse().withId(null).build();
+
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.missingId(), response);
+    }
+
+    @Test
+    public void validate_shouldThrowInvalidSamlExceptionIfIssuerElementIsMissing() throws Exception {
+        Response response = aResponse().withIssuer(null).build();
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.missingIssuer(), response);
+    }
+
+    @Test
+    public void validate_shouldThrowInvalidSamlExceptionIfIssuerIdIsMissing() throws Exception {
+        Response response = aResponse().withIssuer(anIssuer().withIssuerId(null).build()).build();
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.emptyIssuer(), response);
+    }
+
+    @Test
+    public void validateRequest_shouldThrowExceptionIfResponseDoesNotContainASignature() throws Exception {
+        Response response = aResponse().withoutSignatureElement().build();
+
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.missingSignature(), response);
+    }
+
+    @Test
+    public void validateRequest_shouldThrowExceptionIfResponseIsNotSigned() throws Exception {
+        Response response = aResponse().withoutSigning().build();
+
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.signatureNotSigned(), response);
+    }
+
+    @Test
+    public void validateIssuer_shouldThrowExceptionIfFormatAttributeHasInvalidValue() throws Exception {
+        String invalidFormat = "goo";
+        Response response = aResponse().withIssuer(anIssuer().withFormat(invalidFormat).build()).build();
+
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.illegalIssuerFormat(invalidFormat, NameIDType.ENTITY), response);
+    }
+
+    @Test
+    public void validateResponse_shouldThrowExceptionIfThereIsNoInResponseToAttribute() throws Exception {
+        Response response = aResponse().withInResponseTo(null).build();
+
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.missingInResponseTo(), response);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSuccessResponseDoesNotContainSubStatusHealthy() throws Exception {
+        final String subStatusValue = "something-other-than-healthy";
+        Response response = buildResponseFromMatchingServiceWithStatusAndSubStatus(StatusCode.SUCCESS, subStatusValue);
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.invalidSubStatusCode(subStatusValue, StatusCode.SUCCESS), response);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfAResponderStatusIsNotSuccess() throws Exception {
+        final String statusValue = "some-invalid-status";
+        Response response = buildResponseFromMatchingServiceWithStatusAndSubStatus(statusValue, SamlStatusCode.HEALTHY);
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.invalidStatusCode(statusValue), response);
+    }
+
+    @Test
+    public void validate_shouldThrowExceptionIfSubStatusIsNull() throws Exception {
+        Response response =
+                aResponse().withStatus(
+                        aStatus().withStatusCode(
+                                aStatusCode().withValue(StatusCode.SUCCESS)
+                                        .build()
+                        ).build()
+                ).build();
+        assertValidationFailureSamlExceptionMessage(SamlTransformationErrorFactory.missingSubStatus(), response);
+    }
+
+    @Test
+    public void validateResponse_shouldDoNothingIfStatusIsRequesterErrorAndHasNoSubStatus() throws Exception {
+        Response response = aResponse().withNoDefaultAssertion().withStatus(
+                aStatus().withStatusCode(
+                        aStatusCode().withValue(StatusCode.REQUESTER).withSubStatusCode(null
+                        ).build()
+                ).build()
+        ).build();
+        validator.validate(response);
+    }
+
+    private Response buildResponseFromMatchingServiceWithStatusAndSubStatus(String status, String subStatus) throws Exception {
+        return
+                aResponse().withNoDefaultAssertion().withStatus(
+                        aStatus().withStatusCode(
+                                aStatusCode().withValue(status).withSubStatusCode(
+                                        aStatusCode().withValue(subStatus).build()
+                                ).build()
+                        ).build()
+                ).build();
+    }
+
+    private void assertValidationFailureSamlExceptionMessage(SamlValidationSpecificationFailure failure, final Response response) {
+        SamlTransformationErrorManagerTestHelper.validateFail(
+            () -> validator.validate(response),
+            failure
+        );
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/matchingservice/ResponseAssertionsFromMatchingServiceValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/matchingservice/ResponseAssertionsFromMatchingServiceValidatorTest.java
@@ -1,0 +1,81 @@
+package uk.gov.ida.saml.hub.validators.response.matchingservice;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.validators.assertion.IdentityProviderAssertionValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.BasicAssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
+import static uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder.anAuthnStatement;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class ResponseAssertionsFromMatchingServiceValidatorTest {
+
+    @Mock
+    private IdentityProviderAssertionValidator assertionValidator;
+
+    private ResponseAssertionsFromMatchingServiceValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new ResponseAssertionsFromMatchingServiceValidator(assertionValidator, TestEntityIds.HUB_ENTITY_ID);
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfAssertionDoesNotContainAnAuthnContext() throws Exception {
+        String requestId = "some-request-id";
+        final Response response = aResponse()
+                .withInResponseTo(requestId)
+                .build();
+        final Assertion assertion = anAssertion().addAuthnStatement(anAuthnStatement().withAuthnContext(null).build()).buildUnencrypted();
+
+        validateThrows(response, assertion, SamlTransformationErrorFactory.authnContextMissingError());
+    }
+
+    @Test(expected = SamlTransformationErrorException.class)
+    public void validate_shouldThrowExceptionIfAssertionDoesNotContainAnAuthnStatement() throws Exception {
+        String requestId = "some-request-id";
+        final Response response = aResponse()
+                .withInResponseTo(requestId)
+                .build();
+        validateThrows(response, anAssertion().buildUnencrypted(), SamlTransformationErrorFactory.missingAuthnStatement());
+    }
+
+    @Test
+    public void validate_shouldNotThrowExceptionIfResponseIsANoMatch() throws Exception {
+        String requestId = "some-request-id";
+        final Response response = aResponse()
+                .withStatus(aStatus().withStatusCode(aStatusCode().withValue(StatusCode.RESPONDER).build()).build())
+                .withInResponseTo(requestId)
+                .build();
+
+        validator.validate(new ValidatedResponse(response), new ValidatedAssertions(singletonList(anAssertion().buildUnencrypted())));
+    }
+
+    private void validateThrows(Response response, Assertion assertion, SamlValidationSpecificationFailure samlValidationSpecificationFailure) {
+        try {
+            validator.validate(new ValidatedResponse(response), new ValidatedAssertions(singletonList(assertion)));
+        } catch (SamlTransformationErrorException e) {
+            assertThat(e.getMessage()).isEqualTo(samlValidationSpecificationFailure.getErrorMessage());
+            assertThat(e.getLogLevel()).isEqualTo(samlValidationSpecificationFailure.getLogLevel());
+            throw e;
+        }
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStoreTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStoreTest.java
@@ -1,0 +1,88 @@
+package uk.gov.ida.saml.metadata;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import net.shibboleth.utilities.java.support.xml.BasicParserPool;
+import org.apache.xml.security.exceptions.Base64DecodingException;
+import org.apache.xml.security.utils.Base64;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
+import uk.gov.ida.saml.metadata.exceptions.HubEntityMissingException;
+import uk.gov.ida.saml.security.PublicKeyFactory;
+
+import java.io.ByteArrayInputStream;
+import java.net.URISyntaxException;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class HubMetadataPublicKeyStoreTest {
+    private static MetadataResolver metadataResolver;
+    private static MetadataResolver invalidMetadataResolver;
+    private static MetadataResolver emptyMetadataResolver;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        MetadataFactory metadataFactory = new MetadataFactory();
+        metadataResolver = initializeMetadata(metadataFactory.defaultMetadata());
+        invalidMetadataResolver = initializeMetadata(metadataFactory.expiredMetadata());
+        emptyMetadataResolver = initializeMetadata(metadataFactory.emptyMetadata());
+    }
+
+    private static MetadataResolver initializeMetadata(String xml) throws URISyntaxException, ComponentInitializationException {
+        AbstractReloadingMetadataResolver metadataResolver = new StringBackedMetadataResolver(xml);
+        BasicParserPool basicParserPool = new BasicParserPool();
+        basicParserPool.initialize();
+        metadataResolver.setParserPool(basicParserPool);
+        metadataResolver.setId("testResolver");
+        metadataResolver.setRequireValidMetadata(true);
+        metadataResolver.initialize();
+        return metadataResolver;
+    }
+
+    private static PublicKey getX509Key(String encodedCertificate) throws Base64DecodingException, CertificateException {
+        byte[] derValue = Base64.decode(encodedCertificate);
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        Certificate certificate = certificateFactory.generateCertificate(new ByteArrayInputStream(derValue));
+        return certificate.getPublicKey();
+    }
+
+    @Test
+    public void shouldReturnTheSigningPublicKeysForTheHub() throws Exception {
+        HubMetadataPublicKeyStore hubMetadataPublicKeyStore = new HubMetadataPublicKeyStore(metadataResolver, new PublicKeyFactory(), TestEntityIds.HUB_ENTITY_ID);
+        List<PublicKey> verifyingKeysForEntity = hubMetadataPublicKeyStore.getVerifyingKeysForEntity();
+        assertThat(verifyingKeysForEntity).containsOnly(getX509Key(TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT), getX509Key(TestCertificateStrings.HUB_TEST_SECONDARY_PUBLIC_SIGNING_CERT));
+    }
+
+    @Test
+    public void shouldErrorWhenMetadataIsInvalid() throws Exception {
+        HubMetadataPublicKeyStore hubMetadataPublicKeyStore = new HubMetadataPublicKeyStore(invalidMetadataResolver, new PublicKeyFactory(), TestEntityIds.HUB_ENTITY_ID);
+        try {
+            hubMetadataPublicKeyStore.getVerifyingKeysForEntity();
+            fail("we expected the HubEntityMissingException");
+        } catch(HubEntityMissingException e) {
+            assertThat(e).hasMessage("The HUB entity-id: \"https://signin.service.gov.uk\" could not be found in the metadata. Metadata could be expired, invalid, or missing entities");
+        }
+    }
+
+    @Test
+    public void shouldErrorWhenMetadataIsEmpty() throws Exception {
+        HubMetadataPublicKeyStore hubMetadataPublicKeyStore = new HubMetadataPublicKeyStore(emptyMetadataResolver, new PublicKeyFactory(), TestEntityIds.HUB_ENTITY_ID);
+        try {
+            hubMetadataPublicKeyStore.getVerifyingKeysForEntity();
+            fail("we expected the HubEntityMissingException");
+        } catch(HubEntityMissingException e) {
+            assertThat(e).hasMessage("The HUB entity-id: \"https://signin.service.gov.uk\" could not be found in the metadata. Metadata could be expired, invalid, or missing entities");
+        }
+    }
+
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStoreTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStoreTest.java
@@ -1,0 +1,126 @@
+package uk.gov.ida.saml.metadata;
+
+import com.google.common.base.Throwables;
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import net.shibboleth.utilities.java.support.xml.BasicParserPool;
+import org.apache.xml.security.exceptions.Base64DecodingException;
+import org.apache.xml.security.utils.Base64;
+import org.joda.time.DateTime;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensaml.core.config.InitializationException;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.xmlsec.signature.KeyInfo;
+import org.opensaml.xmlsec.signature.X509Certificate;
+import org.opensaml.xmlsec.signature.X509Data;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestEntityIds;
+import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.IdpSsoDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.KeyDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.KeyInfoBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.X509CertificateBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.X509DataBuilder;
+import uk.gov.ida.saml.metadata.exceptions.NoKeyConfiguredForEntityException;
+import uk.gov.ida.saml.metadata.test.factories.metadata.EntityDescriptorFactory;
+import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
+
+import java.io.ByteArrayInputStream;
+import java.net.URISyntaxException;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+import static com.google.common.base.Throwables.propagate;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IdpMetadataPublicKeyStoreTest {
+
+    private static MetadataResolver metadataResolver;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        metadataResolver = initializeMetadata();
+    }
+
+    private static MetadataResolver initializeMetadata() throws URISyntaxException {
+        try {
+            EntityDescriptorFactory descriptorFactory = new EntityDescriptorFactory();
+            String metadata = new MetadataFactory().metadata(asList(
+                    descriptorFactory.hubEntityDescriptor(),
+                    idpEntityDescriptor(TestEntityIds.STUB_IDP_ONE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT)
+            ));
+            InitializationService.initialize();
+            StringBackedMetadataResolver stringBackedMetadataResolver = new StringBackedMetadataResolver(metadata);
+            BasicParserPool basicParserPool = new BasicParserPool();
+            basicParserPool.initialize();
+            stringBackedMetadataResolver.setParserPool(basicParserPool);
+            stringBackedMetadataResolver.setMinRefreshDelay(14400000);
+            stringBackedMetadataResolver.setRequireValidMetadata(true);
+            stringBackedMetadataResolver.setId("testResolver");
+            stringBackedMetadataResolver.initialize();
+            return stringBackedMetadataResolver;
+        } catch (InitializationException | ComponentInitializationException e) {
+            throw propagate(e);
+        }
+    }
+
+    private static PublicKey getX509Key(String encodedCertificate) throws Base64DecodingException, CertificateException {
+        byte[] derValue = Base64.decode(encodedCertificate);
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        Certificate certificate = certificateFactory.generateCertificate(new ByteArrayInputStream(derValue));
+        return certificate.getPublicKey();
+    }
+
+    private static EntityDescriptor idpEntityDescriptor(String idpEntityId, String public_signing_certificate) {
+        KeyDescriptor keyDescriptor = buildKeyDescriptor(public_signing_certificate);
+        IDPSSODescriptor idpssoDescriptor = IdpSsoDescriptorBuilder.anIdpSsoDescriptor().addKeyDescriptor(keyDescriptor).withoutDefaultSigningKey().build();
+        try {
+            return EntityDescriptorBuilder.anEntityDescriptor()
+                    .withEntityId(idpEntityId)
+                    .withIdpSsoDescriptor(idpssoDescriptor)
+                    .withValidUntil(DateTime.now().plusWeeks(2))
+                    .withSignature(null)
+                    .withoutSigning()
+                    .setAddDefaultSpServiceDescriptor(false)
+                    .build();
+        } catch (MarshallingException | SignatureException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private static KeyDescriptor buildKeyDescriptor(String certificate) {
+        X509Certificate x509Certificate = X509CertificateBuilder.aX509Certificate().withCert(certificate).build();
+        X509Data build = X509DataBuilder.aX509Data().withX509Certificate(x509Certificate).build();
+        KeyInfo signing_one = KeyInfoBuilder.aKeyInfo().withKeyName("signing_one").withX509Data(build).build();
+        return KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(signing_one).build();
+    }
+
+    @Test
+    public void shouldReturnTheSigningKeysForAnEntity() throws Exception {
+        IdpMetadataPublicKeyStore idpMetadataPublicKeyStore = new IdpMetadataPublicKeyStore(metadataResolver);
+
+        PublicKey expectedPublicKey = getX509Key(TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT);
+        assertThat(idpMetadataPublicKeyStore.getVerifyingKeysForEntity(TestEntityIds.STUB_IDP_ONE)).containsExactly(expectedPublicKey);
+    }
+
+    @Test(expected = NoKeyConfiguredForEntityException.class)
+    public void shouldRaiseAnExceptionWhenThereIsNoEntityDescriptor() throws Exception {
+        IdpMetadataPublicKeyStore idpMetadataPublicKeyStore = new IdpMetadataPublicKeyStore(metadataResolver);
+        idpMetadataPublicKeyStore.getVerifyingKeysForEntity("my-invented-entity-id");
+    }
+
+    @Test(expected = NoKeyConfiguredForEntityException.class)
+    public void shouldRaiseAnExceptionWhenAttemptingToRetrieveAnSPSSOFromMetadata() throws Exception {
+        IdpMetadataPublicKeyStore idpMetadataPublicKeyStore = new IdpMetadataPublicKeyStore(metadataResolver);
+        idpMetadataPublicKeyStore.getVerifyingKeysForEntity("https://signin.service.gov.uk");
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/HubIdentityProviderMetadataDtoToEntityDescriptorTransformerTest.java
@@ -1,0 +1,91 @@
+package uk.gov.ida.saml.metadata.transformers;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.xmlsec.signature.KeyInfo;
+import org.opensaml.xmlsec.signature.KeyName;
+import org.opensaml.xmlsec.signature.X509Certificate;
+import org.opensaml.xmlsec.signature.X509Data;
+import uk.gov.ida.common.shared.security.Certificate;
+import uk.gov.ida.common.shared.security.IdGenerator;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.core.test.builders.metadata.IdentityProviderMetadataDtoBuilder;
+
+import java.util.List;
+import java.util.UUID;
+
+import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
+
+@RunWith(OpenSAMLRunner.class)
+public class HubIdentityProviderMetadataDtoToEntityDescriptorTransformerTest {
+
+    private HubIdentityProviderMetadataDtoToEntityDescriptorTransformer transformer;
+
+    @Before
+    public void setUp() throws Exception {
+        OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
+        transformer = new HubIdentityProviderMetadataDtoToEntityDescriptorTransformer(openSamlXmlObjectFactory, new KeyDescriptorsUnmarshaller(openSamlXmlObjectFactory), new IdGenerator());
+    }
+
+    @Test
+    public void transform_shouldTransformIdpSigningCertificates() throws Exception {
+        String idpOneIssuerId = UUID.randomUUID().toString();
+        String idpTwoIssuerId = UUID.randomUUID().toString();
+        final Certificate idpCertOne = aCertificate().withIssuerId(idpOneIssuerId).build();
+        final Certificate idpCertTwo = aCertificate().withIssuerId(idpTwoIssuerId).build();
+
+        final EntityDescriptor result = transformer.apply(IdentityProviderMetadataDtoBuilder.anIdentityProviderMetadataDto().addIdpSigningCertificate(idpCertOne).addIdpSigningCertificate(idpCertTwo).build());
+
+        final List<KeyDescriptor> keyDescriptors = result.getIDPSSODescriptor(SAMLConstants.SAML20P_NS).getKeyDescriptors();
+        Assertions.assertThat(keyDescriptors.size()).isEqualTo(4);
+
+        assertCertificateCorrect(keyDescriptors.get(1), idpOneIssuerId, idpCertOne);
+        assertCertificateCorrect(keyDescriptors.get(2), idpTwoIssuerId, idpCertTwo);
+    }
+
+    @Test
+    public void transform_shouldTransformHubEncryptionCertificate() throws Exception {
+        final Certificate encryptionCert = aCertificate().withKeyUse(Certificate.KeyUse.Encryption).build();
+
+        final EntityDescriptor result = transformer.apply(IdentityProviderMetadataDtoBuilder.anIdentityProviderMetadataDto()
+                .withHubEncryptionCertificate(encryptionCert)
+                .build());
+
+        final List<KeyDescriptor> keyDescriptors = result.getIDPSSODescriptor(SAMLConstants.SAML20P_NS).getKeyDescriptors();
+        assertCertificateIsPresent(keyDescriptors, encryptionCert);
+    }
+
+    private void assertCertificateIsPresent(List<KeyDescriptor> keyDescriptors, Certificate encryptionCert) {
+        for (KeyDescriptor keyDescriptor : keyDescriptors) {
+            String keyEntityId = keyDescriptor.getKeyInfo().getKeyNames().get(0).getValue();
+            String x509Value = keyDescriptor.getKeyInfo().getX509Datas().get(0).getX509Certificates().get(0).getValue();
+            UsageType keyUse = keyDescriptor.getUse();
+
+            if (keyEntityId.equals(encryptionCert.getIssuerId()) && x509Value.equals(encryptionCert.getCertificate()) && keyUse == UsageType.ENCRYPTION) {
+                return;
+            }
+        }
+
+        Assertions.fail("Certificate is not present.");
+    }
+
+    private void assertCertificateCorrect(KeyDescriptor keyDescriptor, String issuerId, Certificate certificateValue) {
+        final KeyInfo keyInfo = keyDescriptor.getKeyInfo();
+        final List<KeyName> keyNames = keyInfo.getKeyNames();
+        Assertions.assertThat(keyNames.size()).isEqualTo(1);
+        Assertions.assertThat(keyNames.get(0).getValue()).isEqualTo(issuerId);
+        Assertions.assertThat(keyInfo.getX509Datas().size()).isEqualTo(1);
+
+        final List<X509Data> x509Datas = keyInfo.getX509Datas();
+        final List<X509Certificate> x509Certificates = x509Datas.get(0).getX509Certificates();
+//        assertThat(x509Certificates.size()).isEqualTo(1); //This fails, seemingly because of a bug in OpenSAML; see http://stackoverflow.com/questions/14322463/x509certificates-duplicated-when-added-to-an-x509datas-certificate-list
+        Assertions.assertThat(x509Certificates.get(0).getValue()).isEqualTo(certificateValue.getCertificate());
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/KeyDescriptorFinderTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/KeyDescriptorFinderTest.java
@@ -1,0 +1,89 @@
+package uk.gov.ida.saml.metadata.transformers;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.security.credential.UsageType;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.metadata.KeyDescriptorBuilder;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static uk.gov.ida.saml.core.test.builders.metadata.KeyInfoBuilder.aKeyInfo;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class KeyDescriptorFinderTest {
+
+    private KeyDescriptorFinder finder;
+
+    @Before
+    public void setup() {
+        finder = new KeyDescriptorFinder();
+    }
+
+    @Test
+    public void find_shouldFindKeyDescriptorWithMatchingUsageAndEntityId() throws Exception {
+        final String entityId = UUID.randomUUID().toString();
+        final KeyDescriptor desiredKeyDescriptor = KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(aKeyInfo().withKeyName(entityId).build()).withUse(UsageType.SIGNING.toString()).build();
+
+        final KeyDescriptor result =
+                finder.find(asList(KeyDescriptorBuilder.aKeyDescriptor().build(), desiredKeyDescriptor), UsageType.SIGNING, entityId);
+
+        Assertions.assertThat(result).isEqualTo(desiredKeyDescriptor);
+    }
+
+    @Test
+    public void find_shouldFindKeyDescriptorWithMatchingUsageWhenItHasNoKeyName() throws Exception {
+        final String entityId = UUID.randomUUID().toString();
+        final KeyDescriptor desiredKeyDescriptor = KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(aKeyInfo().withKeyName(null).build()).withUse(UsageType.SIGNING.toString()).build();
+
+        final KeyDescriptor result =
+                finder.find(asList(KeyDescriptorBuilder.aKeyDescriptor().build(), desiredKeyDescriptor), UsageType.SIGNING, entityId);
+
+        Assertions.assertThat(result).isEqualTo(desiredKeyDescriptor);
+    }
+
+    @Test
+    public void find_shouldFindKeyDescriptorWithMatchingUsageWhenKeyNameIsPresentAndExpectedEntityIdIsNull() throws Exception {
+        final KeyDescriptor desiredKeyDescriptor = KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(aKeyInfo().withKeyName("foo").build()).withUse(UsageType.SIGNING.toString()).build();
+
+        final KeyDescriptor result =
+                finder.find(asList(KeyDescriptorBuilder.aKeyDescriptor().withUse(UsageType.ENCRYPTION.toString()).build(), desiredKeyDescriptor), UsageType.SIGNING, null);
+
+        Assertions.assertThat(result).isEqualTo(desiredKeyDescriptor);
+    }
+
+    @Test
+    public void find_shouldThrowExceptionWhenSigningCertificateIsNotPresent() throws Exception {
+        final KeyDescriptor keyDescriptor = KeyDescriptorBuilder.aKeyDescriptor().withUse(UsageType.ENCRYPTION.toString()).build();
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> finder.find(singletonList(keyDescriptor), UsageType.SIGNING, keyDescriptor.getKeyInfo().getKeyNames().get(0).getValue()),
+                SamlTransformationErrorFactory.missingKey(UsageType.SIGNING.toString(), "default-key-name"));
+    }
+
+    @Test
+    public void find_shouldThrowExceptionWhenEncryptionCertificateIsNotPresent() throws Exception {
+        final KeyDescriptor keyDescriptor = KeyDescriptorBuilder.aKeyDescriptor().withUse(UsageType.SIGNING.toString()).build();
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> finder.find(singletonList(keyDescriptor), UsageType.ENCRYPTION, keyDescriptor.getKeyInfo().getKeyNames().get(0).getValue()),
+                SamlTransformationErrorFactory.missingKey(UsageType.ENCRYPTION.toString(), "default-key-name"));
+
+    }
+
+    @Test
+    public void find_shouldThrowExceptionWhenKeyNameIsPresentButDoesNotMatchExpectedEntityId() throws Exception {
+        final KeyDescriptor keyDescriptor = KeyDescriptorBuilder.aKeyDescriptor().withUse(UsageType.SIGNING.toString()).build();
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                () -> finder.find(singletonList(keyDescriptor), UsageType.SIGNING, "wrong-value"),
+                SamlTransformationErrorFactory.missingKey(UsageType.SIGNING.toString(), "wrong-value"));
+
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidatorTest.java
@@ -1,0 +1,122 @@
+package uk.gov.ida.saml.metadata.transformers.decorators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
+import uk.gov.ida.saml.core.test.builders.metadata.IdpSsoDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.KeyDescriptorBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.KeyInfoBuilder;
+import uk.gov.ida.saml.core.test.builders.metadata.X509CertificateBuilder;
+import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+import static uk.gov.ida.saml.core.test.builders.metadata.EndpointBuilder.anEndpoint;
+import static uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder.anEntityDescriptor;
+import static uk.gov.ida.saml.core.test.builders.metadata.OrganizationBuilder.anOrganization;
+import static uk.gov.ida.saml.core.test.builders.metadata.OrganizationDisplayNameBuilder.anOrganizationDisplayName;
+import static uk.gov.ida.saml.core.test.builders.metadata.X509DataBuilder.aX509Data;
+
+@RunWith(OpenSAMLMockitoRunner.class)
+public class SamlEntityDescriptorValidatorTest {
+
+    private SamlEntityDescriptorValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        validator = new SamlEntityDescriptorValidator();
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenEntityIdIsMissing() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withEntityId(null).build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingOrEmptyEntityID());
+
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenEntityIdIsEmpty() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withEntityId("").build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingOrEmptyEntityID());
+
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenRoleDescriptorDoesNotHaveAKeyDescriptorElement() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withIdpSsoDescriptor(IdpSsoDescriptorBuilder.anIdpSsoDescriptor().withoutDefaultSigningKey().build()).build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingKeyDescriptor());
+
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenRoleDescriptorDoesNotHaveAKeyInfoElement() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withIdpSsoDescriptor(IdpSsoDescriptorBuilder.anIdpSsoDescriptor().withoutDefaultSigningKey().addKeyDescriptor(KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(null).build()).build()).build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingKeyInfo());
+
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenRoleDescriptorDoesNotHaveAX509DataElement() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withIdpSsoDescriptor(IdpSsoDescriptorBuilder.anIdpSsoDescriptor().withoutDefaultSigningKey().addKeyDescriptor(KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(KeyInfoBuilder.aKeyInfo().withX509Data(null).build()).build()).build()).build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingX509Data());
+
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenRoleDescriptorDoesNotHaveAX509CertificateElement() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withIdpSsoDescriptor(IdpSsoDescriptorBuilder.anIdpSsoDescriptor().withoutDefaultSigningKey().addKeyDescriptor(KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(KeyInfoBuilder.aKeyInfo().withX509Data(aX509Data().withX509Certificate(null).build()).build()).build()).build()).build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingX509Certificate());
+
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenX509CertificateElementIsEmpty() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withIdpSsoDescriptor(IdpSsoDescriptorBuilder.anIdpSsoDescriptor().withoutDefaultSigningKey().addKeyDescriptor(KeyDescriptorBuilder.aKeyDescriptor().withKeyInfo(KeyInfoBuilder.aKeyInfo().withX509Data(aX509Data().withX509Certificate(X509CertificateBuilder.aX509Certificate().withCertForEntityId(null).withCert(null).build()).build()).build()).build()).build()).build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.emptyX509Certificiate());
+
+    }
+
+    @Test
+    public void decorate_shouldThrowExceptionWhenBothValidUntilAndCacheDurationAreMissing() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withValidUntil(null).withCacheDuration(null).build();
+
+        assertExceptionMessage(entityDescriptor, SamlTransformationErrorFactory.missingCacheDurationAndValidUntil());
+    }
+
+    @Test
+    public void decorate_shouldDoNothingWhenEntityDescriptorIsValid() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withIdpSsoDescriptor(IdpSsoDescriptorBuilder.anIdpSsoDescriptor().withSingleSignOnService(anEndpoint().buildSingleSignOnService()).build()).build();
+
+        validator.validate(entityDescriptor);
+    }
+
+    @Test
+    public void decorate_shouldNotThrowExceptionWhenEntityDescriptorIsNotSignedButNotRequired() throws Exception {
+        EntityDescriptor entityDescriptor = anEntityDescriptor().withoutSigning().build();
+
+        validator.validate(entityDescriptor);
+
+    }
+
+    public void assertExceptionMessage(final EntityDescriptor entityDescriptor, SamlValidationSpecificationFailure failure) {
+
+        SamlTransformationErrorManagerTestHelper.validateFail(
+                new SamlTransformationErrorManagerTestHelper.Action() {
+                    @Override
+                    public void execute() {
+                        validator.validate(entityDescriptor);
+                    }
+                },
+                failure
+        );
+
+    }
+}

--- a/hub-saml/src/test/resources/status-cancel.xml
+++ b/hub-saml/src/test/resources/status-cancel.xml
@@ -1,0 +1,17 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_ccb1eabc4827928c9cbb3db34fdbe9df186dfcb8"
+                Version="2.0"
+                IssueInstant="2015-08-20T09:39:53Z"
+                Destination="https://www.signin.service.gov.uk:443/SAML2/SSO/Response/POST"
+                InResponseTo="_7081cbd6-a811-440a-949a-12a9521ed7cc">
+    <saml:Issuer>http://stub-idp</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">
+            <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext" />
+        </samlp:StatusCode>
+        <samlp:StatusDetail>
+            <StatusValue>authn-cancel</StatusValue>
+        </samlp:StatusDetail>
+    </samlp:Status>
+</samlp:Response>

--- a/hub-saml/src/test/resources/status-noauthncontext.xml
+++ b/hub-saml/src/test/resources/status-noauthncontext.xml
@@ -1,0 +1,14 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_ccb1eabc4827928c9cbb3db34fdbe9df186dfcb8"
+                Version="2.0"
+                IssueInstant="2015-08-20T09:39:53Z"
+                Destination="https://www.signin.service.gov.uk:443/SAML2/SSO/Response/POST"
+                InResponseTo="_7081cbd6-a811-440a-949a-12a9521ed7cc">
+    <saml:Issuer>http://stub-idp</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">
+            <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext" />
+        </samlp:StatusCode>
+    </samlp:Status>
+</samlp:Response>

--- a/hub-saml/src/test/resources/status-pending.xml
+++ b/hub-saml/src/test/resources/status-pending.xml
@@ -1,0 +1,17 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_ccb1eabc4827928c9cbb3db34fdbe9df186dfcb8"
+                Version="2.0"
+                IssueInstant="2015-08-20T09:39:53Z"
+                Destination="https://www.signin.service.gov.uk:443/SAML2/SSO/Response/POST"
+                InResponseTo="_7081cbd6-a811-440a-949a-12a9521ed7cc">
+    <saml:Issuer>http://stub-idp</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">
+            <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext" />
+        </samlp:StatusCode>
+        <samlp:StatusDetail>
+            <StatusValue>loa-pending</StatusValue>
+        </samlp:StatusDetail>
+    </samlp:Status>
+</samlp:Response>

--- a/hub-saml/src/test/resources/status-success-with-cancel.xml
+++ b/hub-saml/src/test/resources/status-success-with-cancel.xml
@@ -1,0 +1,15 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_ccb1eabc4827928c9cbb3db34fdbe9df186dfcb8"
+                Version="2.0"
+                IssueInstant="2015-08-20T09:39:53Z"
+                Destination="https://www.signin.service.gov.uk:443/SAML2/SSO/Response/POST"
+                InResponseTo="_7081cbd6-a811-440a-949a-12a9521ed7cc">
+    <saml:Issuer>http://stub-idp</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+        <samlp:StatusDetail>
+            <StatusValue>authn-cancel</StatusValue>
+        </samlp:StatusDetail>
+    </samlp:Status>
+</samlp:Response>

--- a/hub/config/build.gradle
+++ b/hub/config/build.gradle
@@ -4,7 +4,6 @@ dependencies {
             configurations.dev_pki
 
     compile configurations.ida_utils,
-            configurations.rest_utils,
             configurations.config,
             configurations.dropwizard,
             configurations.common

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/Certificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/Certificate.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.config.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.dropwizard.validation.ValidationMethod;
 import org.joda.time.Duration;
 import org.joda.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 
+@JsonIgnoreProperties({ "certificateType", "notAfter", "x509Valid" })
 public abstract class Certificate {
     protected String fullCert;
 
@@ -63,5 +65,20 @@ public abstract class Certificate {
         return getCertificate().getNotBefore();
     }
 
-    public abstract CertificateType getType();
+    public String getType() {
+        return "x509";
+    }
+
+    public abstract CertificateType getCertificateType();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Certificate that = (Certificate) o;
+
+        return getX509().equals(that.getX509());
+    }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateDetails.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateDetails.java
@@ -37,7 +37,7 @@ public class CertificateDetails {
     }
 
     public CertificateType getKeyUse() {
-        return certificate.getType();
+        return certificate.getCertificateType();
     }
 
     public FederationEntityType getFederationEntityType() { return federationEntityType; }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/EncryptionCertificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/EncryptionCertificate.java
@@ -13,7 +13,7 @@ public class EncryptionCertificate extends Certificate {
     }
 
     @Override
-    public CertificateType getType() {
+    public CertificateType getCertificateType() {
         return CertificateType.ENCRYPTION;
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/SignatureVerificationCertificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/SignatureVerificationCertificate.java
@@ -12,7 +12,7 @@ public class SignatureVerificationCertificate extends Certificate {
     }
 
     @Override
-    public CertificateType getType() {
+    public CertificateType getCertificateType() {
         return CertificateType.SIGNING;
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/dto/CertificateHealthCheckDto.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/dto/CertificateHealthCheckDto.java
@@ -38,7 +38,7 @@ public class CertificateHealthCheckDto {
         String expiryDate = new LocalDate(certificate.getNotAfter()).toString(EXPIRY_DATE_FORMAT);
         String message = getExpiryStatusMessage(status, expiryDate);
 
-        return new CertificateHealthCheckDto(entityId, certificate.getType(), status, message);
+        return new CertificateHealthCheckDto(entityId, certificate.getCertificateType(), status, message);
     }
 
     public String getEntityId() {

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.ida.common.shared.configuration.X509CertificateConfiguration;
 import uk.gov.ida.hub.config.data.ConfigEntityDataRepository;
 import uk.gov.ida.hub.config.domain.CertificateDetails;
 import uk.gov.ida.hub.config.domain.CertificateValidityChecker;
@@ -15,6 +16,7 @@ import uk.gov.ida.hub.config.domain.TransactionConfigEntityData;
 import uk.gov.ida.hub.config.dto.FederationEntityType;
 import uk.gov.ida.hub.config.exceptions.CertificateDisabledException;
 import uk.gov.ida.hub.config.exceptions.NoCertificateFoundException;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,8 +33,8 @@ import static uk.gov.ida.hub.config.domain.builders.TransactionConfigEntityDataB
 public class CertificateServiceTest {
 
     private static final String ENTITY_ID = "id_that_exists";
-    private static final String CERT_ONE_X509 = "cert1";
-    private static final String CERT_TWO_X509 = "cert2";
+    private static final String CERT_ONE_X509 = TestCertificateStrings.UNCHAINED_PUBLIC_CERT;
+    private static final String CERT_TWO_X509 = TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
     
     @Mock
     private ConfigEntityDataRepository<TransactionConfigEntityData> transactionDataSource;
@@ -181,8 +183,8 @@ public class CertificateServiceTest {
 
     @Test
     public void findsSignatureVerificationCertificates_WhenMatchingSignatureCertificatesExists() throws Exception {
-        SignatureVerificationCertificate sigCert1 = aSignatureVerificationCertificate().withX509(CERT_ONE_X509).build();
-        SignatureVerificationCertificate sigCert2 = aSignatureVerificationCertificate().withX509(CERT_TWO_X509).build();
+        SignatureVerificationCertificate sigCert1 = new SignatureVerificationCertificate(new X509CertificateConfiguration(CERT_ONE_X509));
+        SignatureVerificationCertificate sigCert2 = new SignatureVerificationCertificate(new X509CertificateConfiguration(CERT_TWO_X509));
 
         MatchingServiceConfigEntityData matchingServiceConfigEntityData = aMatchingServiceConfigEntityData()
                 .withEntityId(ENTITY_ID)

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/MatchingServiceConfigEntityDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/MatchingServiceConfigEntityDataBuilder.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static uk.gov.ida.hub.config.domain.builders.SignatureVerificationCertificateBuilder.aSignatureVerificationCertificate;
 
@@ -71,9 +72,6 @@ public class MatchingServiceConfigEntityDataBuilder {
     }
 
     private static class TestMatchingServiceConfigEntityData extends MatchingServiceConfigEntityData {
-        private final EncryptionCertificate encCertificate;
-        private final List<SignatureVerificationCertificate> sigCertificates;
-
         private TestMatchingServiceConfigEntityData(
             String entityId,
             EncryptionCertificate encryptionCertificate,
@@ -84,25 +82,14 @@ public class MatchingServiceConfigEntityDataBuilder {
             boolean onboarding) {
 
             this.entityId = entityId;
-            this.encryptionCertificate = new X509CertificateConfiguration(null, "test", null);
-            this.signatureVerificationCertificates = Collections.emptyList();
+            this.encryptionCertificate = new X509CertificateConfiguration(encryptionCertificate.getX509());
+            this.signatureVerificationCertificates = signatureVerificationCertificates.stream()
+                .map(cert -> new X509CertificateConfiguration(cert.getX509()))
+                .collect(Collectors.toList());
             this.uri = uri;
             this.userAccountCreationUri = userAccountCreationUri;
             this.healthCheckEnabled = healthCheckEnabled;
             this.onboarding = onboarding;
-
-            this.encCertificate = encryptionCertificate;
-            this.sigCertificates = signatureVerificationCertificates;
-        }
-
-        @Override
-        public EncryptionCertificate getEncryptionCertificate() {
-            return encCertificate;
-        }
-
-        @Override
-        public Collection<SignatureVerificationCertificate> getSignatureVerificationCertificates() {
-            return sigCertificates;
         }
     }
 }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
@@ -8,6 +8,7 @@ import uk.gov.ida.hub.config.domain.MatchingProcess;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
 import uk.gov.ida.hub.config.domain.TransactionConfigEntityData;
 import uk.gov.ida.hub.config.domain.UserAccountCreationAttribute;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -159,7 +160,7 @@ public class TransactionConfigEntityDataBuilder {
             this.serviceHomepage = serviceHomepage;
             this.entityId = entityId;
             this.simpleId = simpleId;
-            this.encryptionCertificate = new X509CertificateConfiguration(null, "test", null);
+            this.encryptionCertificate = new X509CertificateConfiguration(TestCertificateStrings.UNCHAINED_PUBLIC_CERT);
             this.signatureVerificationCertificates = Collections.emptyList();
             this.matchingServiceEntityId = matchingServiceEntityId;
             this.assertionConsumerServices = assertionConsumerServices;

--- a/hub/policy/build.gradle
+++ b/hub/policy/build.gradle
@@ -8,7 +8,6 @@ dependencies {
             'nl.jqno.equalsverifier:equalsverifier:2.4'
 
     compile configurations.ida_utils,
-            configurations.rest_utils,
             configurations.verify_event_emitter,
             configurations.common,
             configurations.dropwizard,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/Cycle3Service.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/Cycle3Service.java
@@ -25,11 +25,8 @@ public class Cycle3Service {
         String attributeName = controller.getCycle3AttributeRequestData().getAttributeName();
         Cycle3Dataset cycle3Dataset = Cycle3Dataset.createFromData(attributeName, cycle3UserInput.getCycle3Input());
         AbstractAttributeQueryRequestDto attributeQuery = controller.createAttributeQuery(cycle3Dataset);
-
-        // NOTE: transitioning the state before sending the matching request avoids a race condition
-        // where the MSA responds before the new state has been replicated across the policy instances.
-        controller.handleCycle3DataSubmitted(cycle3UserInput.getPrincipalIpAddress());
         attributeQueryService.sendAttributeQueryRequest(sessionId, attributeQuery);
+        controller.handleCycle3DataSubmitted(cycle3UserInput.getPrincipalIpAddress());
     }
 
     public void cancelCycle3DataInput(SessionId sessionId) {

--- a/hub/saml-engine/build.gradle
+++ b/hub/saml-engine/build.gradle
@@ -6,8 +6,7 @@ dependencies {
             configurations.ida_test_utils,
             'org.infinispan:infinispan-core:7.1.1.Final:tests'
 
-    compile configurations.rest_utils,
-            configurations.dropwizard,
+    compile configurations.dropwizard,
             configurations.dropwizard_infinispan,
             configurations.saml,
             configurations.soap,

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -113,6 +113,7 @@ import uk.gov.ida.saml.metadata.EidasTrustAnchorHealthCheck;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorResolver;
 import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
+import uk.gov.ida.saml.metadata.MetadataResolverConfigBuilder;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 import uk.gov.ida.saml.security.AssertionDecrypter;
@@ -345,7 +346,8 @@ public class SamlEngineModule extends AbstractModule {
                     metadataConfiguration,
                     new DropwizardMetadataResolverFactory(),
                     new Timer(),
-                    new MetadataSignatureTrustEngineFactory());
+                    new MetadataSignatureTrustEngineFactory(),
+                    new MetadataResolverConfigBuilder());
 
             registerEidasMetadataRefreshTask(environment, eidasMetadataResolverRepository, "eidas-metadata");
             return Optional.of(eidasMetadataResolverRepository);

--- a/hub/saml-proxy/build.gradle
+++ b/hub/saml-proxy/build.gradle
@@ -4,8 +4,7 @@ dependencies {
             configurations.saml_test,
             configurations.stub_saml_test
 
-    compile configurations.rest_utils,
-            configurations.ida_utils,
+    compile configurations.ida_utils,
             configurations.dropwizard,
             configurations.saml,
             configurations.common,

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/NodeMetadataFactory.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/NodeMetadataFactory.java
@@ -9,7 +9,6 @@ import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.w3c.dom.Element;
-import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.core.test.TestCredentialFactory;
 import uk.gov.ida.saml.core.test.builders.SignatureBuilder;
 import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -70,6 +70,7 @@ import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
 import uk.gov.ida.saml.metadata.HubMetadataPublicKeyStore;
 import uk.gov.ida.saml.metadata.IdpMetadataPublicKeyStore;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
+import uk.gov.ida.saml.metadata.MetadataResolverConfigBuilder;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
@@ -226,7 +227,8 @@ public class SamlProxyModule extends AbstractModule {
                     eidasMetadataConfiguration,
                     new DropwizardMetadataResolverFactory(),
                     new Timer(),
-                    new MetadataSignatureTrustEngineFactory()
+                    new MetadataSignatureTrustEngineFactory(),
+                    new MetadataResolverConfigBuilder()
             );
             registerEidasMetadataRefreshTask(environment, metadataResolverRepository,  "eidas-metadata");
             return Optional.of(metadataResolverRepository);

--- a/hub/saml-soap-proxy/build.gradle
+++ b/hub/saml-soap-proxy/build.gradle
@@ -5,8 +5,7 @@ dependencies {
             configurations.ida_test_utils,
             'org.hamcrest:hamcrest-library:1.3'
 
-    compile configurations.rest_utils,
-            configurations.ida_utils,
+    compile configurations.ida_utils,
             configurations.dropwizard,
             configurations.saml,
             configurations.common,

--- a/hub/stub-event-sink/build.gradle
+++ b/hub/stub-event-sink/build.gradle
@@ -2,7 +2,6 @@ dependencies {
     testCompile configurations.test_deps_compile
 
     compile configurations.ida_utils,
-            configurations.rest_utils,
             configurations.common,
             configurations.dropwizard
 }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e # abort if you encounter an error
 set -o pipefail # abort if there is an error in a piped operation
-./gradlew -Pversion=$BUILD_NUMBER clean test intTest copyToLib
+./gradlew -Pversion=$BUILD_NUMBER clean test intTest copyToLib publish
 bin/build_and_upload_debs.rb
 ./gradlew outputDependencies -q > dependencies.properties

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,31 @@
+configure(['hub-saml', 'hub-saml-test-utils']) {
+    apply plugin: 'maven-publish'
+    apply plugin: 'java'
+
+    task sourceJar(type: Jar) {
+        from sourceSets.main.allJava
+    }
+
+    publishing {
+        repositories {
+            maven {
+                credentials {
+                    username "${System.env.ARTIUSER}"
+                    password "${System.env.ARTIPASSWORD}"
+                }
+                url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
+            }
+        }
+
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                groupId = "uk.gov.ida"
+
+                artifact sourceJar {
+                    classifier "sources"
+                }
+            }
+        }
+    }
+}

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,10 +1,6 @@
-configure(['hub-saml', 'hub-saml-test-utils']) {
+configure([project(':hub-saml'), project(':hub-saml-test-utils')]) {
     apply plugin: 'maven-publish'
     apply plugin: 'java'
-
-    task sourceJar(type: Jar) {
-        from sourceSets.main.allJava
-    }
 
     publishing {
         repositories {
@@ -21,10 +17,7 @@ configure(['hub-saml', 'hub-saml-test-utils']) {
             mavenJava(MavenPublication) {
                 from components.java
                 groupId = "uk.gov.ida"
-
-                artifact sourceJar {
-                    classifier "sources"
-                }
+                version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,6 @@ include "hub:stub-event-sink",
         "hub:policy",
         "hub:saml-engine",
         "hub:saml-proxy",
-        "hub:saml-soap-proxy"
+        "hub:saml-soap-proxy",
+        "hub-saml",
+        "hub-saml-test-utils"


### PR DESCRIPTION
The main dependency on hub-saml is from the hub services meaning that 
every time hub-saml is updated, the version in verify-hub needs to be changed.
Making hub-saml part of this repo ensures that any changes are automatically in sync. hub-saml will still be published as a separate library that can be consumed by other services. It will share the hub's build version.

Author: @vixus0