### PR TITLE
TRELLO-8Xm7DiDy: Make config provide encryption key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-50"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-51"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -69,5 +69,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -107,5 +107,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -100,5 +100,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -142,5 +142,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/debian/saml-proxy/saml-proxy.yml
+++ b/debian/saml-proxy/saml-proxy.yml
@@ -164,5 +164,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/debian/saml-soap-proxy/saml-soap-proxy.yml
+++ b/debian/saml-soap-proxy/saml-soap-proxy.yml
@@ -168,5 +168,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
+import java.util.Base64;
 
 public class EventEmitterConfiguration implements Configuration {
 
@@ -22,14 +23,6 @@ public class EventEmitterConfiguration implements Configuration {
 
     @Valid
     @JsonProperty
-    private String bucketName;
-
-    @Valid
-    @JsonProperty
-    private String keyName;
-
-    @Valid
-    @JsonProperty
     private String accessKeyId;
 
     @Valid
@@ -39,6 +32,10 @@ public class EventEmitterConfiguration implements Configuration {
     @Valid
     @JsonProperty
     private Regions region;
+
+    @Valid
+    @JsonProperty
+    private String encryptionKey;
 
     private EventEmitterConfiguration() { }
 
@@ -70,17 +67,12 @@ public class EventEmitterConfiguration implements Configuration {
     }
 
     @Override
-    public String getBucketName() {
-        return bucketName;
-    }
-
-    @Override
-    public String getKeyName() {
-        return keyName;
-    }
-
-    @Override
     public String getQueueAccountId() {
         return queueAccountId;
+    }
+
+    @Override
+    public byte[] getEncryptionKey() {
+        return Base64.getDecoder().decode(encryptionKey);
     }
 }

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -86,5 +86,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
+import java.util.Base64;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EventEmitterConfiguration implements Configuration {
@@ -24,14 +25,6 @@ public class EventEmitterConfiguration implements Configuration {
 
     @Valid
     @JsonProperty
-    private String bucketName;
-
-    @Valid
-    @JsonProperty
-    private String keyName;
-
-    @Valid
-    @JsonProperty
     private String accessKeyId;
 
     @Valid
@@ -41,6 +34,10 @@ public class EventEmitterConfiguration implements Configuration {
     @Valid
     @JsonProperty
     private Regions region;
+
+    @Valid
+    @JsonProperty
+    private String encryptionKey;
 
     private EventEmitterConfiguration() { }
 
@@ -72,17 +69,12 @@ public class EventEmitterConfiguration implements Configuration {
     }
 
     @Override
-    public String getBucketName() {
-        return bucketName;
-    }
-
-    @Override
-    public String getKeyName() {
-        return keyName;
-    }
-
-    @Override
     public String getQueueAccountId() {
         return queueAccountId;
+    }
+
+    @Override
+    public byte[] getEncryptionKey() {
+        return Base64.getDecoder().decode(encryptionKey);
     }
 }

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -127,5 +127,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
+import java.util.Base64;
 
 public class EventEmitterConfiguration implements Configuration {
     @Valid
@@ -21,14 +22,6 @@ public class EventEmitterConfiguration implements Configuration {
 
     @Valid
     @JsonProperty
-    private String bucketName;
-
-    @Valid
-    @JsonProperty
-    private String keyName;
-
-    @Valid
-    @JsonProperty
     private String accessKeyId;
 
     @Valid
@@ -38,6 +31,10 @@ public class EventEmitterConfiguration implements Configuration {
     @Valid
     @JsonProperty
     private Regions region;
+
+    @Valid
+    @JsonProperty
+    private String encryptionKey;
 
     private EventEmitterConfiguration() { }
 
@@ -69,17 +66,12 @@ public class EventEmitterConfiguration implements Configuration {
     }
 
     @Override
-    public String getBucketName() {
-        return bucketName;
-    }
-
-    @Override
-    public String getKeyName() {
-        return keyName;
-    }
-
-    @Override
     public String getQueueAccountId() {
         return queueAccountId;
+    }
+
+    @Override
+    public byte[] getEncryptionKey() {
+        return Base64.getDecoder().decode(encryptionKey);
     }
 }

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -107,5 +107,4 @@ eventEmitterConfiguration:
   region: eu-west-2
   queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
   sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  bucketName: ${EVENT_EMITTER_BUCKET_NAME}
-  keyName: ${EVENT_EMITTER_KEY_NAME}
+  encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}


### PR DESCRIPTION
- Modify config classes and files to provide encryption key
directly instead of relying on KMS/S3 lookups

- [x] Merge after https://github.com/alphagov/verify-event-emitter/pull/20
- [x] Merge after https://github.com/alphagov/verify-puppet/pull/1164