### PR TITLE
VCU-27: Upgrade EqualsVerifier to 2.4.5.

### DIFF
--- a/hub/policy/build.gradle
+++ b/hub/policy/build.gradle
@@ -5,7 +5,7 @@ dependencies {
             configurations.ida_test_utils,
             configurations.saml,
             'org.infinispan:infinispan-core:7.1.1.Final:tests',
-            'nl.jqno.equalsverifier:equalsverifier:2.4'
+            'nl.jqno.equalsverifier:equalsverifier:2.4.5'
 
     compile configurations.ida_utils,
             configurations.verify_event_emitter,


### PR DESCRIPTION
Allows unit tests to pass under Java 10.

Co-authored-by: Alan Carter <alan.carter@digital.cabinet-office.gov.uk>