### PR TITLE
Handle cases where validSignature is null

### DIFF
--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatter.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatter.java
@@ -7,6 +7,7 @@ import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.core.StatusDetail;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.extensions.StatusValue;
 
 import java.util.Collections;
@@ -23,7 +24,7 @@ public class ProtectiveMonitoringLogFormatter {
             "inResponseTo: %s, direction: %s, destination: %s, issuerId: %s, validSignature: %s, " +
             "status: %s, subStatus: %s, statusDetails: %s}";
 
-    public String formatAuthnRequest(AuthnRequest authnRequest, Direction direction, Boolean validSignature) {
+    public String formatAuthnRequest(AuthnRequest authnRequest, Direction direction, SignatureStatus signatureStatus) {
         Issuer issuer = authnRequest.getIssuer();
         String issuerId = issuer != null ? issuer.getValue() : "";
 
@@ -32,10 +33,10 @@ public class ProtectiveMonitoringLogFormatter {
                 direction,
                 authnRequest.getDestination(),
                 issuerId,
-                validSignature);
+                signatureStatus.valid());
     }
 
-    public String formatAuthnResponse(Response samlResponse, Direction direction, Boolean validSignature) {
+    public String formatAuthnResponse(Response samlResponse, Direction direction, SignatureStatus signatureStatus) {
         Issuer issuer = samlResponse.getIssuer();
         String issuerString = issuer != null ? issuer.getValue() : "";
 
@@ -49,7 +50,7 @@ public class ProtectiveMonitoringLogFormatter {
                 direction,
                 samlResponse.getDestination(),
                 issuerString,
-                validSignature,
+                signatureStatus.valid(),
                 status.getStatusCode().getValue(),
                 subStatus,
                 getStatusDetailValues(status));

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -25,28 +26,23 @@ public class ProtectiveMonitoringLogger {
         this.formatter = formatter;
     }
 
-    public void logAuthnRequest(AuthnRequest request, Direction direction, Boolean validSignature) {
+    public void logAuthnRequest(AuthnRequest request, Direction direction, SignatureStatus signatureStatus) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
-        boolean isSigned = validSignature != null;
-        boolean hasValidSignature = isSigned && validSignature.booleanValue();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("requestId", request.getID())
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(request.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(request.getDestination()).orElse("NoDestination"))
-                .put("isSigned", String.valueOf(isSigned))
-                .put("hasValidSignature", String.valueOf(hasValidSignature))
+                .put("signatureStatus", signatureStatus.name())
                 .build());
-        LOG.info(formatter.formatAuthnRequest(request, direction, validSignature));
+        LOG.info(formatter.formatAuthnRequest(request, direction, signatureStatus));
         MDC.clear();
         MDC.setContextMap(copyOfContextMap);
     }
 
-    public void logAuthnResponse(Response samlResponse, Direction direction, Boolean validSignature) {
+    public void logAuthnResponse(Response samlResponse, Direction direction, SignatureStatus signatureStatus) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
         StatusCode statusCode = samlResponse.getStatus().getStatusCode();
-        boolean isSigned = validSignature != null;
-        boolean hasValidSignature = isSigned && validSignature.booleanValue();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("responseId", samlResponse.getID())
                 .put("inResponseTo", samlResponse.getInResponseTo())
@@ -55,10 +51,9 @@ public class ProtectiveMonitoringLogger {
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(samlResponse.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(samlResponse.getDestination()).orElse("NoDestination"))
-                .put("isSigned", String.valueOf(isSigned))
-                .put("hasValidSignature", String.valueOf(hasValidSignature))
+                .put("signatureStatus", signatureStatus.name())
                 .build());
-        LOG.info(formatter.formatAuthnResponse(samlResponse, direction, validSignature));
+        LOG.info(formatter.formatAuthnResponse(samlResponse, direction, signatureStatus));
         MDC.clear();
         MDC.setContextMap(copyOfContextMap);
     }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
@@ -27,12 +27,15 @@ public class ProtectiveMonitoringLogger {
 
     public void logAuthnRequest(AuthnRequest request, Direction direction, Boolean validSignature) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
+        boolean isSigned = validSignature != null;
+        boolean hasValidSignature = isSigned && validSignature.booleanValue();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("requestId", request.getID())
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(request.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(request.getDestination()).orElse("NoDestination"))
-                .put("validSignature", validSignature.toString())
+                .put("isSigned", String.valueOf(isSigned))
+                .put("hasValidSignature", String.valueOf(hasValidSignature))
                 .build());
         LOG.info(formatter.formatAuthnRequest(request, direction, validSignature));
         MDC.clear();
@@ -42,6 +45,8 @@ public class ProtectiveMonitoringLogger {
     public void logAuthnResponse(Response samlResponse, Direction direction, Boolean validSignature) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
         StatusCode statusCode = samlResponse.getStatus().getStatusCode();
+        boolean isSigned = validSignature != null;
+        boolean hasValidSignature = isSigned && validSignature.booleanValue();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("responseId", samlResponse.getID())
                 .put("inResponseTo", samlResponse.getInResponseTo())
@@ -50,7 +55,8 @@ public class ProtectiveMonitoringLogger {
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(samlResponse.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(samlResponse.getDestination()).orElse("NoDestination"))
-                .put("validSignature", validSignature.toString())
+                .put("isSigned", String.valueOf(isSigned))
+                .put("hasValidSignature", String.valueOf(hasValidSignature))
                 .build());
         LOG.info(formatter.formatAuthnResponse(samlResponse, direction, validSignature));
         MDC.clear();

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/repositories/SignatureStatus.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/repositories/SignatureStatus.java
@@ -1,0 +1,15 @@
+package uk.gov.ida.hub.samlproxy.repositories;
+
+import uk.gov.ida.saml.core.validation.SamlValidationResponse;
+
+public enum SignatureStatus {
+    VALID_SIGNATURE, INVALID_SIGNATURE, NO_SIGNATURE;
+
+    public static SignatureStatus fromValidationResponse(SamlValidationResponse samlValidationResponse) {
+        return samlValidationResponse.isOK() ? VALID_SIGNATURE : INVALID_SIGNATURE;
+    }
+
+    public boolean valid() {
+        return this == VALID_SIGNATURE;
+    }
+}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
@@ -15,6 +15,7 @@ import uk.gov.ida.hub.samlproxy.factories.EidasValidatorFactory;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.security.RelayStateValidator;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
@@ -76,7 +77,7 @@ public class SamlMessageReceiverApi {
 
         SamlValidationResponse signatureValidationResponse = authnRequestSignatureValidator.validate(authnRequest, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
-        protectiveMonitoringLogger.logAuthnRequest(authnRequest, Direction.INBOUND, signatureValidationResponse.isOK());
+        protectiveMonitoringLogger.logAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.fromValidationResponse(signatureValidationResponse));
 
         if (!signatureValidationResponse.isOK()) {
             SamlValidationSpecificationFailure failure = signatureValidationResponse.getSamlValidationSpecificationFailure();
@@ -107,7 +108,7 @@ public class SamlMessageReceiverApi {
         protectiveMonitoringLogger.logAuthnResponse(
                 samlResponse,
                 Direction.INBOUND,
-                signatureValidationResponse.isOK());
+                SignatureStatus.fromValidationResponse(signatureValidationResponse));
 
         if (!signatureValidationResponse.isOK()) {
             SamlValidationSpecificationFailure failure = signatureValidationResponse.getSamlValidationSpecificationFailure();
@@ -138,12 +139,12 @@ public class SamlMessageReceiverApi {
 
             org.opensaml.saml.saml2.core.Response samlResponse = stringSamlResponseTransformer.apply(samlRequestDto.getSamlRequest());
 
-            ValidatedResponse validatedResponse = eidasValidatorFactory.get().getValidatedResponse(samlResponse);
+            eidasValidatorFactory.get().getValidatedResponse(samlResponse);
 
             protectiveMonitoringLogger.logAuthnResponse(
                 samlResponse,
                 Direction.INBOUND,
-                validatedResponse.isSuccess());
+                SignatureStatus.VALID_SIGNATURE);
 
             final SamlAuthnResponseContainerDto authnResponseDto = new SamlAuthnResponseContainerDto(
                 samlRequestDto.getSamlRequest(),

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandlerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.ida.hub.samlproxy.logging.ExternalCommunicationEventLogger;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
@@ -119,7 +120,7 @@ public class SamlMessageSenderHandlerTest {
         assertThat(authnResponse.getSamlMessageType()).isEqualTo(SamlMessageType.SAML_RESPONSE);
 
         verify(externalCommunicationEventLogger).logResponseFromHub(expectedSamlMessageId, sessionId, postEndPoint, principalIpAddressAsSeenByHub);
-        verify(protectiveMonitoringLogger).logAuthnResponse(openSamlResponse, Direction.OUTBOUND, true);
+        verify(protectiveMonitoringLogger).logAuthnResponse(openSamlResponse, Direction.OUTBOUND, SignatureStatus.VALID_SIGNATURE);
     }
 
     @Test

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatterTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatterTest.java
@@ -8,6 +8,7 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.core.test.OpenSAMLRunner;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
@@ -39,7 +40,7 @@ public class ProtectiveMonitoringLogFormatterTest {
         String cancelXml = readXmlFile("status-cancel.xml");
         Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(cancelXml);
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(cancelResponse, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(cancelResponse, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         String expectedLogMessage = "Protective Monitoring – Authn Response Event – " +
                 "{responseId: _ccb1eabc4827928c9cbb3db34fdbe9df186dfcb8, " +
@@ -58,7 +59,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatAuthnSuccessResponse() throws IOException, URISyntaxException, MarshallingException, SignatureException {
         Response response = aResponse().build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         String expectedLogMessage = "Protective Monitoring – Authn Response Event – " +
                 "{responseId: default-response-id, " +
@@ -77,7 +78,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatResponseWithNoIssuer() throws IOException, URISyntaxException, MarshallingException, SignatureException {
         Response response = aResponse().withIssuer(null).build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         assertThat(logString).contains("issuerId: ,");
     }
@@ -86,7 +87,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatAuthnRequest() throws IOException, URISyntaxException {
         AuthnRequest authnRequest = anAuthnRequest().withId("test-id").withDestination("veganistan").build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         String expectedLogMessage = "Protective Monitoring – Authn Request Event – {" +
                 "requestId: test-id, " +
@@ -101,7 +102,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatAuthnRequestWithoutIssuer() throws IOException, URISyntaxException {
         AuthnRequest authnRequest = anAuthnRequest().withId("test-id").withDestination("veganistan").withIssuer(null).build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
         assertThat(logString).contains("issuerId: ,");
     }
 

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
@@ -17,9 +17,13 @@ import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProtectiveMonitoringLoggerTest {
@@ -58,13 +62,12 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, null);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.NO_SIGNATURE);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
         assertThat(loggingEvent.getMDCPropertyMap()).contains(
-                MapEntry.entry("isSigned", "false"),
-                MapEntry.entry("hasValidSignature", "false")
+                MapEntry.entry("signatureStatus", "NO_SIGNATURE")
         );
     }
 
@@ -78,13 +81,12 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, true);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.VALID_SIGNATURE);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
         assertThat(loggingEvent.getMDCPropertyMap()).contains(
-                MapEntry.entry("isSigned", "true"),
-                MapEntry.entry("hasValidSignature", "true")
+                MapEntry.entry("signatureStatus", "VALID_SIGNATURE")
         );
     }
 
@@ -98,13 +100,12 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.INVALID_SIGNATURE);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
         assertThat(loggingEvent.getMDCPropertyMap()).contains(
-                MapEntry.entry("isSigned", "true"),
-                MapEntry.entry("hasValidSignature", "false")
+                MapEntry.entry("signatureStatus", "INVALID_SIGNATURE")
         );
     }
 }

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
@@ -1,0 +1,100 @@
+package uk.gov.ida.hub.samlproxy.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import org.assertj.core.data.MapEntry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.slf4j.LoggerFactory;
+
+import uk.gov.ida.hub.samlproxy.repositories.Direction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProtectiveMonitoringLoggerTest {
+
+    @Mock
+    private Response samlResponse;
+    @Mock
+    private Status status;
+    @Mock
+    private StatusCode statusCode;
+
+    private static TestAppender testAppender = new TestAppender();
+
+    @Before
+    public void setUp() {
+        testAppender.start();
+        Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        logger.addAppender(testAppender);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        testAppender.stop();
+        TestAppender.events.clear();
+        Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        logger.detachAppender(testAppender);
+    }
+
+    @Test
+    public void shouldLogWhenNoSignatureExists() {
+        ProtectiveMonitoringLogger protectiveMonitoringLogger = new ProtectiveMonitoringLogger(new ProtectiveMonitoringLogFormatter());
+        when(samlResponse.getStatus()).thenReturn(status);
+        when(samlResponse.getID()).thenReturn("ID");
+        when(samlResponse.getInResponseTo()).thenReturn("InResponseTo");
+        when(status.getStatusCode()).thenReturn(statusCode);
+        when(statusCode.getValue()).thenReturn("all-good");
+
+
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, null);
+
+        assertThat(TestAppender.events.size()).isEqualTo(1);
+        assertThat(TestAppender.events.get(0).getMDCPropertyMap()).contains(
+                MapEntry.entry("isSigned", "false"),
+                MapEntry.entry("hasValidSignature", "false")
+        );
+    }
+
+    @Test
+    public void shouldLogWhenSignatureIsPresentAndCorrect() {
+        ProtectiveMonitoringLogger protectiveMonitoringLogger = new ProtectiveMonitoringLogger(new ProtectiveMonitoringLogFormatter());
+        when(samlResponse.getStatus()).thenReturn(status);
+        when(samlResponse.getID()).thenReturn("ID");
+        when(samlResponse.getInResponseTo()).thenReturn("InResponseTo");
+        when(status.getStatusCode()).thenReturn(statusCode);
+        when(statusCode.getValue()).thenReturn("all-good");
+
+
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, true);
+
+        assertThat(TestAppender.events.size()).isEqualTo(1);
+        assertThat(TestAppender.events.get(0).getMDCPropertyMap()).contains(
+                MapEntry.entry("isSigned", "true"),
+                MapEntry.entry("hasValidSignature", "true")
+        );
+    }
+
+    private static class TestAppender extends AppenderBase<ILoggingEvent> {
+        public static List<ILoggingEvent> events = new ArrayList<>();
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            events.add(eventObject);
+        }
+
+    }
+}

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
@@ -88,6 +88,25 @@ public class ProtectiveMonitoringLoggerTest {
         );
     }
 
+    @Test
+    public void shouldLogWhenSignatureIsPresentButInvalid() {
+        ProtectiveMonitoringLogger protectiveMonitoringLogger = new ProtectiveMonitoringLogger(new ProtectiveMonitoringLogFormatter());
+        when(samlResponse.getStatus()).thenReturn(status);
+        when(samlResponse.getID()).thenReturn("ID");
+        when(samlResponse.getInResponseTo()).thenReturn("InResponseTo");
+        when(status.getStatusCode()).thenReturn(statusCode);
+        when(statusCode.getValue()).thenReturn("all-good");
+
+
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false);
+
+        assertThat(TestAppender.events.size()).isEqualTo(1);
+        assertThat(TestAppender.events.get(0).getMDCPropertyMap()).contains(
+                MapEntry.entry("isSigned", "true"),
+                MapEntry.entry("hasValidSignature", "false")
+        );
+    }
+
     private static class TestAppender extends AppenderBase<ILoggingEvent> {
         public static List<ILoggingEvent> events = new ArrayList<>();
 

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
@@ -20,6 +20,7 @@ import uk.gov.ida.hub.samlproxy.factories.EidasValidatorFactory;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.security.RelayStateValidator;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
@@ -173,7 +174,7 @@ public class SamlMessageReceiverApiTest {
 
         samlMessageReceiverApi.handleRequestPost(SAML_REQUEST_DTO);
 
-        verify(protectiveMonitoringLogger).logAuthnRequest(authnRequest, Direction.INBOUND, true);
+        verify(protectiveMonitoringLogger).logAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
     }
 
     @Test
@@ -186,8 +187,8 @@ public class SamlMessageReceiverApiTest {
         verify(protectiveMonitoringLogger).logAuthnResponse(
                 validSamlResponse,
                 Direction.INBOUND,
-                true
-                );
+                SignatureStatus.VALID_SIGNATURE
+        );
     }
 
     @Test


### PR DESCRIPTION
In some cases the Hub will not sign Responses (relying on signed
assertions) and this logging would error with a NullPointerException.

This change separates the states of not having a signature and that
signature not being valid to better represent what is happening.