### PR TITLE
VCU-96: Use of SharedSecrets compatible with Java 8, 9 and 10.

### DIFF
--- a/hub/saml-engine/build.gradle
+++ b/hub/saml-engine/build.gradle
@@ -20,6 +20,12 @@ apply plugin: 'application'
 ext.mainclass = 'uk.gov.ida.hub.samlengine.SamlEngineApplication'
 mainClassName = ext.mainclass
 
+test {
+    if(JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+        jvmArgs += ["--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED"]
+    }
+}
+
 task copyToLib(dependsOn: jar, type: Copy) {
     into "$buildDir/output/lib"
     from configurations.runtime

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/security/NumberedPipeReader.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/security/NumberedPipeReader.java
@@ -11,8 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.PrivateKey;
 
-import static sun.misc.SharedSecrets.getJavaIOFileDescriptorAccess;
-
 public class NumberedPipeReader {
 
     private final PrivateKeyFactory privateKeyFactory;
@@ -26,7 +24,7 @@ public class NumberedPipeReader {
 
     public PrivateKey readKey(int fileDescriptorNumber) {
         FileDescriptor fileDescriptor = new FileDescriptor();
-        getJavaIOFileDescriptorAccess().set(fileDescriptor, fileDescriptorNumber);
+        SharedSecretsWrapper.setJavaIOFileDescriptorAccess(fileDescriptor, fileDescriptorNumber);
         InputStream fileInputStream = new FileInputStream(fileDescriptor);
         try {
             if (fileInputStream.available() == 0) {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/security/SharedSecretsWrapper.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/security/SharedSecretsWrapper.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.hub.samlengine.security;
+
+import uk.gov.ida.common.shared.security.exceptions.KeyLoadingException;
+
+import java.io.FileDescriptor;
+
+public class SharedSecretsWrapper {
+    public static void setJavaIOFileDescriptorAccess(FileDescriptor fileDescriptor, int fileDescriptorNumber) {
+
+        /**
+         * Temporary code to dynamically load a moved class in a Java 10 JVM having been built with an 8 JDK
+         * To be removed when built with a 10 JDK
+         */
+        try {
+            String javaVersion = System.getProperty("java.specification.version");
+            String sharedSecretsPackageName = javaVersion.startsWith("1.8") ? "sun.misc." : "jdk.internal.misc.";
+
+            Object javaIOFileDescriptorAccess = Class.forName(sharedSecretsPackageName + "SharedSecrets").getMethod(
+                    "getJavaIOFileDescriptorAccess").invoke(null);
+
+            Class.forName(sharedSecretsPackageName + "JavaIOFileDescriptorAccess").getMethod(
+                    "set", FileDescriptor.class, int.class).invoke(javaIOFileDescriptorAccess, fileDescriptor, fileDescriptorNumber);
+
+        } catch (Exception e) {
+            throw new KeyLoadingException(fileDescriptorNumber, e);
+        }
+    }
+}

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/security/EncryptionKeysFromFileDescriptorsTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/security/EncryptionKeysFromFileDescriptorsTest.java
@@ -1,0 +1,18 @@
+package uk.gov.ida.hub.samlengine.security;
+
+import org.junit.Test;
+import java.io.FileDescriptor;
+
+import static junit.framework.TestCase.fail;
+
+public class EncryptionKeysFromFileDescriptorsTest {
+
+    @Test
+    public void sharedSecretsWrapperNoException() {
+        try {
+            SharedSecretsWrapper.setJavaIOFileDescriptorAccess(new FileDescriptor(), 4);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Temporary change to load SharedSecrets via Reflection.
Allows compilation and execution on Java 8, 9 and 10.
To be removed on final upgrade to Java 10.

Co-authored-by:  Alan Carter <alan.carter@digital.cabinet-office.gov.uk>, javindo