### PR TITLE
BAU: Ignore local.env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ hub/frontend/.jruby/gems
 *.swp
 *~
 *#
+local.env
 artefacts
 /vendor
 target


### PR DESCRIPTION
local.env is a generated file and is used for local environment. It does not need to be committed to GitHub.

Authors: @adityapahuja