### PR TITLE
EID-817 - Give eidas support for required algorithms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-44",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-34',
-            saml_libs:"$opensaml_version-153",
+            saml_libs:"$opensaml_version-155",
         ]
 
 subprojects {

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/support/AssertionDecrypter.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/support/AssertionDecrypter.java
@@ -51,9 +51,11 @@ public class AssertionDecrypter {
         IdaKeyStore keyStore = new IdaKeyStore(signingKeyPair, Collections.singletonList(encryptionKeyPair));
         IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
         Decrypter decrypter = new DecrypterFactory().createDecrypter(idaKeyStoreCredentialRetriever.getDecryptingCredentials());
+        ImmutableSet<String> contentEncryptionAlgorithms = ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256, EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM);
+        ImmutableSet<String> keyTransportAlgorithms = ImmutableSet.of(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP11);
 
         uk.gov.ida.saml.security.AssertionDecrypter assertionDecrypter = new uk.gov.ida.saml.security.AssertionDecrypter(
-            new EncryptionAlgorithmValidator(ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM)),
+            new EncryptionAlgorithmValidator(contentEncryptionAlgorithms, keyTransportAlgorithms),
             decrypter
         );
         return assertionDecrypter.decryptAssertions(new ValidatedResponse(response));

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -248,7 +248,7 @@ public class SamlEngineModule extends AbstractModule {
                                                                                            IdpIdaStatusUnmarshaller idpIdaStatusUnmarshaller,
                                                                                            @Named("ResponseAssertionsFromCountryValidator") Optional<ResponseAssertionsFromCountryValidator> responseAssertionFromCountryValidator,
                                                                                            Optional<DestinationValidator> validateSamlResponseIssuedByIdpDestination,
-                                                                                           @Named("AES256DecrypterWithGCM") AssertionDecrypter assertionDecrypter,
+                                                                                           @Named("EidasAssertionDecrypter") AssertionDecrypter assertionDecrypter,
                                                                                            AssertionBlobEncrypter assertionBlobEncrypter,
                                                                                            Optional<EidasValidatorFactory> eidasValidatorFactory,
                                                                                            PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller) {
@@ -643,12 +643,18 @@ public class SamlEngineModule extends AbstractModule {
     }
 
     @Provides
-    @Named("AES256DecrypterWithGCM")
-    private AssertionDecrypter getAES256WithGCMAssertionDecrypter(IdaKeyStore keyStore) {
+    @Named("EidasAssertionDecrypter")
+    private AssertionDecrypter getEidasAssertionDecrypter(IdaKeyStore keyStore) {
         IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
         Decrypter decrypter = new DecrypterFactory().createDecrypter(idaKeyStoreCredentialRetriever.getDecryptingCredentials());
+        ImmutableSet<String> contentEncryptionAlgorithms = ImmutableSet.of(
+                EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256,
+                EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM);
+        ImmutableSet<String> keyTransportAlgorithms = ImmutableSet.of(
+                EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP,
+                EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP11);
         return new AssertionDecrypter(
-            new EncryptionAlgorithmValidator(ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256, EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM)),
+            new EncryptionAlgorithmValidator(contentEncryptionAlgorithms, keyTransportAlgorithms),
             decrypter
         );
     }


### PR DESCRIPTION
- Give eidas flow support to the encryption algorithms for content
encryption and key transport as in the eidas crypto spec. 
- Renamed method Named attribute in SamlEngineModule as it is only used for Eidas and doesn't just use AES256 anymore.
- The best place to test this would be from StubCountry, encrypting the assertion using the algorithms in the crypto spec. This would give full end to end coverage. 
- This change will cover EID-817 and EID-820