### PR TITLE
bau: Build verify-hub in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+env:
+  - VERIFY_USE_PUBLIC_BINARIES=true
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk8
+matrix:
+  allow_failures:
+  - jdk: oraclejdk9
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 verify-hub
 =======
 
+[![Build Status](https://travis-ci.org/alphagov/verify-hub.svg?branch=master)](https://travis-ci.org/alphagov/verify-hub)
+
 The goal of the Verify Hub Architecture is to provide a long term flexible and scalable solution for GOV.UK Verify. In order to achieve this, the system is a Service Oriented Architecture(SOA) using REST and principles borrowed from the concept of microservices.
 
 The system is divided into logical microservices – with one or more services that provide the functionality required to implement the Hub SAML Profile. Some of the separation is due to logical differences between the components, while other separation is base on security aspects of the service. The eventual goal for this system is for each of these components to be independently deployable and live in separate code bases.

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,18 @@
 buildscript {
     repositories {
-        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+          logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+          maven { url 'https://dl.bintray.com/alphagov/maven-test' }
+          jcenter()
+        }
+        else {
+          maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        }
     }
     dependencies {
         classpath 'com.github.spullara.mustache.java:compiler:0.8.10',
                 'org.yaml:snakeyaml:1.10',
-                'uk.gov.ida:ida-gradle:1.1.0-20',
+                'uk.gov.ida:ida-gradle:1.1.0-23',
                 'com.google.guava:guava:14.0.1',
                 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     }
@@ -21,15 +28,15 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'333',
+            ida_utils:'336',
             dropwizard:'1.1.4',
-            dropwizard_infinispan:'1.1.4-41',
+            dropwizard_infinispan:'1.1.4-45',
             pact:'3.5.6',
-            stub_idp_saml:"$opensaml_version-70",
-            ida_test_utils:"2.0.0-39",
+            stub_idp_saml:"$opensaml_version-72",
+            ida_test_utils:"2.0.0-43",
             opensaml:"$opensaml_version",
-            dev_pki: '1.1.0-28',
-            saml_libs:"$opensaml_version-143",
+            dev_pki: '1.1.0-34',
+            saml_libs:"$opensaml_version-147",
         ]
 
 subprojects {
@@ -40,7 +47,15 @@ subprojects {
     version = "0.1.$version"
 
     repositories {
-        maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+          logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+          maven { url 'https://dl.bintray.com/alphagov/maven' } // For dropwizard-logstash
+          maven { url 'https://dl.bintray.com/alphagov/maven-test' } // For other public verify binaries
+          jcenter()
+        }
+        else {
+          maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        }
     }
 
     configurations.all {

--- a/idea.gradle
+++ b/idea.gradle
@@ -1,11 +1,16 @@
 buildscript {
     repositories {
-        maven {
-            url 'https://build.ida.digital.cabinet-office.gov.uk/maven/'
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+          logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+          maven { url 'https://dl.bintray.com/alphagov/maven-test' }
+          jcenter()
+        }
+        else {
+          maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
         }
     }
     dependencies {
-        classpath 'uk.gov.ida:ida-gradle:1.0.0-4'
+        classpath 'uk.gov.ida:ida-gradle:1.1.0-23'
     }
 }
 


### PR DESCRIPTION
Using the same VERIFY_USE_PUBLIC_BINARIES environment variable as in the
libraries to flag the us of the bintray binaries.

This will mean that:

1) Third parties can build hub without access to our private artifactory
2) We will have nice travis-y PR builds in hub
3) We can display a nice build status badge in the readme

Also discovered that there were three tests that would fail if LOG LEVEL was
set higher than INFO (which it is on Travis), due to a missing side effect of
the console logger. These are a bit more robust now thanks to a pretty hacky
call to `getMDCPropertyMap()`.