### PR TITLE
User latest version of event emitter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-51"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-52"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",


### PR DESCRIPTION
- [x] Merge after [event emitter 21](https://github.com/alphagov/verify-event-emitter/pull/21)

The event emitter now serializes timestamps for each event as time since epoch in milliseconds instead of sending a java datetime object