### PR TITLE
HUB-103: Add client truststore back to policy and config

### DIFF
--- a/configuration/local/config.yml
+++ b/configuration/local/config.yml
@@ -20,6 +20,10 @@ serviceInfo:
 
 rootDataDirectory: ${FED_CONFIG_PATH:-data/stub-fed-config}
 
+clientTrustStoreConfiguration:
+  path: data/pki/hub.ts
+  password: marshmallow
+
 rpTrustStoreConfiguration:
   path: ${RP_TRUST_STORE_PATH:-data/pki/relying_parties.ts}
   password: marshmallow

--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -56,4 +56,8 @@ timeoutPeriod: 60m
 assertionLifetime: 60m
 matchingServiceResponseWaitPeriod: 60s
 
+clientTrustStoreConfiguration:
+  path: ${HUB_TRUST_STORE_PATH:-data/pki/hub.ts}
+  password: marshmallow
+
 eidas: true

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -33,6 +33,7 @@ import static uk.gov.ida.hub.config.domain.builders.TransactionConfigEntityDataB
 
 public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
 
+    private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
     private static final KeyStoreResource rpTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rpCA", CACertificates.TEST_RP_CA).build();
     private static final File FED_CONFIG_ROOT = new File(System.getProperty("java.io.tmpdir"), "test-fed-config");
     private final ObjectMapper mapper = new ObjectMapper();
@@ -51,6 +52,8 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
 
     public static ConfigOverride[] withDefaultOverrides(ConfigOverride ... configOverrides) {
         ImmutableList<ConfigOverride> overrides = ImmutableList.<ConfigOverride>builder()
+                .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
+                .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
                 .add(config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()))
                 .add(config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()))
                 .add(config("rootDataDirectory", FED_CONFIG_ROOT.getAbsolutePath()))
@@ -82,6 +85,7 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
     @Override
     protected void before() {
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
+        clientTrustStore.create();
         rpTrustStore.create();
 
         createFedConfig();
@@ -92,6 +96,7 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
     @Override
     protected void after() {
         rpTrustStore.delete();
+        clientTrustStore.delete();
 
         try {
             FileUtils.deleteDirectory(FED_CONFIG_ROOT);

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -15,8 +15,6 @@ import javax.validation.constraints.NotNull;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ConfigConfiguration extends Configuration implements TrustStoreConfiguration, ServiceNameConfiguration {
 
-    protected ConfigConfiguration() {}
-
     @Valid
     @NotNull
     @JsonProperty
@@ -26,6 +24,11 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @NotNull
     @Valid
     protected ServiceInfoConfiguration serviceInfo;
+
+    @Valid
+    @NotNull
+    @JsonProperty
+    protected ClientTrustStoreConfiguration clientTrustStoreConfiguration;
 
     @Valid
     @NotNull
@@ -42,6 +45,8 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @JsonProperty
     protected Duration certificateWarningPeriod = Duration.days(30);
 
+    protected ConfigConfiguration() {}
+
     public String getDataDirectory() {
         return rootDataDirectory;
     }
@@ -57,6 +62,10 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @Override
     public String getServiceName() {
         return serviceInfo.getName();
+    }
+
+    public ClientTrustStoreConfiguration getClientTrustStoreConfiguration() {
+        return this.clientTrustStoreConfiguration;
     }
 
     @Override

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/truststore/TrustStoreForCertificateProvider.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/truststore/TrustStoreForCertificateProvider.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.config.truststore;
 
+import uk.gov.ida.hub.config.ConfigConfiguration;
 import uk.gov.ida.hub.config.dto.FederationEntityType;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.KeyStoreCache;
@@ -12,13 +13,18 @@ import static java.text.MessageFormat.format;
 
 public class TrustStoreForCertificateProvider {
 
-    private TrustStoreConfiguration trustStoreConfiguration;
+    private final TrustStoreConfiguration trustStoreConfiguration;
     private final KeyStoreCache keyStoreCache;
+    private final ConfigConfiguration configConfiguration;
 
     @Inject
-    public TrustStoreForCertificateProvider(final TrustStoreConfiguration trustStoreConfiguration, KeyStoreCache keyStoreCache) {
+    public TrustStoreForCertificateProvider(
+        final TrustStoreConfiguration trustStoreConfiguration,
+        final KeyStoreCache keyStoreCache,
+        final ConfigConfiguration configConfiguration) {
         this.trustStoreConfiguration = trustStoreConfiguration;
         this.keyStoreCache = keyStoreCache;
+        this.configConfiguration = configConfiguration;
     }
 
     public KeyStore getTrustStoreFor(FederationEntityType federationEntityType) {
@@ -28,6 +34,9 @@ public class TrustStoreForCertificateProvider {
 
     private ClientTrustStoreConfiguration getAppropriateTrustStoreConfig(final FederationEntityType federationEntityType) {
         switch (federationEntityType) {
+            case HUB:
+            case IDP:
+                return configConfiguration.getClientTrustStoreConfiguration();
             case RP:
             case MS:
                 return trustStoreConfiguration.getRpTrustStoreConfiguration();

--- a/hub/config/src/test/resources/config.yml
+++ b/hub/config/src/test/resources/config.yml
@@ -36,6 +36,10 @@ serviceInfo:
 
 rootDataDirectory: configuration/config-service-data/local
 
+clientTrustStoreConfiguration:
+  path: ${IDP_TRUSTSTORE_PATH}
+  password: ${IDP_TRUSTSTORE_PASSWORD}
+
 rpTrustStoreConfiguration:
   path: ${RP_TRUSTSTORE_PATH}
   password: ${RP_TRUSTSTORE_PASSWORD}

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
@@ -1,9 +1,12 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule.support;
 
+import certificates.values.CACertificates;
 import com.google.common.collect.ImmutableList;
 import helpers.ResourceHelpers;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import keystore.KeyStoreResource;
+import keystore.builders.KeyStoreResourceBuilder;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;
@@ -12,7 +15,11 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.concurrent.ConcurrentMap;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+
 public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
+
+    private static final KeyStoreResource clientTrustStore = KeyStoreResourceBuilder.aKeyStoreResource().withCertificate("interCA", CACertificates.TEST_CORE_CA).withCertificate("rootCA", CACertificates.TEST_ROOT_CA).withCertificate("idpCA", CACertificates.TEST_IDP_CA).build();
 
     public PolicyAppRule(final ConfigOverride... configOverrides) {
         super(PolicyIntegrationApplication.class, ResourceHelpers.resourceFilePath("policy.yml"), withDefaultOverrides(configOverrides));
@@ -20,6 +27,8 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
 
     public static ConfigOverride[] withDefaultOverrides(final ConfigOverride... configOverrides) {
         ImmutableList<ConfigOverride> mergedConfigOverrides = ImmutableList.<ConfigOverride>builder()
+                .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
+                .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
                 .add(configOverrides)
                 .build();
         return mergedConfigOverrides.toArray(new ConfigOverride[mergedConfigOverrides.size()]);
@@ -27,11 +36,15 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
 
     @Override
     protected void before() {
+        clientTrustStore.create();
+
         super.before();
     }
 
     @Override
     protected void after() {
+        clientTrustStore.delete();
+
         super.after();
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/PolicyConfigurationBuilder.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/PolicyConfigurationBuilder.java
@@ -4,9 +4,11 @@ import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
+import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 
 import java.net.URI;
 
+import static org.mockito.Mockito.mock;
 import static uk.gov.ida.common.ServiceInfoConfigurationBuilder.aServiceInfo;
 
 public class PolicyConfigurationBuilder {
@@ -22,6 +24,7 @@ public class PolicyConfigurationBuilder {
         return new TestPolicyConfiguration(
                 new JerseyClientConfiguration(),
                 serviceInfo,
+                mock(ClientTrustStoreConfiguration.class),
                 timeoutPeriod,
                 Duration.minutes(1),
                 Duration.minutes(15));
@@ -41,6 +44,8 @@ public class PolicyConfigurationBuilder {
         private TestPolicyConfiguration(
                 JerseyClientConfiguration httpClient,
                 ServiceInfoConfiguration serviceInfo,
+                ClientTrustStoreConfiguration clientTrustStoreConfiguration,
+
                 Duration timeoutPeriod,
                 Duration matchingServiceResponseWaitPeriod,
                 Duration assertionLifetime) {
@@ -50,6 +55,7 @@ public class PolicyConfigurationBuilder {
             this.samlSoapProxyUri = URI.create("http://saml-soap-proxy");
             this.httpClient = httpClient;
             this.serviceInfo = serviceInfo;
+            this.clientTrustStoreConfiguration = clientTrustStoreConfiguration;
 
             this.timeoutPeriod = timeoutPeriod;
             this.matchingServiceResponseWaitPeriod = matchingServiceResponseWaitPeriod;

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -10,6 +10,7 @@ import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanServiceConfiguration;
+import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -17,8 +18,6 @@ import java.net.URI;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PolicyConfiguration extends Configuration implements RestfulClientConfiguration, ServiceNameConfiguration, InfinispanServiceConfiguration, AssertionLifetimeConfiguration {
-
-    protected PolicyConfiguration() {}
 
     @Valid
     @JsonProperty
@@ -80,12 +79,19 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @JsonProperty
     public URI configUri;
 
+    @Valid
+    @NotNull
+    @JsonProperty
+    public ClientTrustStoreConfiguration clientTrustStoreConfiguration;
+
     @JsonProperty
     public Boolean eidas = false;
 
     @Valid
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
+
+    protected PolicyConfiguration() {}
 
     public URI getSamlSoapProxyUri() { return samlSoapProxyUri;  }
 
@@ -135,6 +141,10 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @Override
     public String getServiceName() {
         return serviceInfo.getName();
+    }
+
+    public ClientTrustStoreConfiguration getClientTrustStoreConfiguration() {
+        return this.clientTrustStoreConfiguration;
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -44,12 +44,15 @@ import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.restclient.ClientProvider;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
+import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.KeyStoreLoader;
+import uk.gov.ida.truststore.KeyStoreProvider;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
+import java.security.KeyStore;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
@@ -60,6 +63,7 @@ public class PolicyModule extends AbstractModule {
         bind(RestfulClientConfiguration.class).to(PolicyConfiguration.class).in(Scopes.SINGLETON);
         bind(AssertionLifetimeConfiguration.class).to(PolicyConfiguration.class).in(Scopes.SINGLETON);
         bind(Client.class).toProvider(DefaultClientProvider.class).in(Scopes.SINGLETON);
+        bind(KeyStore.class).toProvider(KeyStoreProvider.class).in(Scopes.SINGLETON);
         bind(KeyStoreLoader.class).toInstance(new KeyStoreLoader());
         bind(InfinispanStartupTasks.class).asEagerSingleton();
         bind(JsonResponseProcessor.class);
@@ -134,6 +138,12 @@ public class PolicyModule extends AbstractModule {
     @Singleton
     public ServiceInfoConfiguration serviceInfo(PolicyConfiguration policyConfiguration) {
         return policyConfiguration.getServiceInfo();
+    }
+
+    @Provides
+    @Singleton
+    public ClientTrustStoreConfiguration clientTrustStoreConfiguration(PolicyConfiguration policyConfiguration) {
+        return policyConfiguration.getClientTrustStoreConfiguration();
     }
 
     @Provides

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -73,4 +73,8 @@ timeoutPeriod: 60m
 assertionLifetime: 60m
 matchingServiceResponseWaitPeriod: 60s
 
+clientTrustStoreConfiguration:
+  path: ${IDP_TRUSTSTORE_PATH}
+  password: ${IDP_TRUSTSTORE_PASSWORD}
+
 eidas: true


### PR DESCRIPTION
Policy and config use client truststore for other purposes and they do not use
metadata resolver to perform certificate chain validation on hub SAML signature
and encryption certificates and identity providers SAML signature certificates
in hub federation metadata file.

Co-authored-by: Rachel Smith <rachel.smith@digital.cabinet-office.gov.uk>