### PR TITLE
Log useful request / response attrs as JSON

### DIFF
--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
@@ -1,12 +1,18 @@
 package uk.gov.ida.hub.samlproxy.logging;
 
+import com.google.common.collect.ImmutableMap;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.StatusCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
 
 import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
 
 public class ProtectiveMonitoringLogger {
     private static final Logger LOG = LoggerFactory.getLogger(ProtectiveMonitoringLogger.class);
@@ -19,11 +25,35 @@ public class ProtectiveMonitoringLogger {
     }
 
     public void logAuthnRequest(AuthnRequest request, Direction direction, Boolean validSignature) {
+        Map<String, String> copyOfContextMap = MDC.getCopyOfContextMap();
+        MDC.setContextMap(ImmutableMap.<String, String>builder()
+                .put("requestId", request.getID())
+                .put("direction", direction.name())
+                .put("issuerId", Optional.ofNullable(request.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
+                .put("destination", request.getDestination())
+                .put("validSignature", validSignature.toString())
+                .put("service-name", "saml-proxy")
+                .build());
         LOG.info(formatter.formatAuthnRequest(request, direction, validSignature));
+        MDC.setContextMap(copyOfContextMap);
     }
 
     public void logAuthnResponse(Response samlResponse, Direction direction, Boolean validSignature) {
+        Map<String, String> copyOfContextMap = MDC.getCopyOfContextMap();
+        StatusCode statusCode = samlResponse.getStatus().getStatusCode();
+        MDC.setContextMap(ImmutableMap.<String, String>builder()
+                .put("responseId", samlResponse.getID())
+                .put("inResponseTo", samlResponse.getInResponseTo())
+                .put("status", statusCode.getValue())
+                .put("subStatus", Optional.ofNullable(statusCode.getStatusCode()).map(StatusCode::getValue).orElse("NoSubStatus"))
+                .put("direction", direction.name())
+                .put("issuerId", Optional.ofNullable(samlResponse.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
+                .put("destination", samlResponse.getDestination())
+                .put("validSignature", validSignature.toString())
+                .put("service-name", "saml-proxy")
+                .build());
         LOG.info(formatter.formatAuthnResponse(samlResponse, direction, validSignature));
+        MDC.setContextMap(copyOfContextMap);
     }
 
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
@@ -32,9 +32,9 @@ public class ProtectiveMonitoringLogger {
                 .put("issuerId", Optional.ofNullable(request.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", request.getDestination())
                 .put("validSignature", validSignature.toString())
-                .put("service-name", "saml-proxy")
                 .build());
         LOG.info(formatter.formatAuthnRequest(request, direction, validSignature));
+        MDC.clear();
         MDC.setContextMap(copyOfContextMap);
     }
 
@@ -50,9 +50,9 @@ public class ProtectiveMonitoringLogger {
                 .put("issuerId", Optional.ofNullable(samlResponse.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", samlResponse.getDestination())
                 .put("validSignature", validSignature.toString())
-                .put("service-name", "saml-proxy")
                 .build());
         LOG.info(formatter.formatAuthnResponse(samlResponse, direction, validSignature));
+        MDC.clear();
         MDC.setContextMap(copyOfContextMap);
     }
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
@@ -11,6 +11,7 @@ import org.slf4j.MDC;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -25,12 +26,12 @@ public class ProtectiveMonitoringLogger {
     }
 
     public void logAuthnRequest(AuthnRequest request, Direction direction, Boolean validSignature) {
-        Map<String, String> copyOfContextMap = MDC.getCopyOfContextMap();
+        Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("requestId", request.getID())
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(request.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
-                .put("destination", request.getDestination())
+                .put("destination", Optional.ofNullable(request.getDestination()).orElse("NoDestination"))
                 .put("validSignature", validSignature.toString())
                 .build());
         LOG.info(formatter.formatAuthnRequest(request, direction, validSignature));
@@ -39,7 +40,7 @@ public class ProtectiveMonitoringLogger {
     }
 
     public void logAuthnResponse(Response samlResponse, Direction direction, Boolean validSignature) {
-        Map<String, String> copyOfContextMap = MDC.getCopyOfContextMap();
+        Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
         StatusCode statusCode = samlResponse.getStatus().getStatusCode();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("responseId", samlResponse.getID())
@@ -48,7 +49,7 @@ public class ProtectiveMonitoringLogger {
                 .put("subStatus", Optional.ofNullable(statusCode.getStatusCode()).map(StatusCode::getValue).orElse("NoSubStatus"))
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(samlResponse.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
-                .put("destination", samlResponse.getDestination())
+                .put("destination", Optional.ofNullable(samlResponse.getDestination()).orElse("NoDestination"))
                 .put("validSignature", validSignature.toString())
                 .build());
         LOG.info(formatter.formatAuthnResponse(samlResponse, direction, validSignature));


### PR DESCRIPTION
Currently the ProtectiveMonitoringLogFormatter logs something which at
first glance may appear to be JSON. It has {} and keys/values separated
by : however don't be fooled. This is not JSON, there are no quotes "!.

This change places attributes which were part of the LogFormatter into
the MDC which is included in the Logstash output as JSON. Having
structured logs makes it easier to query them through ELK.

As this change doesn't alter the message logged it shouldn't impact any
current users of the logs (e.g. SecOps).