### PR TITLE
VCU-43: Configurable Signing Algorithm per Service

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundLegacyResponseFromHubToStringFunctionSHA256.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundLegacyResponseFromHubToStringFunctionSHA256.java
@@ -1,0 +1,18 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+
+import java.util.function.Function;
+
+public class OutboundLegacyResponseFromHubToStringFunctionSHA256 implements Function<OutboundResponseFromHub, String> {
+    private Function<OutboundResponseFromHub, String> transformer;
+
+    public OutboundLegacyResponseFromHubToStringFunctionSHA256(Function<OutboundResponseFromHub,String> transformer) {
+        this.transformer = transformer;
+    }
+
+    @Override
+    public String apply(OutboundResponseFromHub outboundResponseFromHub) {
+        return transformer.apply(outboundResponseFromHub);
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundSamlProfileResponseFromHubToStringFunctionSHA256.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundSamlProfileResponseFromHubToStringFunctionSHA256.java
@@ -1,0 +1,18 @@
+package uk.gov.ida.saml.hub.transformers.outbound;
+
+import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
+
+import java.util.function.Function;
+
+public class OutboundSamlProfileResponseFromHubToStringFunctionSHA256 implements Function<OutboundResponseFromHub, String> {
+    private Function<OutboundResponseFromHub, String> transformer;
+
+    public OutboundSamlProfileResponseFromHubToStringFunctionSHA256(Function<OutboundResponseFromHub,String> transformer) {
+        this.transformer = transformer;
+    }
+
+    @Override
+    public String apply(OutboundResponseFromHub outboundResponseFromHub) {
+        return transformer.apply(outboundResponseFromHub);
+    }
+}

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -98,11 +98,7 @@ import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappings
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer;
-import uk.gov.ida.saml.hub.transformers.outbound.AssertionFromIdpToAssertionTransformer;
-import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunction;
-import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunction;
-import uk.gov.ida.saml.hub.transformers.outbound.SimpleProfileOutboundResponseFromHubToSamlResponseTransformer;
-import uk.gov.ida.saml.hub.transformers.outbound.SimpleProfileTransactionIdaStatusMarshaller;
+import uk.gov.ida.saml.hub.transformers.outbound.*;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.ResponseToUnsignedStringTransformer;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.SimpleProfileOutboundResponseFromHubToResponseTransformerProvider;
 import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestIdKey;
@@ -501,6 +497,27 @@ public class SamlEngineModule extends AbstractModule {
 
     @Provides
     @SuppressWarnings("unused")
+    private OutboundLegacyResponseFromHubToStringFunctionSHA256 getOutboundLegacyResponseFromHubToSignedResponseTransformerProvider(
+            EncryptionKeyStore encryptionKeyStore,
+            IdaKeyStore keyStore,
+            EntityToEncryptForLocator entityToEncryptForLocator,
+            ResponseAssertionSigner responseAssertionSigner,
+            DigestAlgorithm digestAlgorithm) {
+
+        return new OutboundLegacyResponseFromHubToStringFunctionSHA256(
+                hubTransformersFactory.getOutboundResponseFromHubToStringTransformer(
+                        encryptionKeyStore,
+                        keyStore,
+                        entityToEncryptForLocator,
+                        responseAssertionSigner,
+                        new SignatureRSASHA256(),
+                        digestAlgorithm
+                )
+        );
+    }
+
+    @Provides
+    @SuppressWarnings("unused")
     private OutboundSamlProfileResponseFromHubToStringFunction getOutboundSamlProfileResponseFromHubToSignedResponseTransformerProvider(
             EncryptionKeyStore encryptionKeyStore,
             IdaKeyStore keyStore,
@@ -516,6 +533,27 @@ public class SamlEngineModule extends AbstractModule {
                         entityToEncryptForLocator,
                         responseAssertionSigner,
                         signatureAlgorithm,
+                        digestAlgorithm
+                )
+        );
+    }
+
+    @Provides
+    @SuppressWarnings("unused")
+    private OutboundSamlProfileResponseFromHubToStringFunctionSHA256 getOutboundSamlProfileResponseFromHubToSignedResponseTransformerProviderSHA256(
+            EncryptionKeyStore encryptionKeyStore,
+            IdaKeyStore keyStore,
+            EntityToEncryptForLocator entityToEncryptForLocator,
+            ResponseAssertionSigner responseAssertionSigner,
+            DigestAlgorithm digestAlgorithm) {
+
+        return new OutboundSamlProfileResponseFromHubToStringFunctionSHA256(
+                hubTransformersFactory.getSamlProfileOutboundResponseFromHubToStringTransformer(
+                        encryptionKeyStore,
+                        keyStore,
+                        entityToEncryptForLocator,
+                        responseAssertionSigner,
+                        new SignatureRSASHA256(),
                         digestAlgorithm
                 )
         );

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/OutboundResponseFromHubToResponseTransformerFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/OutboundResponseFromHubToResponseTransformerFactory.java
@@ -3,7 +3,9 @@ package uk.gov.ida.hub.samlengine.factories;
 import uk.gov.ida.hub.samlengine.proxy.TransactionsConfigProxy;
 import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
 import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunctionSHA256;
 import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunctionSHA256;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.SimpleProfileOutboundResponseFromHubToResponseTransformerProvider;
 
 import javax.inject.Inject;
@@ -12,7 +14,9 @@ import java.util.function.Function;
 public class OutboundResponseFromHubToResponseTransformerFactory {
 
     private final OutboundLegacyResponseFromHubToStringFunction outboundLegacyResponseFromHubToStringFunction;
+    private final OutboundLegacyResponseFromHubToStringFunctionSHA256 outboundLegacyResponseFromHubToStringFunctionSHA256;
     private final OutboundSamlProfileResponseFromHubToStringFunction outboundSamlProfileResponseFromHubToStringFunction;
+    private final OutboundSamlProfileResponseFromHubToStringFunctionSHA256 outboundSamlProfileResponseFromHubToStringFunctionSHA256;
     private final SimpleProfileOutboundResponseFromHubToResponseTransformerProvider simpleProfileOutboundResponseFromHubToResponseTransformerProvider;
     private final TransactionsConfigProxy transactionsConfigProxy;
 
@@ -20,9 +24,13 @@ public class OutboundResponseFromHubToResponseTransformerFactory {
     public OutboundResponseFromHubToResponseTransformerFactory(OutboundLegacyResponseFromHubToStringFunction outboundLegacyResponseFromHubToStringFunction,
                                                                OutboundSamlProfileResponseFromHubToStringFunction outboundSamlProfileResponseFromHubToStringFunction,
                                                                SimpleProfileOutboundResponseFromHubToResponseTransformerProvider simpleProfileOutboundResponseFromHubToResponseTransformerProvider,
-                                                               TransactionsConfigProxy transactionsConfigProxy) {
+                                                               TransactionsConfigProxy transactionsConfigProxy,
+                                                               OutboundSamlProfileResponseFromHubToStringFunctionSHA256 outboundSamlProfileResponseFromHubToStringFunctionSHA256,
+                                                               OutboundLegacyResponseFromHubToStringFunctionSHA256 outboundLegacyResponseFromHubToStringFunctionSHA256) {
         this.outboundLegacyResponseFromHubToStringFunction = outboundLegacyResponseFromHubToStringFunction;
+        this.outboundLegacyResponseFromHubToStringFunctionSHA256 = outboundLegacyResponseFromHubToStringFunctionSHA256;
         this.outboundSamlProfileResponseFromHubToStringFunction = outboundSamlProfileResponseFromHubToStringFunction;
+        this.outboundSamlProfileResponseFromHubToStringFunctionSHA256 = outboundSamlProfileResponseFromHubToStringFunctionSHA256;
         this.simpleProfileOutboundResponseFromHubToResponseTransformerProvider = simpleProfileOutboundResponseFromHubToResponseTransformerProvider;
         this.transactionsConfigProxy = transactionsConfigProxy;
     }
@@ -30,9 +38,13 @@ public class OutboundResponseFromHubToResponseTransformerFactory {
     public Function<OutboundResponseFromHub, String> get(String authnRequestIssuerEntityId) {
         if (transactionsConfigProxy.getShouldHubSignResponseMessages(authnRequestIssuerEntityId)) {
             if (transactionsConfigProxy.getShouldHubUseLegacySamlStandard(authnRequestIssuerEntityId)) {
-                return outboundLegacyResponseFromHubToStringFunction;
+                return transactionsConfigProxy.getShouldSignWithSHA1(authnRequestIssuerEntityId) ?
+                        outboundLegacyResponseFromHubToStringFunction :
+                        outboundLegacyResponseFromHubToStringFunctionSHA256;
             } else {
-                return outboundSamlProfileResponseFromHubToStringFunction;
+                return transactionsConfigProxy.getShouldSignWithSHA1(authnRequestIssuerEntityId) ?
+                        outboundSamlProfileResponseFromHubToStringFunction :
+                        outboundSamlProfileResponseFromHubToStringFunctionSHA256;
             }
         }
         return simpleProfileOutboundResponseFromHubToResponseTransformerProvider.get();

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/proxy/TransactionsConfigProxy.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/proxy/TransactionsConfigProxy.java
@@ -72,4 +72,8 @@ public class TransactionsConfigProxy {
             throw new RuntimeException(e.getCause());
         }
     }
+    
+    public Boolean getShouldSignWithSHA1(String entityId) {
+        return true;
+    }
 }

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/factories/OutboundResponseFromHubToResponseTransformerFactoryTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/factories/OutboundResponseFromHubToResponseTransformerFactoryTest.java
@@ -8,7 +8,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ida.hub.samlengine.proxy.TransactionsConfigProxy;
 import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
 import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunctionSHA256;
 import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunctionSHA256;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.SimpleProfileOutboundResponseFromHubToResponseTransformerProvider;
 
 import java.util.function.Function;
@@ -25,7 +27,13 @@ public class OutboundResponseFromHubToResponseTransformerFactoryTest {
     private OutboundLegacyResponseFromHubToStringFunction outboundLegacyResponseFromHubToStringFunction;
 
     @Mock
+    private OutboundLegacyResponseFromHubToStringFunctionSHA256 outboundLegacyResponseFromHubToStringFunctionSHA256;
+
+    @Mock
     private OutboundSamlProfileResponseFromHubToStringFunction outboundSamlProfileResponseFromHubToStringFunction;
+
+    @Mock
+    private OutboundSamlProfileResponseFromHubToStringFunctionSHA256 outboundSamlProfileResponseFromHubToStringFunctionSHA256;
 
     @Mock
     private SimpleProfileOutboundResponseFromHubToResponseTransformerProvider simpleProfileOutboundResponseFromHubToResponseTransformerProvider;
@@ -44,13 +52,16 @@ public class OutboundResponseFromHubToResponseTransformerFactoryTest {
                 outboundLegacyResponseFromHubToStringFunction,
                 outboundSamlProfileResponseFromHubToStringFunction,
                 simpleProfileOutboundResponseFromHubToResponseTransformerProvider,
-                transactionsConfigProxy);
+                transactionsConfigProxy,
+                outboundSamlProfileResponseFromHubToStringFunctionSHA256,
+                outboundLegacyResponseFromHubToStringFunctionSHA256);
     }
 
     @Test
-    public void toResponse_shouldReturnOutboundLegacyResponseFromHubToStringFunctionWhenHubShouldSignResponseMessages() throws Exception {
+    public void toResponseShouldReturnOutboundLegacyResponseFromHubToStringFunctionWhenHubShouldSignResponseMessages() throws Exception {
         when(transactionsConfigProxy.getShouldHubSignResponseMessages(ENTITY_ID)).thenReturn(true);
         when(transactionsConfigProxy.getShouldHubUseLegacySamlStandard(ENTITY_ID)).thenReturn(true);
+        when(transactionsConfigProxy.getShouldSignWithSHA1(ENTITY_ID)).thenReturn(true);
 
         Function<OutboundResponseFromHub, String> transformer = outboundResponseFromHubToResponseTransformerFactory.get(ENTITY_ID);
 
@@ -58,9 +69,23 @@ public class OutboundResponseFromHubToResponseTransformerFactoryTest {
     }
 
     @Test
-    public void toResponse_shouldReturnOutboundSamlProfileResponseFromHubToStringFunctionWhenHubShouldSignResponseMessages() throws Exception {
+    public void toResponseShouldReturnOutboundLegacyResponseFromHubToStringFunctionSHA256WhenHubShouldSignResponseMessages() throws Exception {
+
+        when(transactionsConfigProxy.getShouldHubSignResponseMessages(ENTITY_ID)).thenReturn(true);
+        when(transactionsConfigProxy.getShouldHubUseLegacySamlStandard(ENTITY_ID)).thenReturn(true);
+        when(transactionsConfigProxy.getShouldSignWithSHA1(ENTITY_ID)).thenReturn(false);
+
+        Function<OutboundResponseFromHub, String> transformer = outboundResponseFromHubToResponseTransformerFactory.get(ENTITY_ID);
+
+        assertThat(transformer).isEqualTo(outboundLegacyResponseFromHubToStringFunctionSHA256);
+    }
+
+    @Test
+    public void toResponseShouldReturnOutboundSamlProfileResponseFromHubToStringFunctionWhenHubShouldSignResponseMessages() throws Exception {
+
         when(transactionsConfigProxy.getShouldHubSignResponseMessages(ENTITY_ID)).thenReturn(true);
         when(transactionsConfigProxy.getShouldHubUseLegacySamlStandard(ENTITY_ID)).thenReturn(false);
+        when(transactionsConfigProxy.getShouldSignWithSHA1(ENTITY_ID)).thenReturn(true);
 
         Function<OutboundResponseFromHub, String> transformer = outboundResponseFromHubToResponseTransformerFactory.get(ENTITY_ID);
 
@@ -68,7 +93,21 @@ public class OutboundResponseFromHubToResponseTransformerFactoryTest {
     }
 
     @Test
-    public void toResponse_shouldReturnSimpleProfileOutboundResponseFromHubToResponseTransformerProviderWhenHubShouldSignResponseMessages() throws Exception {
+    public void toResponseShouldReturnOutboundSamlProfileResponseFromHubToStringFunctionSHA256WhenHubShouldSignResponseMessages() throws Exception {
+
+        when(transactionsConfigProxy.getShouldHubSignResponseMessages(ENTITY_ID)).thenReturn(true);
+        when(transactionsConfigProxy.getShouldHubUseLegacySamlStandard(ENTITY_ID)).thenReturn(false);
+        when(transactionsConfigProxy.getShouldSignWithSHA1(ENTITY_ID)).thenReturn(false);
+
+        Function<OutboundResponseFromHub, String> transformer = outboundResponseFromHubToResponseTransformerFactory.get(ENTITY_ID);
+
+        assertThat(transformer).isEqualTo(outboundSamlProfileResponseFromHubToStringFunctionSHA256);
+    }
+
+    @Test
+
+    public void toResponseShouldReturnSimpleProfileOutboundResponseFromHubToResponseTransformerProviderWhenHubShouldSignResponseMessages() throws Exception {
+
         when(transactionsConfigProxy.getShouldHubSignResponseMessages(ENTITY_ID)).thenReturn(false);
 
         when(simpleProfileOutboundResponseFromHubToResponseTransformerProvider.get()).thenReturn(simpleProfileOutboundResponseFromHubToResponseTransformer);


### PR DESCRIPTION
Switch between SHA1 and SHA256 signing depending on a flag in the transaction configuration.
Flag currently hard-coded to stay on SHA1, pending corresponding changes to the config component.