### PR TITLE
EID-842: Accept transient NameIDs

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidator.java
@@ -5,6 +5,9 @@ import org.opensaml.saml.saml2.core.Subject;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
+
+import java.util.stream.Stream;
+
 public class AssertionSubjectValidator {
 
     public void validate(
@@ -26,7 +29,11 @@ public class AssertionSubjectValidator {
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
 
-        if (!NameIDType.PERSISTENT.equals(subject.getNameID().getFormat())) {
+        boolean correctNameIdType = Stream
+                .of(NameIDType.PERSISTENT, NameIDType.TRANSIENT)
+                .anyMatch(type -> type.equals(subject.getNameID().getFormat()));
+
+        if (!correctNameIdType) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.illegalAssertionSubjectNameIDFormat(assertionId, subject.getNameID().getFormat());
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/subject/AssertionSubjectValidatorTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.saml.core.validators.subject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.core.Subject;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.SamlTransformationErrorManagerTestHelper;
@@ -39,6 +40,15 @@ public class AssertionSubjectValidatorTest {
     public void validate_shouldThrowExceptionIfSubjectNameIdFormatAttributeIsMissing() throws Exception {
         final Subject subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat(null).build()).build();
         assertExceptionMessage(subject, ResponseProcessingValidationSpecification.class, SamlTransformationErrorFactory.missingAssertionSubjectNameIDFormat(ASSERTION_ID));
+    }
+
+    @Test
+    public void validate_shouldSuccessfullyValidateMultipleNameIdFormats() throws Exception {
+        Subject subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat(NameIDType.PERSISTENT).build()).build();
+        assert(subject.getNameID().getFormat().equals(NameIDType.PERSISTENT));
+
+        subject = aSubject().withNameId(NameIdBuilder.aNameId().withFormat(NameIDType.TRANSIENT).build()).build();
+        assert(subject.getNameID().getFormat().equals(NameIDType.TRANSIENT));
     }
 
     @Test


### PR DESCRIPTION
The German eIDAS Middleware returns NameIDs with the format set to
*transient*. Normally, Verify IDPs return *persistent*. We should allow
the validator to accept both types of NameID since it doesn't really
affect the journey.