### PR TITLE
Bau update to use non deprecated class for trustStore config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-38",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-21',
-            saml_libs:"$opensaml_version-114",
+            saml_libs:"$opensaml_version-119",
         ]
 
 subprojects {

--- a/configuration/local/saml-engine.yml
+++ b/configuration/local/saml-engine.yml
@@ -82,7 +82,7 @@ metadata:
   uri: ${METADATA_URL}
   trustStorePath: data/pki/metadata.ts
   trustStorePassword: marshmallow
-  truststore:
+  trustStore:
     path: data/pki/metadata.ts
     password: marshmallow
   minRefreshDelay: 60000

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -75,7 +75,7 @@ metadata:
   uri: ${METADATA_URL}
   trustStorePath: data/pki/metadata.ts
   trustStorePassword: marshmallow
-  truststore:
+  trustStore:
     path: data/pki/metadata.ts
     password: marshmallow
   minRefreshDelay: 60000

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -33,7 +33,6 @@ import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
@@ -46,8 +45,6 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Throwables.propagate;
 import static io.dropwizard.testing.ConfigOverride.config;
-import static java.net.URLEncoder.encode;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT;
@@ -109,8 +106,8 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
                 config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()),
                 config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()),
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
-                config("metadata.trustStorePath", metadataTrustStore.getAbsolutePath()),
-                config("metadata.trustStorePassword", metadataTrustStore.getPassword()),
+                config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
+                config("metadata.trustStore.password", metadataTrustStore.getPassword()),
                 config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH)
         ).collect(Collectors.toList());
 

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -14,7 +14,7 @@ import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.saml.hub.configuration.SamlAuthnRequestValidityDurationConfiguration;
 import uk.gov.ida.saml.hub.configuration.SamlDuplicateRequestValidationConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
-import uk.gov.ida.saml.metadata.TrustStorePathMetadataConfiguration;
+import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanServiceConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
@@ -75,7 +75,7 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @NotNull
     @Valid
     @JsonProperty
-    protected TrustStorePathMetadataConfiguration metadata;
+    protected TrustStoreBackedMetadataConfiguration metadata;
 
     @Valid
     @JsonProperty

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -100,7 +100,7 @@ metadata:
   uri: ${METADATA_URI}
   trustStorePath: ${METADATA_TRUSTSTORE_PATH}
   trustStorePassword: ${METADATA_TRUSTSTORE_PASSWORD}
-  truststore:
+  trustStore:
       path: ${METADATA_TRUSTSTORE_PATH}
       password: ${METADATA_TRUSTSTORE_PASSWORD}
   minRefreshDelay: 60000

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
@@ -90,8 +90,8 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
                 config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()),
                 config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()),
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
-                config("metadata.trustStorePath", metadataTrustStore.getAbsolutePath()),
-                config("metadata.trustStorePassword", metadataTrustStore.getPassword()),
+                config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
+                config("metadata.trustStore.password", metadataTrustStore.getPassword()),
                 config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH)
         ).collect(Collectors.toList());
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -12,7 +12,7 @@ import uk.gov.ida.hub.samlproxy.config.CountryConfiguration;
 import uk.gov.ida.hub.samlproxy.config.SamlConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
-import uk.gov.ida.saml.metadata.TrustStorePathMetadataConfiguration;
+import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
@@ -44,7 +44,7 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @NotNull
     @Valid
     @JsonProperty
-    protected TrustStorePathMetadataConfiguration metadata;
+    protected TrustStoreBackedMetadataConfiguration metadata;
 
     @Valid
     @NotNull

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -72,7 +72,7 @@ metadata:
   uri: ${METADATA_URI:-http://localhost:55000/metadata.xml}
   trustStorePath: ${METADATA_TRUSTSTORE_PATH}
   trustStorePassword: ${METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
-  truststore:
+  trustStore:
       path: ${METADATA_TRUSTSTORE_PATH}
       password: ${METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
   minRefreshDelay: 60000

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
@@ -50,8 +50,8 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
                 config("clientTrustStoreConfiguration.password", idpTrustStore.getPassword()),
                 config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()),
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
-                config("metadata.trustStorePath", metadataTrustStore.getAbsolutePath()),
-                config("metadata.trustStorePassword", metadataTrustStore.getPassword()),
+                config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
+                config("metadata.trustStore.password", metadataTrustStore.getPassword()),
                 config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
                 config("metadata.expectedEntityId", HUB_ENTITY_ID)
         ).collect(Collectors.toList());

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -9,7 +9,7 @@ import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.hub.samlsoapproxy.config.SamlConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
-import uk.gov.ida.saml.metadata.TrustStorePathMetadataConfiguration;
+import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
@@ -51,7 +51,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Valid
     @NotNull
     @JsonProperty
-    protected TrustStorePathMetadataConfiguration metadata;
+    protected TrustStoreBackedMetadataConfiguration metadata;
 
     @Valid
     @NotNull

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -91,7 +91,7 @@ metadata:
   uri: ${METADATA_URI}
   trustStorePath: ${METADATA_TRUSTSTORE_PATH}
   trustStorePassword: ${METADATA_TRUSTSTORE_PASSWORD}
-  truststore:
+  trustStore:
       path: ${METADATA_TRUSTSTORE_PATH}
       password: ${METADATA_TRUSTSTORE_PASSWORD}
   minRefreshDelay: 60000


### PR DESCRIPTION
Change SAML Engine, SAML SOAP Proxy and SAML Proxy to use the non-deprecated class 'TrustStoreBackedMetadataConfiguration' instead of the deprecated class 'TrustStorePathMetadataConfiguration'.
Update to use the latest version of verify-saml-libs to enable the non-deprecated class TrustStoreBackedMetadataConfiguration to ignore unknown json properties.
Replace truststore with trustStore in SAML Engine, SAML SOAP Proxy and SAML Proxy config files.

Co-authored-by: Rachel Smith <rachel.smith@digital.cabinet-office.gov.uk>
Co-authored-by: Kornelis Sietsma <kornelis.sietsma@digital.cabinet-office.gov.uk>