### PR TITLE
BAU: Allow unknown properties on event emitter config

### DIFF
--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
@@ -1,10 +1,12 @@
 package uk.gov.ida.hub.samlproxy;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventEmitterConfiguration implements Configuration {
 
     @Valid


### PR DESCRIPTION
- We are likely to be changing the format of this config quite
a lot as we iterate on it so to have slightly fewer releases it is
nice to be able to ignore unknown properties

Co-authored-by: Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk>