### PR TITLE
EID-820 - Use correct algorithm when decrypting eidas assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-44",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-34',
-            saml_libs:"$opensaml_version-155",
+            saml_libs:"$opensaml_version-157",
         ]
 
 subprojects {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -648,7 +648,7 @@ public class SamlEngineModule extends AbstractModule {
         IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
         Decrypter decrypter = new DecrypterFactory().createDecrypter(idaKeyStoreCredentialRetriever.getDecryptingCredentials());
         ImmutableSet<String> contentEncryptionAlgorithms = ImmutableSet.of(
-                EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256,
+                EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM,
                 EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM);
         ImmutableSet<String> keyTransportAlgorithms = ImmutableSet.of(
                 EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP,

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorServiceTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorServiceTest.java
@@ -117,5 +117,4 @@ public class CountryAuthnResponseTranslatorServiceTest {
         assertThat(result.getEncryptedIdentityAssertionBlob().isPresent()).isTrue();
         assertThat(result.getEncryptedIdentityAssertionBlob().get()).isEqualTo(identityUnderlyingAssertionBlob);
     }
-
 }


### PR DESCRIPTION
- Was previously AES256-CBC, should have been AES128-GCM as in the spec.
- Create tests to generate Saml Response using different encryption algorithms,
so we can ensure that Hub can handle them.