### PR TITLE
Remove boxed Boolean type from ProtMonLogging

### DIFF
--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandler.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandler.java
@@ -12,6 +12,7 @@ import uk.gov.ida.hub.samlproxy.logging.ExternalCommunicationEventLogger;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
@@ -111,7 +112,7 @@ public class SamlMessageSenderHandler {
         AuthnRequest request = authnRequestTransformer.apply(authnRequestFromHub.getSamlRequest());
 
         SamlValidationResponse samlSignatureValidationResponse = samlMessageSignatureValidator.validate(request, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
-        protectiveMonitoringLogger.logAuthnRequest(request, Direction.OUTBOUND, samlSignatureValidationResponse.isOK());
+        protectiveMonitoringLogger.logAuthnRequest(request, Direction.OUTBOUND, SignatureStatus.fromValidationResponse(samlSignatureValidationResponse));
 
         if (!samlSignatureValidationResponse.isOK()) {
             SamlValidationSpecificationFailure failure = samlSignatureValidationResponse.getSamlValidationSpecificationFailure();
@@ -127,14 +128,14 @@ public class SamlMessageSenderHandler {
         boolean isSigned = samlResponse.getIssuer() != null;
         if (isSigned) {
             SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(samlResponse, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
-            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, signatureValidationResponse.isOK(), isSigned);
+            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.fromValidationResponse(signatureValidationResponse));
 
             if (!signatureValidationResponse.isOK()) {
                 SamlValidationSpecificationFailure failure = signatureValidationResponse.getSamlValidationSpecificationFailure();
                 throw new SamlTransformationErrorException(failure.getErrorMessage(), signatureValidationResponse.getCause(), Level.ERROR);
             }
         } else {
-            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false, isSigned);
+            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.NO_SIGNATURE);
         }
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandler.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandler.java
@@ -127,14 +127,14 @@ public class SamlMessageSenderHandler {
         boolean isSigned = samlResponse.getIssuer() != null;
         if (isSigned) {
             SamlValidationResponse signatureValidationResponse = samlMessageSignatureValidator.validate(samlResponse, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
-            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, signatureValidationResponse.isOK());
+            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, signatureValidationResponse.isOK(), isSigned);
 
             if (!signatureValidationResponse.isOK()) {
                 SamlValidationSpecificationFailure failure = signatureValidationResponse.getSamlValidationSpecificationFailure();
                 throw new SamlTransformationErrorException(failure.getErrorMessage(), signatureValidationResponse.getCause(), Level.ERROR);
             }
         } else {
-            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, null);
+            protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false, isSigned);
         }
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatter.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatter.java
@@ -23,7 +23,7 @@ public class ProtectiveMonitoringLogFormatter {
             "inResponseTo: %s, direction: %s, destination: %s, issuerId: %s, validSignature: %s, " +
             "status: %s, subStatus: %s, statusDetails: %s}";
 
-    public String formatAuthnRequest(AuthnRequest authnRequest, Direction direction, Boolean validSignature) {
+    public String formatAuthnRequest(AuthnRequest authnRequest, Direction direction, boolean validSignature) {
         Issuer issuer = authnRequest.getIssuer();
         String issuerId = issuer != null ? issuer.getValue() : "";
 
@@ -35,7 +35,7 @@ public class ProtectiveMonitoringLogFormatter {
                 validSignature);
     }
 
-    public String formatAuthnResponse(Response samlResponse, Direction direction, Boolean validSignature) {
+    public String formatAuthnResponse(Response samlResponse, Direction direction, boolean validSignature) {
         Issuer issuer = samlResponse.getIssuer();
         String issuerString = issuer != null ? issuer.getValue() : "";
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatter.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatter.java
@@ -7,6 +7,7 @@ import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.core.StatusDetail;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.extensions.StatusValue;
 
 import java.util.Collections;
@@ -23,7 +24,7 @@ public class ProtectiveMonitoringLogFormatter {
             "inResponseTo: %s, direction: %s, destination: %s, issuerId: %s, validSignature: %s, " +
             "status: %s, subStatus: %s, statusDetails: %s}";
 
-    public String formatAuthnRequest(AuthnRequest authnRequest, Direction direction, boolean validSignature) {
+    public String formatAuthnRequest(AuthnRequest authnRequest, Direction direction, SignatureStatus signatureStatus) {
         Issuer issuer = authnRequest.getIssuer();
         String issuerId = issuer != null ? issuer.getValue() : "";
 
@@ -32,10 +33,10 @@ public class ProtectiveMonitoringLogFormatter {
                 direction,
                 authnRequest.getDestination(),
                 issuerId,
-                validSignature);
+                signatureStatus.valid());
     }
 
-    public String formatAuthnResponse(Response samlResponse, Direction direction, boolean validSignature) {
+    public String formatAuthnResponse(Response samlResponse, Direction direction, SignatureStatus signatureStatus) {
         Issuer issuer = samlResponse.getIssuer();
         String issuerString = issuer != null ? issuer.getValue() : "";
 
@@ -49,7 +50,7 @@ public class ProtectiveMonitoringLogFormatter {
                 direction,
                 samlResponse.getDestination(),
                 issuerString,
-                validSignature,
+                signatureStatus.valid(),
                 status.getStatusCode().getValue(),
                 subStatus,
                 getStatusDetailValues(status));

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -25,21 +26,21 @@ public class ProtectiveMonitoringLogger {
         this.formatter = formatter;
     }
 
-    public void logAuthnRequest(AuthnRequest request, Direction direction, boolean validSignature) {
+    public void logAuthnRequest(AuthnRequest request, Direction direction, SignatureStatus signatureStatus) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("requestId", request.getID())
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(request.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(request.getDestination()).orElse("NoDestination"))
-                .put("hasValidSignature", String.valueOf(validSignature))
+                .put("signatureStatus", signatureStatus.name())
                 .build());
-        LOG.info(formatter.formatAuthnRequest(request, direction, validSignature));
+        LOG.info(formatter.formatAuthnRequest(request, direction, signatureStatus));
         MDC.clear();
         MDC.setContextMap(copyOfContextMap);
     }
 
-    public void logAuthnResponse(Response samlResponse, Direction direction, boolean validSignature, boolean isSigned) {
+    public void logAuthnResponse(Response samlResponse, Direction direction, SignatureStatus signatureStatus) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
         StatusCode statusCode = samlResponse.getStatus().getStatusCode();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
@@ -50,10 +51,9 @@ public class ProtectiveMonitoringLogger {
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(samlResponse.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(samlResponse.getDestination()).orElse("NoDestination"))
-                .put("isSigned", String.valueOf(isSigned))
-                .put("hasValidSignature", String.valueOf(validSignature))
+                .put("signatureStatus", signatureStatus.name())
                 .build());
-        LOG.info(formatter.formatAuthnResponse(samlResponse, direction, validSignature));
+        LOG.info(formatter.formatAuthnResponse(samlResponse, direction, signatureStatus));
         MDC.clear();
         MDC.setContextMap(copyOfContextMap);
     }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogger.java
@@ -25,28 +25,23 @@ public class ProtectiveMonitoringLogger {
         this.formatter = formatter;
     }
 
-    public void logAuthnRequest(AuthnRequest request, Direction direction, Boolean validSignature) {
+    public void logAuthnRequest(AuthnRequest request, Direction direction, boolean validSignature) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
-        boolean isSigned = validSignature != null;
-        boolean hasValidSignature = isSigned && validSignature.booleanValue();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("requestId", request.getID())
                 .put("direction", direction.name())
                 .put("issuerId", Optional.ofNullable(request.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(request.getDestination()).orElse("NoDestination"))
-                .put("isSigned", String.valueOf(isSigned))
-                .put("hasValidSignature", String.valueOf(hasValidSignature))
+                .put("hasValidSignature", String.valueOf(validSignature))
                 .build());
         LOG.info(formatter.formatAuthnRequest(request, direction, validSignature));
         MDC.clear();
         MDC.setContextMap(copyOfContextMap);
     }
 
-    public void logAuthnResponse(Response samlResponse, Direction direction, Boolean validSignature) {
+    public void logAuthnResponse(Response samlResponse, Direction direction, boolean validSignature, boolean isSigned) {
         Map<String, String> copyOfContextMap = Optional.ofNullable(MDC.getCopyOfContextMap()).orElse(Collections.emptyMap());
         StatusCode statusCode = samlResponse.getStatus().getStatusCode();
-        boolean isSigned = validSignature != null;
-        boolean hasValidSignature = isSigned && validSignature.booleanValue();
         MDC.setContextMap(ImmutableMap.<String, String>builder()
                 .put("responseId", samlResponse.getID())
                 .put("inResponseTo", samlResponse.getInResponseTo())
@@ -56,7 +51,7 @@ public class ProtectiveMonitoringLogger {
                 .put("issuerId", Optional.ofNullable(samlResponse.getIssuer()).map(Issuer::getValue).orElse("NoIssuer"))
                 .put("destination", Optional.ofNullable(samlResponse.getDestination()).orElse("NoDestination"))
                 .put("isSigned", String.valueOf(isSigned))
-                .put("hasValidSignature", String.valueOf(hasValidSignature))
+                .put("hasValidSignature", String.valueOf(validSignature))
                 .build());
         LOG.info(formatter.formatAuthnResponse(samlResponse, direction, validSignature));
         MDC.clear();

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/repositories/SignatureStatus.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/repositories/SignatureStatus.java
@@ -1,0 +1,15 @@
+package uk.gov.ida.hub.samlproxy.repositories;
+
+import uk.gov.ida.saml.core.validation.SamlValidationResponse;
+
+public enum SignatureStatus {
+    VALID_SIGNATURE, INVALID_SIGNATURE, NO_SIGNATURE;
+
+    public static SignatureStatus fromValidationResponse(SamlValidationResponse samlValidationResponse) {
+        return samlValidationResponse.isOK() ? VALID_SIGNATURE : INVALID_SIGNATURE;
+    }
+
+    public boolean valid() {
+        return this == VALID_SIGNATURE;
+    }
+}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
@@ -15,6 +15,7 @@ import uk.gov.ida.hub.samlproxy.factories.EidasValidatorFactory;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.security.RelayStateValidator;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
@@ -76,7 +77,7 @@ public class SamlMessageReceiverApi {
 
         SamlValidationResponse signatureValidationResponse = authnRequestSignatureValidator.validate(authnRequest, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
-        protectiveMonitoringLogger.logAuthnRequest(authnRequest, Direction.INBOUND, signatureValidationResponse.isOK());
+        protectiveMonitoringLogger.logAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.fromValidationResponse(signatureValidationResponse));
 
         if (!signatureValidationResponse.isOK()) {
             SamlValidationSpecificationFailure failure = signatureValidationResponse.getSamlValidationSpecificationFailure();
@@ -107,7 +108,7 @@ public class SamlMessageReceiverApi {
         protectiveMonitoringLogger.logAuthnResponse(
                 samlResponse,
                 Direction.INBOUND,
-                signatureValidationResponse.isOK(), true);
+                SignatureStatus.fromValidationResponse(signatureValidationResponse));
 
         if (!signatureValidationResponse.isOK()) {
             SamlValidationSpecificationFailure failure = signatureValidationResponse.getSamlValidationSpecificationFailure();
@@ -138,12 +139,12 @@ public class SamlMessageReceiverApi {
 
             org.opensaml.saml.saml2.core.Response samlResponse = stringSamlResponseTransformer.apply(samlRequestDto.getSamlRequest());
 
-            ValidatedResponse validatedResponse = eidasValidatorFactory.get().getValidatedResponse(samlResponse);
+            eidasValidatorFactory.get().getValidatedResponse(samlResponse);
 
             protectiveMonitoringLogger.logAuthnResponse(
                 samlResponse,
                 Direction.INBOUND,
-                validatedResponse.isSuccess(), true);
+                SignatureStatus.VALID_SIGNATURE);
 
             final SamlAuthnResponseContainerDto authnResponseDto = new SamlAuthnResponseContainerDto(
                 samlRequestDto.getSamlRequest(),

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
@@ -107,7 +107,7 @@ public class SamlMessageReceiverApi {
         protectiveMonitoringLogger.logAuthnResponse(
                 samlResponse,
                 Direction.INBOUND,
-                signatureValidationResponse.isOK());
+                signatureValidationResponse.isOK(), true);
 
         if (!signatureValidationResponse.isOK()) {
             SamlValidationSpecificationFailure failure = signatureValidationResponse.getSamlValidationSpecificationFailure();
@@ -143,7 +143,7 @@ public class SamlMessageReceiverApi {
             protectiveMonitoringLogger.logAuthnResponse(
                 samlResponse,
                 Direction.INBOUND,
-                validatedResponse.isSuccess());
+                validatedResponse.isSuccess(), true);
 
             final SamlAuthnResponseContainerDto authnResponseDto = new SamlAuthnResponseContainerDto(
                 samlRequestDto.getSamlRequest(),

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandlerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandlerTest.java
@@ -119,7 +119,7 @@ public class SamlMessageSenderHandlerTest {
         assertThat(authnResponse.getSamlMessageType()).isEqualTo(SamlMessageType.SAML_RESPONSE);
 
         verify(externalCommunicationEventLogger).logResponseFromHub(expectedSamlMessageId, sessionId, postEndPoint, principalIpAddressAsSeenByHub);
-        verify(protectiveMonitoringLogger).logAuthnResponse(openSamlResponse, Direction.OUTBOUND, true);
+        verify(protectiveMonitoringLogger).logAuthnResponse(openSamlResponse, Direction.OUTBOUND, true, true);
     }
 
     @Test

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandlerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageSenderHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.ida.hub.samlproxy.logging.ExternalCommunicationEventLogger;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
@@ -119,7 +120,7 @@ public class SamlMessageSenderHandlerTest {
         assertThat(authnResponse.getSamlMessageType()).isEqualTo(SamlMessageType.SAML_RESPONSE);
 
         verify(externalCommunicationEventLogger).logResponseFromHub(expectedSamlMessageId, sessionId, postEndPoint, principalIpAddressAsSeenByHub);
-        verify(protectiveMonitoringLogger).logAuthnResponse(openSamlResponse, Direction.OUTBOUND, true, true);
+        verify(protectiveMonitoringLogger).logAuthnResponse(openSamlResponse, Direction.OUTBOUND, SignatureStatus.VALID_SIGNATURE);
     }
 
     @Test

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatterTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatterTest.java
@@ -8,6 +8,7 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.core.test.OpenSAMLRunner;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
@@ -39,7 +40,7 @@ public class ProtectiveMonitoringLogFormatterTest {
         String cancelXml = readXmlFile("status-cancel.xml");
         Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(cancelXml);
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(cancelResponse, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(cancelResponse, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         String expectedLogMessage = "Protective Monitoring – Authn Response Event – " +
                 "{responseId: _ccb1eabc4827928c9cbb3db34fdbe9df186dfcb8, " +
@@ -58,7 +59,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatAuthnSuccessResponse() throws IOException, URISyntaxException, MarshallingException, SignatureException {
         Response response = aResponse().build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         String expectedLogMessage = "Protective Monitoring – Authn Response Event – " +
                 "{responseId: default-response-id, " +
@@ -77,7 +78,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatResponseWithNoIssuer() throws IOException, URISyntaxException, MarshallingException, SignatureException {
         Response response = aResponse().withIssuer(null).build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         assertThat(logString).contains("issuerId: ,");
     }
@@ -86,7 +87,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatAuthnRequest() throws IOException, URISyntaxException {
         AuthnRequest authnRequest = anAuthnRequest().withId("test-id").withDestination("veganistan").build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         String expectedLogMessage = "Protective Monitoring – Authn Request Event – {" +
                 "requestId: test-id, " +
@@ -101,7 +102,7 @@ public class ProtectiveMonitoringLogFormatterTest {
     public void shouldFormatAuthnRequestWithoutIssuer() throws IOException, URISyntaxException {
         AuthnRequest authnRequest = anAuthnRequest().withId("test-id").withDestination("veganistan").withIssuer(null).build();
 
-        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, true);
+        String logString = new ProtectiveMonitoringLogFormatter().formatAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
         assertThat(logString).contains("issuerId: ,");
     }
 

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
@@ -58,7 +58,7 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, null);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false, false);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
@@ -78,7 +78,7 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, true);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, true, true);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
@@ -98,7 +98,7 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false, true);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLoggerTest.java
@@ -17,9 +17,13 @@ import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProtectiveMonitoringLoggerTest {
@@ -58,13 +62,12 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false, false);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.NO_SIGNATURE);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
         assertThat(loggingEvent.getMDCPropertyMap()).contains(
-                MapEntry.entry("isSigned", "false"),
-                MapEntry.entry("hasValidSignature", "false")
+                MapEntry.entry("signatureStatus", "NO_SIGNATURE")
         );
     }
 
@@ -78,13 +81,12 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, true, true);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.VALID_SIGNATURE);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
         assertThat(loggingEvent.getMDCPropertyMap()).contains(
-                MapEntry.entry("isSigned", "true"),
-                MapEntry.entry("hasValidSignature", "true")
+                MapEntry.entry("signatureStatus", "VALID_SIGNATURE")
         );
     }
 
@@ -98,13 +100,12 @@ public class ProtectiveMonitoringLoggerTest {
         when(statusCode.getValue()).thenReturn("all-good");
 
 
-        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, false, true);
+        protectiveMonitoringLogger.logAuthnResponse(samlResponse, Direction.OUTBOUND, SignatureStatus.INVALID_SIGNATURE);
 
         verify(appender, times(1)).doAppend(captorLoggingEvent.capture());
         final ILoggingEvent loggingEvent = captorLoggingEvent.getValue();
         assertThat(loggingEvent.getMDCPropertyMap()).contains(
-                MapEntry.entry("isSigned", "true"),
-                MapEntry.entry("hasValidSignature", "false")
+                MapEntry.entry("signatureStatus", "INVALID_SIGNATURE")
         );
     }
 }

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
@@ -186,8 +186,8 @@ public class SamlMessageReceiverApiTest {
         verify(protectiveMonitoringLogger).logAuthnResponse(
                 validSamlResponse,
                 Direction.INBOUND,
-                true
-                );
+                true, true
+        );
     }
 
     @Test

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
@@ -20,6 +20,7 @@ import uk.gov.ida.hub.samlproxy.factories.EidasValidatorFactory;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.repositories.Direction;
+import uk.gov.ida.hub.samlproxy.repositories.SignatureStatus;
 import uk.gov.ida.saml.core.security.RelayStateValidator;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.validation.SamlValidationResponse;
@@ -173,7 +174,7 @@ public class SamlMessageReceiverApiTest {
 
         samlMessageReceiverApi.handleRequestPost(SAML_REQUEST_DTO);
 
-        verify(protectiveMonitoringLogger).logAuthnRequest(authnRequest, Direction.INBOUND, true);
+        verify(protectiveMonitoringLogger).logAuthnRequest(authnRequest, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
     }
 
     @Test
@@ -186,7 +187,7 @@ public class SamlMessageReceiverApiTest {
         verify(protectiveMonitoringLogger).logAuthnResponse(
                 validSamlResponse,
                 Direction.INBOUND,
-                true, true
+                SignatureStatus.VALID_SIGNATURE
         );
     }
 


### PR DESCRIPTION
Previously we were using a Boolean type to represent the following
 - null: no signature on the request/response
 - false: signature present but not valid
 - true: signature present and valid

This can be problematic as null checks need to be carefully performed.
These checks were missing in a035bb51a2f469022dbb25bd163e4d9a49d3ce8b

This commit replaces the usage of `null` with a separate isSigned
boolean. The change is only necessary for when processing Response
objects as they have this option of being unsigned (simple profile).