### PR TITLE
Hub 103: remove client truststores

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'332',
+            ida_utils:'333',
             dropwizard:'1.1.4',
             dropwizard_infinispan:'1.1.4-41',
             pact:'3.5.6',

--- a/configuration/local/config.yml
+++ b/configuration/local/config.yml
@@ -20,10 +20,6 @@ serviceInfo:
 
 rootDataDirectory: ${FED_CONFIG_PATH:-data/stub-fed-config}
 
-clientTrustStoreConfiguration:
-  path: data/pki/hub.ts
-  password: marshmallow
-
 rpTrustStoreConfiguration:
   path: ${RP_TRUST_STORE_PATH:-data/pki/relying_parties.ts}
   password: marshmallow

--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -56,8 +56,4 @@ timeoutPeriod: 60m
 assertionLifetime: 60m
 matchingServiceResponseWaitPeriod: 60s
 
-clientTrustStoreConfiguration:
-  path: ${HUB_TRUST_STORE_PATH:-data/pki/hub.ts}
-  password: marshmallow
-
 eidas: true

--- a/configuration/local/saml-engine.yml
+++ b/configuration/local/saml-engine.yml
@@ -66,10 +66,6 @@ secondaryPublicEncryptionCert:
    certFile: data/pki/hub_encryption_primary.crt
    name: someId
 
-clientTrustStoreConfiguration:
-  path: data/pki/hub.ts
-  password: marshmallow
-
 rpTrustStoreConfiguration:
   path: data/pki/relying_parties.ts
   password: marshmallow

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -42,10 +42,6 @@ policyUri: ${POLICY_URL}
 serviceInfo:
   name: saml-proxy
 
-clientTrustStoreConfiguration:
-  path: data/pki/hub.ts
-  password: marshmallow
-
 rpTrustStoreConfiguration:
   path: data/pki/relying_parties.ts
   password: marshmallow

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -63,10 +63,6 @@ matchingServiceExecutorConfiguration:
   maxPoolSize: 10
   keepAliveDuration: 10s
 
-clientTrustStoreConfiguration:
-  path: data/pki/hub.ts
-  password: marshmallow
-
 rpTrustStoreConfiguration:
   path: data/pki/relying_parties.ts
   password: marshmallow

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -33,7 +33,6 @@ import static uk.gov.ida.hub.config.domain.builders.TransactionConfigEntityDataB
 
 public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
 
-    private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource rpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rpCA", CACertificates.TEST_RP_CA).build();
     private static final File FED_CONFIG_ROOT = new File(System.getProperty("java.io.tmpdir"), "test-fed-config");
     private final ObjectMapper mapper = new ObjectMapper();
@@ -52,8 +51,6 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
 
     public static ConfigOverride[] withDefaultOverrides(ConfigOverride ... configOverrides) {
         ImmutableList<ConfigOverride> overrides = ImmutableList.<ConfigOverride>builder()
-                .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
-                .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
                 .add(config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()))
                 .add(config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()))
                 .add(config("rootDataDirectory", FED_CONFIG_ROOT.getAbsolutePath()))
@@ -85,7 +82,6 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
     @Override
     protected void before() {
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
-        clientTrustStore.create();
         rpTrustStore.create();
 
         createFedConfig();
@@ -96,7 +92,6 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
     @Override
     protected void after() {
         rpTrustStore.delete();
-        clientTrustStore.delete();
 
         try {
             FileUtils.deleteDirectory(FED_CONFIG_ROOT);

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -30,11 +30,6 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @Valid
     @NotNull
     @JsonProperty
-    protected ClientTrustStoreConfiguration clientTrustStoreConfiguration;
-
-    @Valid
-    @NotNull
-    @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     @Valid
@@ -62,11 +57,6 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @Override
     public String getServiceName() {
         return serviceInfo.getName();
-    }
-
-    @Override
-    public ClientTrustStoreConfiguration getClientTrustStoreConfiguration() {
-        return this.clientTrustStoreConfiguration;
     }
 
     @Override

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/truststore/TrustStoreForCertificateProvider.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/truststore/TrustStoreForCertificateProvider.java
@@ -28,9 +28,6 @@ public class TrustStoreForCertificateProvider {
 
     private ClientTrustStoreConfiguration getAppropriateTrustStoreConfig(final FederationEntityType federationEntityType) {
         switch (federationEntityType) {
-            case HUB:
-            case IDP:
-                return trustStoreConfiguration.getClientTrustStoreConfiguration();
             case RP:
             case MS:
                 return trustStoreConfiguration.getRpTrustStoreConfiguration();

--- a/hub/config/src/test/resources/config.yml
+++ b/hub/config/src/test/resources/config.yml
@@ -36,10 +36,6 @@ serviceInfo:
 
 rootDataDirectory: configuration/config-service-data/local
 
-clientTrustStoreConfiguration:
-  path: ${IDP_TRUSTSTORE_PATH}
-  password: ${IDP_TRUSTSTORE_PASSWORD}
-
 rpTrustStoreConfiguration:
   path: ${RP_TRUSTSTORE_PATH}
   password: ${RP_TRUSTSTORE_PASSWORD}

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
@@ -1,12 +1,9 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule.support;
 
-import certificates.values.CACertificates;
 import com.google.common.collect.ImmutableList;
 import helpers.ResourceHelpers;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import keystore.KeyStoreResource;
-import keystore.builders.KeyStoreResourceBuilder;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;
@@ -15,11 +12,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.concurrent.ConcurrentMap;
 
-import static io.dropwizard.testing.ConfigOverride.config;
-
 public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
-
-    private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
 
     public PolicyAppRule(final ConfigOverride... configOverrides) {
         super(PolicyIntegrationApplication.class, ResourceHelpers.resourceFilePath("policy.yml"), withDefaultOverrides(configOverrides));
@@ -27,8 +20,6 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
 
     public static ConfigOverride[] withDefaultOverrides(final ConfigOverride... configOverrides) {
         ImmutableList<ConfigOverride> mergedConfigOverrides = ImmutableList.<ConfigOverride>builder()
-                .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
-                .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
                 .add(configOverrides)
                 .build();
         return mergedConfigOverrides.toArray(new ConfigOverride[mergedConfigOverrides.size()]);
@@ -36,15 +27,11 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
 
     @Override
     protected void before() {
-        clientTrustStore.create();
-
         super.before();
     }
 
     @Override
     protected void after() {
-        clientTrustStore.delete();
-
         super.after();
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/PolicyConfigurationBuilder.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/PolicyConfigurationBuilder.java
@@ -4,11 +4,9 @@ import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
-import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 
 import java.net.URI;
 
-import static org.mockito.Mockito.mock;
 import static uk.gov.ida.common.ServiceInfoConfigurationBuilder.aServiceInfo;
 
 public class PolicyConfigurationBuilder {
@@ -24,7 +22,6 @@ public class PolicyConfigurationBuilder {
         return new TestPolicyConfiguration(
                 new JerseyClientConfiguration(),
                 serviceInfo,
-                mock(ClientTrustStoreConfiguration.class),
                 timeoutPeriod,
                 Duration.minutes(1),
                 Duration.minutes(15));
@@ -44,8 +41,6 @@ public class PolicyConfigurationBuilder {
         private TestPolicyConfiguration(
                 JerseyClientConfiguration httpClient,
                 ServiceInfoConfiguration serviceInfo,
-                ClientTrustStoreConfiguration clientTrustStoreConfiguration,
-
                 Duration timeoutPeriod,
                 Duration matchingServiceResponseWaitPeriod,
                 Duration assertionLifetime) {
@@ -55,7 +50,6 @@ public class PolicyConfigurationBuilder {
             this.samlSoapProxyUri = URI.create("http://saml-soap-proxy");
             this.httpClient = httpClient;
             this.serviceInfo = serviceInfo;
-            this.clientTrustStoreConfiguration = clientTrustStoreConfiguration;
 
             this.timeoutPeriod = timeoutPeriod;
             this.matchingServiceResponseWaitPeriod = matchingServiceResponseWaitPeriod;

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -10,7 +10,6 @@ import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanServiceConfiguration;
-import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -81,11 +80,6 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @JsonProperty
     public URI configUri;
 
-    @Valid
-    @NotNull
-    @JsonProperty
-    public ClientTrustStoreConfiguration clientTrustStoreConfiguration;
-
     @JsonProperty
     public Boolean eidas = false;
 
@@ -141,10 +135,6 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @Override
     public String getServiceName() {
         return serviceInfo.getName();
-    }
-
-    public ClientTrustStoreConfiguration getClientTrustStoreConfiguration() {
-        return this.clientTrustStoreConfiguration;
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -44,15 +44,12 @@ import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.restclient.ClientProvider;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
-import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.KeyStoreLoader;
-import uk.gov.ida.truststore.KeyStoreProvider;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
-import java.security.KeyStore;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
@@ -63,7 +60,6 @@ public class PolicyModule extends AbstractModule {
         bind(RestfulClientConfiguration.class).to(PolicyConfiguration.class).in(Scopes.SINGLETON);
         bind(AssertionLifetimeConfiguration.class).to(PolicyConfiguration.class).in(Scopes.SINGLETON);
         bind(Client.class).toProvider(DefaultClientProvider.class).in(Scopes.SINGLETON);
-        bind(KeyStore.class).toProvider(KeyStoreProvider.class).in(Scopes.SINGLETON);
         bind(KeyStoreLoader.class).toInstance(new KeyStoreLoader());
         bind(InfinispanStartupTasks.class).asEagerSingleton();
         bind(JsonResponseProcessor.class);
@@ -138,12 +134,6 @@ public class PolicyModule extends AbstractModule {
     @Singleton
     public ServiceInfoConfiguration serviceInfo(PolicyConfiguration policyConfiguration) {
         return policyConfiguration.getServiceInfo();
-    }
-
-    @Provides
-    @Singleton
-    public ClientTrustStoreConfiguration clientTrustStoreConfiguration(PolicyConfiguration policyConfiguration) {
-        return policyConfiguration.getClientTrustStoreConfiguration();
     }
 
     @Provides

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -73,8 +73,4 @@ timeoutPeriod: 60m
 assertionLifetime: 60m
 matchingServiceResponseWaitPeriod: 60s
 
-clientTrustStoreConfiguration:
-  path: ${IDP_TRUSTSTORE_PATH}
-  password: ${IDP_TRUSTSTORE_PASSWORD}
-
 eidas: true

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -73,7 +73,6 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
     private static final KeyStoreResource metadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
     private static final KeyStoreResource hubTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("hubCA", CACertificates.TEST_CORE_CA).build();
     private static final KeyStoreResource idpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
-    private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource rpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rpCA", CACertificates.TEST_RP_CA).build();
     private static final KeyStoreResource countryMetadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("idpCA", CACertificates.TEST_IDP_CA).withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
 
@@ -104,8 +103,6 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
                 config("secondaryPrivateEncryptionKeyConfiguration.key", TEST_PRIVATE_KEY),
                 config("secondaryPrivateEncryptionKeyConfiguration.type", "encoded"),
                 config("secondaryPublicEncryptionCert.x509", TEST_PUBLIC_CERT),
-                config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()),
-                config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()),
                 config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()),
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
                 config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
@@ -156,7 +153,6 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
         metadataTrustStore.create();
         hubTrustStore.create();
         idpTrustStore.create();
-        clientTrustStore.create();
         rpTrustStore.create();
         countryMetadataTrustStore.create();
 
@@ -190,7 +186,6 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
         hubTrustStore.delete();
         idpTrustStore.delete();
         rpTrustStore.delete();
-        clientTrustStore.delete();
         countryMetadataTrustStore.delete();
 
         super.after();

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/CryptoModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/CryptoModule.java
@@ -19,8 +19,6 @@ import uk.gov.ida.hub.samlengine.security.SamlResponseFromMatchingServiceKeyStor
 import uk.gov.ida.saml.core.transformers.outbound.decorators.AssertionBlobEncrypter;
 import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlResponseAssertionEncrypter;
 import uk.gov.ida.saml.security.EncrypterFactory;
-import uk.gov.ida.saml.security.EncryptionCredentialFactory;
-import uk.gov.ida.saml.security.EncryptionCredentialResolver;
 import uk.gov.ida.saml.security.EncryptionKeyStore;
 import uk.gov.ida.saml.security.EntityToEncryptForLocator;
 import uk.gov.ida.saml.security.IdaKeyStore;

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -104,11 +104,6 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @Valid
     @NotNull
     @JsonProperty
-    protected ClientTrustStoreConfiguration clientTrustStoreConfiguration;
-
-    @Valid
-    @NotNull
-    @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     public SamlConfiguration getSamlConfiguration() {
@@ -176,11 +171,6 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @Override
     public String getServiceName() {
         return serviceInfo.getName();
-    }
-
-    @Override
-    public ClientTrustStoreConfiguration getClientTrustStoreConfiguration() {
-        return this.clientTrustStoreConfiguration;
     }
 
     @Override

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
-import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
 import org.joda.time.DateTime;
@@ -132,7 +131,6 @@ import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
 import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
 import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
 import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
-import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
 import javax.inject.Named;
@@ -472,12 +470,6 @@ public class SamlEngineModule extends AbstractModule {
     @Singleton
     private ServiceInfoConfiguration serviceInfoConfiguration(SamlEngineConfiguration configuration) {
         return configuration.getServiceInfo();
-    }
-
-    @Provides
-    @Singleton
-    private ClientTrustStoreConfiguration clientTrustStoreConfiguration(SamlEngineConfiguration configuration) {
-        return configuration.getClientTrustStoreConfiguration();
     }
 
     @Provides

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/TrustStoreForCertificateProvider.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/TrustStoreForCertificateProvider.java
@@ -28,9 +28,6 @@ public class TrustStoreForCertificateProvider {
 
     private ClientTrustStoreConfiguration getAppropriateTrustStoreConfig(final FederationEntityType federationEntityType) {
         switch (federationEntityType) {
-            case HUB:
-            case IDP:
-                return trustStoreConfiguration.getClientTrustStoreConfiguration();
             case RP:
             case MS:
                 return trustStoreConfiguration.getRpTrustStoreConfiguration();

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -84,9 +84,6 @@ primaryPrivateEncryptionKeyConfiguration:
 secondaryPrivateEncryptionKeyConfiguration:
   type: base64
   key: ${HUB_SECONDARY_ENC_KEY:}
-clientTrustStoreConfiguration:
-  path: ${IDP_TRUSTSTORE_PATH}
-  password: ${IDP_TRUSTSTORE_PASSWORD}
 
 rpTrustStoreConfiguration:
   path: ${RP_TRUSTSTORE_PATH}

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
@@ -67,7 +67,6 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
     private static final KeyStoreResource metadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
     private static final KeyStoreResource hubTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("hubCA", CACertificates.TEST_CORE_CA).build();
     private static final KeyStoreResource idpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
-    private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource rpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rpCA", CACertificates.TEST_RP_CA).build();
     private static final KeyStoreResource countryMetadataTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("idpCA", CACertificates.TEST_IDP_CA).withCertificate("metadataCA", CACertificates.TEST_METADATA_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).build();
 
@@ -88,8 +87,6 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
                 config("saml.entityId", HUB_ENTITY_ID),
                 config("server.applicationConnectors[0].port", "0"),
                 config("server.adminConnectors[0].port", "0"),
-                config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()),
-                config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()),
                 config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()),
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
                 config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),
@@ -137,7 +134,6 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
         metadataTrustStore.create();
         hubTrustStore.create();
         idpTrustStore.create();
-        clientTrustStore.create();
         rpTrustStore.create();
         countryMetadataTrustStore.create();
 
@@ -170,7 +166,6 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
         hubTrustStore.delete();
         idpTrustStore.delete();
         rpTrustStore.delete();
-        clientTrustStore.delete();
 
         super.after();
     }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -84,11 +84,6 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @Valid
     @NotNull
     @JsonProperty
-    protected ClientTrustStoreConfiguration clientTrustStoreConfiguration;
-
-    @Valid
-    @NotNull
-    @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     @Valid
@@ -139,11 +134,6 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @Override
     public String getServiceName() {
         return serviceInfo.getName();
-    }
-
-    @Override
-    public ClientTrustStoreConfiguration getClientTrustStoreConfiguration() {
-        return this.clientTrustStoreConfiguration;
     }
 
     @Override

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -6,7 +6,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
-import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.servlets.tasks.Task;
 import io.dropwizard.setup.Environment;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
@@ -85,10 +84,8 @@ import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
 import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
 import uk.gov.ida.shared.utils.IpAddressResolver;
 import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
-import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.KeyStoreCache;
 import uk.gov.ida.truststore.KeyStoreLoader;
-import uk.gov.ida.truststore.KeyStoreProvider;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
 import javax.inject.Named;
@@ -115,7 +112,6 @@ public class SamlProxyModule extends AbstractModule {
         bind(SigningKeyStore.class).to(AuthnRequestKeyStore.class);
         bind(Client.class).toProvider(DefaultClientProvider.class).in(Scopes.SINGLETON);
         bind(EventSinkProxy.class).to(EventSinkHttpProxy.class);
-        bind(KeyStore.class).toProvider(KeyStoreProvider.class).in(Scopes.SINGLETON);
         bind(ConfigServiceKeyStore.class).asEagerSingleton();
         bind(KeyStoreLoader.class).toInstance(new KeyStoreLoader());
         bind(ResponseMaxSizeValidator.class);
@@ -394,12 +390,6 @@ public class SamlProxyModule extends AbstractModule {
     @Policy
     public URI policyUri(SamlProxyConfiguration samlProxyConfiguration) {
         return samlProxyConfiguration.getPolicyUri();
-    }
-
-    @Provides
-    @Singleton
-    public ClientTrustStoreConfiguration clientTrustStoreConfiguration(SamlProxyConfiguration configuration) {
-        return configuration.getClientTrustStoreConfiguration();
     }
 
     @Provides

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/config/TrustStoreForCertificateProvider.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/config/TrustStoreForCertificateProvider.java
@@ -28,9 +28,6 @@ public class TrustStoreForCertificateProvider {
 
     private ClientTrustStoreConfiguration getAppropriateTrustStoreConfig(final FederationEntityType federationEntityType) {
         switch (federationEntityType) {
-            case HUB:
-            case IDP:
-                return trustStoreConfiguration.getClientTrustStoreConfiguration();
             case RP:
             case MS:
                 return trustStoreConfiguration.getRpTrustStoreConfiguration();

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -58,10 +58,6 @@ policyUri: ${POLICY_URI:-http://localhost:50110}
 serviceInfo:
   name: saml-proxy
 
-clientTrustStoreConfiguration:
-  path: ${IDP_TRUSTSTORE_PATH}
-  password: ${IDP_TRUSTSTORE_PASSWORD:-marshmallow}
-
 rpTrustStoreConfiguration:
   path: ${RP_TRUSTSTORE_PATH}
   password: ${RP_TRUSTSTORE_PASSWORD:-marshmallow}

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
@@ -47,8 +47,6 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
                 config("saml.entityId", HUB_ENTITY_ID),
                 config("server.applicationConnectors[0].port", "0"),
                 config("server.adminConnectors[0].port", "0"),
-                config("clientTrustStoreConfiguration.path", idpTrustStore.getAbsolutePath()),
-                config("clientTrustStoreConfiguration.password", idpTrustStore.getPassword()),
                 config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()),
                 config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
                 config("metadata.trustStore.path", metadataTrustStore.getAbsolutePath()),

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -85,11 +85,6 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Valid
     @NotNull
     @JsonProperty
-    protected ClientTrustStoreConfiguration clientTrustStoreConfiguration;
-
-    @Valid
-    @NotNull
-    @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     @Valid
@@ -144,11 +139,6 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Override
     public String getServiceName() {
         return serviceInfo.getName();
-    }
-
-    @Override
-    public ClientTrustStoreConfiguration getClientTrustStoreConfiguration() {
-        return this.clientTrustStoreConfiguration;
     }
 
     @Override

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/config/TrustStoreForCertificateProvider.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/config/TrustStoreForCertificateProvider.java
@@ -28,9 +28,6 @@ public class TrustStoreForCertificateProvider {
 
     private ClientTrustStoreConfiguration getAppropriateTrustStoreConfig(final FederationEntityType federationEntityType) {
         switch (federationEntityType) {
-            case HUB:
-            case IDP:
-                return trustStoreConfiguration.getClientTrustStoreConfiguration();
             case RP:
             case MS:
                 return trustStoreConfiguration.getRpTrustStoreConfiguration();

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -79,10 +79,6 @@ matchingServiceExecutorConfiguration:
   maxPoolSize: 10
   keepAliveDuration: 10s
 
-clientTrustStoreConfiguration:
-  path: ${IDP_TRUSTSTORE_PATH}
-  password: ${IDP_TRUSTSTORE_PASSWORD}
-
 rpTrustStoreConfiguration:
   path: ${RP_TRUSTSTORE_PATH}
   password: ${RP_TRUSTSTORE_PASSWORD}


### PR DESCRIPTION
Update to use latest version of verify-utils-libs which removes the getClientTrustStoreConfiguration method from the TrustStoreConfiguration interface. Client truststore is not used anymore for Certificate Chain Validation for Hub or IDP trust stores. This is now all done by a filter in the Metadata Resolver. Certificate Chain Validation is still done for the RP truststore so the overall function needs to remain.

Remove clientTrustStore from config files.