### PR TITLE
TT-2120: Fix accidental revert

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/Cycle3Service.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/Cycle3Service.java
@@ -25,8 +25,10 @@ public class Cycle3Service {
         String attributeName = controller.getCycle3AttributeRequestData().getAttributeName();
         Cycle3Dataset cycle3Dataset = Cycle3Dataset.createFromData(attributeName, cycle3UserInput.getCycle3Input());
         AbstractAttributeQueryRequestDto attributeQuery = controller.createAttributeQuery(cycle3Dataset);
-        attributeQueryService.sendAttributeQueryRequest(sessionId, attributeQuery);
+        // NOTE: transitioning the state before sending the matching request avoids a race condition
+        // where the MSA responds before the new state has been replicated across the policy instances.
         controller.handleCycle3DataSubmitted(cycle3UserInput.getPrincipalIpAddress());
+        attributeQueryService.sendAttributeQueryRequest(sessionId, attributeQuery);
     }
 
     public void cancelCycle3DataInput(SessionId sessionId) {


### PR DESCRIPTION
During the hub-saml merge, the changes to ensure the state transition
for Cycle 3 submission takes place before the attribute query request were accidentally
reverted.

Author: @vixus0