### PR TITLE
VCU-43: Configurable SHA Signing Algorithm

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/CryptoModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/CryptoModule.java
@@ -8,6 +8,7 @@ import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
 import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
 import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA1;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.PKIXParametersProvider;
@@ -44,7 +45,6 @@ public class CryptoModule extends AbstractModule {
         bind(KeyStoreLoader.class).toInstance(new KeyStoreLoader());
         bind(AssertionBlobEncrypter.class);
         bind(EncrypterFactory.class).toInstance(new EncrypterFactory());
-        bind(SignatureAlgorithm.class).toInstance(new SignatureRSASHA1());
         bind(DigestAlgorithm.class).toInstance(new DigestSHA256());
     }
 
@@ -66,6 +66,16 @@ public class CryptoModule extends AbstractModule {
     @Singleton
     public IdaKeyStoreCredentialRetriever getKeyStoreCredentialRetriever(IdaKeyStore keyStore) {
         return new IdaKeyStoreCredentialRetriever(keyStore);
+    }
+
+    @Provides
+    @Singleton
+    public SignatureAlgorithm getSignatureAlgorithm(SamlEngineConfiguration samlEngineConfiguration) {
+
+        return samlEngineConfiguration.shouldSignWithSHA1() ?
+                new SignatureRSASHA1() :
+                new SignatureRSASHA256();
+
     }
 
     @Provides

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -106,6 +106,11 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
+    @NotNull
+    @Valid
+    @JsonProperty
+    private boolean shouldSignWithSHA1 = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -180,5 +185,9 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
 
     @Override
     public boolean getEnableRetryTimeOutConnections() { return enableRetryTimeOutConnections; }
+
+    public boolean shouldSignWithSHA1() {
+        return shouldSignWithSHA1;
+    }
 
 }


### PR DESCRIPTION
Update the Hub (saml-engine) to sign with SHA256 by default.
Configuration option provided to revert to SHA1 if required.

Co-authored-by Alan Carter <alan.carter@digital.cabinet-office.gov.uk>