### PR TITLE
Revert "TRELLO-8Xm7DiDy: Update event emitter to the latest version"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-47"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-31"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -61,12 +61,3 @@ clientTrustStoreConfiguration:
   password: marshmallow
 
 eidas: true
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -99,12 +99,3 @@ country:
         protocol: TLSv1.2
         verifyHostname: false
         trustSelfSignedCertificates: true
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -92,12 +92,3 @@ metadata:
     keepAlive: 60s
     chunkedEncodingEnabled: false
     validateAfterInactivityPeriod: 5s
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -134,12 +134,3 @@ logging:
       tags: service-name:policy
 
 eidas: ${EIDAS_ENABLED}
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/debian/saml-proxy/saml-proxy.yml
+++ b/debian/saml-proxy/saml-proxy.yml
@@ -156,12 +156,3 @@ country:
         protocol: TLSv1.2
         verifyHostname: false
         trustSelfSignedCertificates: true
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/debian/saml-soap-proxy/saml-soap-proxy.yml
+++ b/debian/saml-soap-proxy/saml-soap-proxy.yml
@@ -160,12 +160,3 @@ metadata:
       protocol: TLSv1.2
       trustStorePath: /ida/truststore/ida_metadata_tls_truststore.ts
       trustStorePassword: ${METADATA_CLIENT_TLS_TRUSTSTORE_PASSWORD}
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
@@ -29,7 +29,6 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
         ImmutableList<ConfigOverride> mergedConfigOverrides = ImmutableList.<ConfigOverride>builder()
                 .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
                 .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
-                .add(config("eventEmitterConfiguration.enabled", "false"))
                 .add(configOverrides)
                 .build();
         return mergedConfigOverrides.toArray(new ConfigOverride[mergedConfigOverrides.size()]);

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
@@ -1,16 +1,11 @@
 package uk.gov.ida.hub.policy;
 
-import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
 
 public class EventEmitterConfiguration implements Configuration {
-
-    @Valid
-    @JsonProperty
-    private boolean enabled;
 
     @Valid
     @JsonProperty
@@ -24,40 +19,10 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private String keyName;
 
-    @Valid
-    @JsonProperty
-    private String accessKeyId;
-
-    @Valid
-    @JsonProperty
-    private String secretAccessKey;
-
-    @Valid
-    @JsonProperty
-    private Regions region;
-
     private EventEmitterConfiguration() { }
 
     public EventEmitterConfiguration(String sourceQueueName) {
         this.sourceQueueName = sourceQueueName;
-    }
-
-    @Override
-    public boolean isEnabled() { return enabled; }
-
-    @Override
-    public String getAccessKeyId() {
-        return accessKeyId;
-    }
-
-    @Override
-    public String getSecretAccessKey() {
-        return secretAccessKey;
-    }
-
-    @Override
-    public Regions getRegion() {
-        return region;
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -93,8 +93,8 @@ public class PolicyModule extends AbstractModule {
     }
 
     @Provides
-    private Configuration getEventEmitterConfiguration(final PolicyConfiguration configuration) {
-        return configuration.getEventEmitterConfiguration();
+    private Optional<Configuration> getEventEmitterConfiguration(final PolicyConfiguration configuration) {
+        return Optional.ofNullable(configuration.getEventEmitterConfiguration());
     }
 
     @Provides

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -78,12 +78,3 @@ clientTrustStoreConfiguration:
   password: ${IDP_TRUSTSTORE_PASSWORD}
 
 eidas: true
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
@@ -96,8 +96,7 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
                 config("metadata.hubTrustStore.path", hubTrustStore.getAbsolutePath()),
                 config("metadata.hubTrustStore.password", hubTrustStore.getPassword()),
                 config("metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
-                config("metadata.idpTrustStore.password", idpTrustStore.getPassword()),
-                config("eventEmitterConfiguration.enabled", "false")
+                config("metadata.idpTrustStore.password", idpTrustStore.getPassword())
         ).collect(Collectors.toList());
 
         if (isCountryEnabled) {
@@ -124,8 +123,7 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
 
                     config("country.metadata.client.tls.protocol", "TLSv1.2"),
                     config("country.metadata.client.tls.verifyHostname", "false"),
-                    config("country.metadata.client.tls.trustSelfSignedCertificates", "true"),
-                    config("eventEmitterConfiguration.enabled", "false")
+                    config("country.metadata.client.tls.trustSelfSignedCertificates", "true")
             ).collect(Collectors.toList());
             overrides.addAll(countryOverrides);
         }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlproxy;
 
-import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
@@ -9,10 +8,6 @@ import javax.validation.Valid;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EventEmitterConfiguration implements Configuration {
-
-    @Valid
-    @JsonProperty
-    private boolean enabled;
 
     @Valid
     @JsonProperty
@@ -26,40 +21,10 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private String keyName;
 
-    @Valid
-    @JsonProperty
-    private String accessKeyId;
-
-    @Valid
-    @JsonProperty
-    private String secretAccessKey;
-
-    @Valid
-    @JsonProperty
-    private Regions region;
-
     private EventEmitterConfiguration() { }
 
     public EventEmitterConfiguration(String sourceQueueName) {
         this.sourceQueueName = sourceQueueName;
-    }
-
-    @Override
-    public boolean isEnabled() { return enabled; }
-
-    @Override
-    public String getAccessKeyId() {
-        return accessKeyId;
-    }
-
-    @Override
-    public String getSecretAccessKey() {
-        return secretAccessKey;
-    }
-
-    @Override
-    public Regions getRegion() {
-        return region;
     }
 
     @Override

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -140,8 +140,8 @@ public class SamlProxyModule extends AbstractModule {
     }
 
     @Provides
-    private Configuration getEventEmitterConfiguration(final SamlProxyConfiguration configuration) {
-        return configuration.getEventEmitterConfiguration();
+    private Optional<Configuration> getEventEmitterConfiguration(final SamlProxyConfiguration configuration) {
+        return Optional.ofNullable(configuration.getEventEmitterConfiguration());
     }
 
     @Provides

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -119,12 +119,3 @@ country:
         protocol: TLSv1.2
         verifyHostname: false
         trustSelfSignedCertificates: true
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
@@ -56,8 +56,7 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
                 config("metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
                 config("metadata.idpTrustStore.password", idpTrustStore.getPassword()),
                 config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
-                config("metadata.expectedEntityId", HUB_ENTITY_ID),
-                config("eventEmitterConfiguration.enabled", "false")
+                config("metadata.expectedEntityId", HUB_ENTITY_ID)
         ).collect(Collectors.toList());
 
         overrides.addAll(Arrays.asList(configOverrides));

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
@@ -1,15 +1,11 @@
 package uk.gov.ida.hub.samlsoapproxy;
 
-import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
 
 public class EventEmitterConfiguration implements Configuration {
-    @Valid
-    @JsonProperty
-    private boolean enabled;
 
     @Valid
     @JsonProperty
@@ -23,40 +19,10 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private String keyName;
 
-    @Valid
-    @JsonProperty
-    private String accessKeyId;
-
-    @Valid
-    @JsonProperty
-    private String secretAccessKey;
-
-    @Valid
-    @JsonProperty
-    private Regions region;
-
     private EventEmitterConfiguration() { }
 
     public EventEmitterConfiguration(String sourceQueueName) {
         this.sourceQueueName = sourceQueueName;
-    }
-
-    @Override
-    public boolean isEnabled() { return enabled; }
-
-    @Override
-    public String getAccessKeyId() {
-        return accessKeyId;
-    }
-
-    @Override
-    public String getSecretAccessKey() {
-        return secretAccessKey;
-    }
-
-    @Override
-    public Regions getRegion() {
-        return region;
     }
 
     @Override

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -88,7 +88,6 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     @Valid
-    @NotNull
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
 

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -138,8 +138,8 @@ public class SamlSoapProxyModule extends AbstractModule {
     }
 
     @Provides
-    private Configuration getEventEmitterConfiguration(final SamlSoapProxyConfiguration configuration) {
-        return configuration.getEventEmitterConfiguration();
+    private Optional<Configuration> getEventEmitterConfiguration(final SamlSoapProxyConfiguration configuration) {
+        return Optional.ofNullable(configuration.getEventEmitterConfiguration());
     }
 
 

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -99,12 +99,3 @@ metadata:
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
   expectedEntityId: ${SAML_ENTITY_ID}
-
-eventEmitterConfiguration:
-  enabled: ${EVENT_EMITTER_ENABLED}
-  accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
-  secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
-  region: eu-west-2
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}


### PR DESCRIPTION
Reverts alphagov/verify-hub#93. We need to do some cross account configuration to get this working correctly