### PR TITLE
HUB-101: Update config to use new logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,11 @@ def dependencyVersions = [
             dropwizard:'1.1.4',
             dropwizard_infinispan:'1.1.4-41',
             pact:'3.5.6',
-            stub_idp_saml:"$opensaml_version-68",
+            stub_idp_saml:"$opensaml_version-69",
             ida_test_utils:"2.0.0-38",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-21',
-            saml_libs:"$opensaml_version-121",
+            saml_libs:"$opensaml_version-126",
         ]
 
 subprojects {

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -71,6 +71,8 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
     private static final HttpStubRule trustAnchorServer = new HttpStubRule();
 
     private static final KeyStoreResource metadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
+    private static final KeyStoreResource hubTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("hubCA", CACertificates.TEST_CORE_CA).build();
+    private static final KeyStoreResource idpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource rpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rpCA", CACertificates.TEST_RP_CA).build();
     private static final KeyStoreResource countryMetadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("idpCA", CACertificates.TEST_IDP_CA).withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
@@ -108,7 +110,11 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
                 config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
                 config("metadata.trustStore.password", metadataTrustStore.getPassword()),
-                config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH)
+                config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
+                config("metadata.hubTrustStore.path", hubTrustStore.getAbsolutePath()),
+                config("metadata.hubTrustStore.password", hubTrustStore.getPassword()),
+                config("metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
+                config("metadata.idpTrustStore.password", idpTrustStore.getPassword())
         ).collect(Collectors.toList());
 
         if (isCountryEnabled) {
@@ -148,6 +154,8 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
     @Override
     protected void before() {
         metadataTrustStore.create();
+        hubTrustStore.create();
+        idpTrustStore.create();
         clientTrustStore.create();
         rpTrustStore.create();
         countryMetadataTrustStore.create();
@@ -179,6 +187,8 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
     @Override
     protected void after() {
         metadataTrustStore.delete();
+        hubTrustStore.delete();
+        idpTrustStore.delete();
         rpTrustStore.delete();
         clientTrustStore.delete();
         countryMetadataTrustStore.delete();

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -14,7 +14,7 @@ import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.saml.hub.configuration.SamlAuthnRequestValidityDurationConfiguration;
 import uk.gov.ida.saml.hub.configuration.SamlDuplicateRequestValidationConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
-import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
+import uk.gov.ida.saml.metadata.MultiTrustStoresBackedMetadataConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanServiceConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
@@ -75,7 +75,7 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @NotNull
     @Valid
     @JsonProperty
-    protected TrustStoreBackedMetadataConfiguration metadata;
+    protected MultiTrustStoresBackedMetadataConfiguration metadata;
 
     @Valid
     @JsonProperty

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -101,8 +101,14 @@ metadata:
   trustStorePath: ${METADATA_TRUSTSTORE_PATH}
   trustStorePassword: ${METADATA_TRUSTSTORE_PASSWORD}
   trustStore:
-      path: ${METADATA_TRUSTSTORE_PATH}
-      password: ${METADATA_TRUSTSTORE_PASSWORD}
+    path: ${METADATA_TRUSTSTORE_PATH}
+    password: ${METADATA_TRUSTSTORE_PASSWORD}
+  hubTrustStore:
+    path: ${HUB_FEDERATION_TRUSTSTORE_PATH}
+    password: ${HUB_FEDERATION_TRUSTSTORE_PASSWORD}
+  idpTrustStore:
+    path: ${IDP_FEDERATION_TRUSTSTORE_PATH}
+    password: ${IDP_FEDERATION_TRUSTSTORE_PASSWORD}
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
   expectedEntityId: ${SAML_ENTITY_ID}

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
@@ -65,6 +65,8 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
     private static final HttpStubRule trustAnchorServer = new HttpStubRule();
 
     private static final KeyStoreResource metadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
+    private static final KeyStoreResource hubTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("hubCA", CACertificates.TEST_CORE_CA).build();
+    private static final KeyStoreResource idpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource rpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rpCA", CACertificates.TEST_RP_CA).build();
     private static final KeyStoreResource countryMetadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("idpCA", CACertificates.TEST_IDP_CA).withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
@@ -92,7 +94,11 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
                 config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
                 config("metadata.trustStore.password", metadataTrustStore.getPassword()),
-                config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH)
+                config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
+                config("metadata.hubTrustStore.path", hubTrustStore.getAbsolutePath()),
+                config("metadata.hubTrustStore.password", hubTrustStore.getPassword()),
+                config("metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
+                config("metadata.idpTrustStore.password", idpTrustStore.getPassword())
         ).collect(Collectors.toList());
 
         if (isCountryEnabled) {
@@ -129,6 +135,8 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
     @Override
     protected void before() {
         metadataTrustStore.create();
+        hubTrustStore.create();
+        idpTrustStore.create();
         clientTrustStore.create();
         rpTrustStore.create();
         countryMetadataTrustStore.create();
@@ -159,6 +167,8 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
     @Override
     protected void after() {
         metadataTrustStore.delete();
+        hubTrustStore.delete();
+        idpTrustStore.delete();
         rpTrustStore.delete();
         clientTrustStore.delete();
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -12,7 +12,7 @@ import uk.gov.ida.hub.samlproxy.config.CountryConfiguration;
 import uk.gov.ida.hub.samlproxy.config.SamlConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
-import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
+import uk.gov.ida.saml.metadata.MultiTrustStoresBackedMetadataConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
@@ -44,7 +44,7 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @NotNull
     @Valid
     @JsonProperty
-    protected TrustStoreBackedMetadataConfiguration metadata;
+    protected MultiTrustStoresBackedMetadataConfiguration metadata;
 
     @Valid
     @NotNull

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -73,8 +73,14 @@ metadata:
   trustStorePath: ${METADATA_TRUSTSTORE_PATH}
   trustStorePassword: ${METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
   trustStore:
-      path: ${METADATA_TRUSTSTORE_PATH}
-      password: ${METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
+    path: ${METADATA_TRUSTSTORE_PATH}
+    password: ${METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
+  hubTrustStore:
+    path: ${HUB_FEDERATION_TRUSTSTORE_PATH}
+    password: ${HUB_FEDERATION_TRUSTSTORE_PASSWORD:-marshmallow}
+  idpTrustStore:
+    path: ${IDP_FEDERATION_TRUSTSTORE_PATH}
+    password: ${IDP_FEDERATION_TRUSTSTORE_PASSWORD:-marshmallow}
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
   expectedEntityId: ${SAML_ENTITY_ID:-http://dev-hub.local}

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
@@ -31,6 +31,7 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
     private static final HttpStubRule countryMetadataServer = new HttpStubRule();
 
     private static final KeyStoreResource metadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
+    private static final KeyStoreResource hubTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("hubCA", CACertificates.TEST_CORE_CA).build();
     private static final KeyStoreResource idpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource rpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("rpCA", CACertificates.TEST_RP_CA).build();
 
@@ -52,6 +53,10 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
                 config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
                 config("metadata.trustStore.password", metadataTrustStore.getPassword()),
+                config("metadata.hubTrustStore.path", hubTrustStore.getAbsolutePath()),
+                config("metadata.hubTrustStore.password", hubTrustStore.getPassword()),
+                config("metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
+                config("metadata.idpTrustStore.password", idpTrustStore.getPassword()),
                 config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
                 config("metadata.expectedEntityId", HUB_ENTITY_ID)
         ).collect(Collectors.toList());
@@ -63,6 +68,7 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
     @Override
     protected void before() {
         metadataTrustStore.create();
+        hubTrustStore.create();
         idpTrustStore.create();
         rpTrustStore.create();
 
@@ -85,6 +91,7 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
     protected void after() {
         metadataTrustStore.delete();
         rpTrustStore.delete();
+        hubTrustStore.delete();
         idpTrustStore.delete();
 
         super.after();

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -9,7 +9,7 @@ import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.hub.samlsoapproxy.config.SamlConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
-import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
+import uk.gov.ida.saml.metadata.MultiTrustStoresBackedMetadataConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
@@ -51,7 +51,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Valid
     @NotNull
     @JsonProperty
-    protected TrustStoreBackedMetadataConfiguration metadata;
+    protected MultiTrustStoresBackedMetadataConfiguration metadata;
 
     @Valid
     @NotNull

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -92,8 +92,14 @@ metadata:
   trustStorePath: ${METADATA_TRUSTSTORE_PATH}
   trustStorePassword: ${METADATA_TRUSTSTORE_PASSWORD}
   trustStore:
-      path: ${METADATA_TRUSTSTORE_PATH}
-      password: ${METADATA_TRUSTSTORE_PASSWORD}
+    path: ${METADATA_TRUSTSTORE_PATH}
+    password: ${METADATA_TRUSTSTORE_PASSWORD}
+  hubTrustStore:
+    path: ${HUB_FEDERATION_TRUSTSTORE_PATH}
+    password: ${HUB_FEDERATION_TRUSTSTORE_PASSWORD}
+  idpTrustStore:
+    path: ${IDP_FEDERATION_TRUSTSTORE_PATH}
+    password: ${IDP_FEDERATION_TRUSTSTORE_PASSWORD}
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
   expectedEntityId: ${SAML_ENTITY_ID}


### PR DESCRIPTION
Update the config in saml-engine, saml-soap-proxy and saml-proxy to use
the new logic in verify-saml-libs for
MultiTrustStoreBackedMetadataConfiguration.

Co-authored-by: Rachel Smith <rachel.smith@digital.cabinet-office.gov.uk>