### PR TITLE
bau: Publish hub-saml to bintray

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e # abort if you encounter an error
 set -o pipefail # abort if there is an error in a piped operation
-./gradlew -Pversion=$BUILD_NUMBER clean test intTest copyToLib publish
+./gradlew -Pversion=$BUILD_NUMBER clean test intTest copyToLib publish bintrayUpload
 bin/build_and_upload_debs.rb
 ./gradlew outputDependencies -q > dependencies.properties


### PR DESCRIPTION
I thought the hub-saml jenkins job would do this, but it looks like that
job is actually a vestige of before we moved hub-saml into hub and
archived the repo.

verify-hub's jenkins job isn't JJB'd, so I'll set up the relevant bits
in the jenkins UI.