### PR TITLE
BAU: Make session store usage more general

### DIFF
--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -14,14 +14,16 @@ logging:
   appenders:
     - type: console
 
-
-infinispan:
-  bindAddress: 
-  initialHosts: 
-  clusterName: 
-  type: standalone
-  expiration: 8h
-  persistenceToFileEnabled: false
+sessionStoreConfiguration:
+  infinispanConfiguration:
+    enabled: true
+    configuration:
+      bindAddress:
+      initialHosts:
+      clusterName:
+      type: standalone
+      expiration: 8h
+      persistenceToFileEnabled: false
 
 eventSinkUri: ${EVENT_SINK_URL}
 

--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -49,26 +49,28 @@ metrics:
       prefix: ${GRAPHITE_PREFIX}
       frequency: 10s
 
-
-infinispan:
-  bindAddress: ${INFINISPAN_BIND_ADDRESS}
-  initialHosts: ${INFINISPAN_INITIAL_HOSTS}
-  clusterName: 'policy-cluster'
-  port: 7801
-  type: ${INFINISPAN_TYPE}
-  expiration: 150m
-  encryptConfiguration:
-    keyStoreName: /ida/policy/keys/infinispan_policy.ks
-    keyStorePassword: ${INFINISPAN_ENCRYPT_KEYSTORE_PASSWORD}
-    encryptionKeyAlias: 'infinispan_policy'
-  authConfiguration:
-    authValue: ${INFINISPAN_AUTH_AUTHVALUE}
-    keyStorePath: /ida/policy/keys/infinispan_policy.ks
-    keyStorePassword: ${INFINISPAN_AUTH_KEYSTORE_PASSWORD}
-    keyStoreType: 'jceks'
-    certAlias: 'infinispan_policy_auth_key'
-    cipherType: 'RSA'
-  persistenceToFileEnabled: false
+sessionStoreConfiguration:
+  infinispanConfiguration:
+    enabled: true
+    configuration:
+      bindAddress: ${INFINISPAN_BIND_ADDRESS}
+      initialHosts: ${INFINISPAN_INITIAL_HOSTS}
+      clusterName: 'policy-cluster'
+      port: 7801
+      type: ${INFINISPAN_TYPE}
+      expiration: 150m
+      encryptConfiguration:
+        keyStoreName: /ida/policy/keys/infinispan_policy.ks
+        keyStorePassword: ${INFINISPAN_ENCRYPT_KEYSTORE_PASSWORD}
+        encryptionKeyAlias: 'infinispan_policy'
+      authConfiguration:
+        authValue: ${INFINISPAN_AUTH_AUTHVALUE}
+        keyStorePath: /ida/policy/keys/infinispan_policy.ks
+        keyStorePassword: ${INFINISPAN_AUTH_KEYSTORE_PASSWORD}
+        keyStoreType: 'jceks'
+        certAlias: 'infinispan_policy_auth_key'
+        cipherType: 'RSA'
+      persistenceToFileEnabled: false
 
 
 eventSinkUri: https://event-sink:51103

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/StateControllerFactoryTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/StateControllerFactoryTest.java
@@ -11,10 +11,12 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import uk.gov.ida.eventsink.EventSinkProxy;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
 import uk.gov.ida.hub.policy.PolicyModule;
+import uk.gov.ida.hub.policy.configuration.SessionStoreConfiguration;
 import uk.gov.ida.hub.policy.domain.AbstractState;
 import uk.gov.ida.hub.policy.domain.StateController;
 import uk.gov.ida.hub.policy.domain.StateTransitionAction;
@@ -30,6 +32,7 @@ import java.net.URI;
 import static com.google.common.base.Optional.absent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder.aSessionId;
 import static uk.gov.ida.hub.policy.builder.state.AuthnFailedErrorStateBuilder.anAuthnFailedErrorState;
 import static uk.gov.ida.hub.policy.builder.state.AwaitingCycle3DataStateBuilder.anAwaitingCycle3DataState;
@@ -62,27 +65,31 @@ public class StateControllerFactoryTest {
     @Mock
     private StateTransitionAction stateTransitionAction;
 
+    @Mock (answer = Answers.RETURNS_DEEP_STUBS)
+    private SessionStoreConfiguration sessionStoreConfiguration;
+
     private StateControllerFactory factory;
 
     @Before
     public void setup() {
+        when(sessionStoreConfiguration.getInfinispanConfiguration().isEnabled()).thenReturn(true);
         Injector injector = Guice.createInjector(
-            Modules.override(new PolicyModule()
-            ).with(new AbstractModule() {
-                @Override
-                protected void configure() {
-                    bind(EventSinkProxy.class).toInstance(mock(EventSinkProxy.class));
-                    bind(IdentityProvidersConfigProxy.class).toInstance(mock(IdentityProvidersConfigProxy.class));
-                    bind(Client.class).toInstance(mock(Client.class));
-                    bind(Environment.class).toInstance(mock(Environment.class));
-                    bind(PolicyConfiguration.class).toInstance(aPolicyConfiguration().build());
-                    InfinispanCacheManager infinispanCacheManager = anInfinispanCacheManager().build(InfinispanJunitRunner.EMBEDDED_CACHE_MANAGER);
-                    bind(InfinispanCacheManager.class).toInstance(infinispanCacheManager);
-                    bind(HubEventLogger.class).toInstance(mock(HubEventLogger.class));
-                    bind(JsonClient.class).annotatedWith(Names.named("samlSoapProxyClient")).toInstance(mock(JsonClient.class));
-                    bind(JsonClient.class).toInstance(mock(JsonClient.class));
-                }
-            })
+              Modules.override(new PolicyModule()
+              ).with(new AbstractModule() {
+                  @Override
+                  protected void configure() {
+                      bind(EventSinkProxy.class).toInstance(mock(EventSinkProxy.class));
+                      bind(IdentityProvidersConfigProxy.class).toInstance(mock(IdentityProvidersConfigProxy.class));
+                      bind(Client.class).toInstance(mock(Client.class));
+                      bind(Environment.class).toInstance(mock(Environment.class));
+                      bind(PolicyConfiguration.class).toInstance(aPolicyConfiguration().withCacheConfiguration(sessionStoreConfiguration).build());
+                      InfinispanCacheManager infinispanCacheManager = anInfinispanCacheManager().build(InfinispanJunitRunner.EMBEDDED_CACHE_MANAGER);
+                      bind(InfinispanCacheManager.class).toInstance(infinispanCacheManager);
+                      bind(HubEventLogger.class).toInstance(mock(HubEventLogger.class));
+                      bind(JsonClient.class).annotatedWith(Names.named("samlSoapProxyClient")).toInstance(mock(JsonClient.class));
+                      bind(JsonClient.class).toInstance(mock(JsonClient.class));
+                  }
+              })
         );
 
         factory = new StateControllerFactory(injector);

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyIntegrationApplication.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyIntegrationApplication.java
@@ -1,13 +1,12 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule.support;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.inject.AbstractModule;
-import com.google.inject.Module;
 import io.dropwizard.setup.Environment;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import uk.gov.ida.hub.policy.PolicyApplication;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
 import uk.gov.ida.hub.policy.PolicyModule;
+import uk.gov.ida.hub.policy.SessionModule;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;
 import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
@@ -30,21 +29,17 @@ public class PolicyIntegrationApplication extends PolicyApplication {
     }
 
     @Override
-    protected Module bindInfinispan(Provider<InfinispanCacheManager> cacheManagerProvider) {
-        return new AbstractModule() {
-            @Override
-            protected void configure() {
-               bind(InfinispanCacheManager.class).toInstance(infinispanCacheManager);
-            }
-        };
-    }
-
-    @Override
     protected PolicyModule getPolicyModule() {
         return new PolicyModuleForIntegrationTests();
     }
 
-    public ConcurrentMap<SessionId, State> getDataStore() {
+    @Override
+    protected SessionModule getSessionModule(Provider<InfinispanCacheManager> infinispanCacheManagerProvider,
+                         Provider<ConcurrentMap<SessionId, State>> sessionStateStoreProvider) {
+        return new SessionModule(() -> infinispanCacheManager, () -> getDataStore());
+    }
+
+    public ConcurrentMap<SessionId,State> getDataStore() {
         return infinispanCacheManager.getCache("state_cache");
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/PolicyConfigurationBuilder.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/PolicyConfigurationBuilder.java
@@ -4,6 +4,7 @@ import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
+import uk.gov.ida.hub.policy.configuration.SessionStoreConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 
 import java.net.URI;
@@ -15,6 +16,7 @@ public class PolicyConfigurationBuilder {
 
     private Duration timeoutPeriod = Duration.minutes(2);
     private ServiceInfoConfiguration serviceInfo = aServiceInfo().withName("Policy").build();
+    private SessionStoreConfiguration sessionStoreConfiguration;
 
     public static PolicyConfigurationBuilder aPolicyConfiguration() {
         return new PolicyConfigurationBuilder();
@@ -25,6 +27,7 @@ public class PolicyConfigurationBuilder {
                 new JerseyClientConfiguration(),
                 serviceInfo,
                 mock(ClientTrustStoreConfiguration.class),
+                sessionStoreConfiguration,
                 timeoutPeriod,
                 Duration.minutes(1),
                 Duration.minutes(15));
@@ -40,12 +43,17 @@ public class PolicyConfigurationBuilder {
         return this;
     }
 
+    public PolicyConfigurationBuilder withCacheConfiguration(SessionStoreConfiguration sessionStoreConfiguration) {
+        this.sessionStoreConfiguration = sessionStoreConfiguration;
+        return this;
+    }
+
     private static class TestPolicyConfiguration extends PolicyConfiguration {
         private TestPolicyConfiguration(
                 JerseyClientConfiguration httpClient,
                 ServiceInfoConfiguration serviceInfo,
                 ClientTrustStoreConfiguration clientTrustStoreConfiguration,
-
+                SessionStoreConfiguration sessionStoreConfiguration,
                 Duration timeoutPeriod,
                 Duration matchingServiceResponseWaitPeriod,
                 Duration assertionLifetime) {
@@ -56,6 +64,7 @@ public class PolicyConfigurationBuilder {
             this.httpClient = httpClient;
             this.serviceInfo = serviceInfo;
             this.clientTrustStoreConfiguration = clientTrustStoreConfiguration;
+            this.sessionStoreConfiguration = sessionStoreConfiguration;
 
             this.timeoutPeriod = timeoutPeriod;
             this.matchingServiceResponseWaitPeriod = matchingServiceResponseWaitPeriod;

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/InfinispanStartupTasks.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/InfinispanStartupTasks.java
@@ -9,17 +9,17 @@ import java.util.concurrent.ConcurrentMap;
 
 public class InfinispanStartupTasks implements Managed {
 
-    private final ConcurrentMap<SessionId, State> sessionCache;
+    private final ConcurrentMap<SessionId, State> sessionStateStore;
 
     @Inject
-    public InfinispanStartupTasks(ConcurrentMap<SessionId, State> sessionCache) {
-        this.sessionCache = sessionCache;
+    public InfinispanStartupTasks(ConcurrentMap<SessionId, State> sessionStateStore) {
+        this.sessionStateStore = sessionStateStore;
     }
 
     @Override
     public void start() throws Exception {
         SessionId newSessionId = SessionId.createNewSessionId();
-        sessionCache.get(newSessionId);
+        sessionStateStore.get(newSessionId);
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
@@ -1,8 +1,6 @@
 package uk.gov.ida.hub.policy;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import com.google.inject.AbstractModule;
-import com.google.inject.Module;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
@@ -14,6 +12,8 @@ import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
 import uk.gov.ida.eventemitter.EventEmitterModule;
+import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.hub.policy.domain.State;
 import uk.gov.ida.hub.policy.domain.exception.SessionAlreadyExistingExceptionMapper;
 import uk.gov.ida.hub.policy.domain.exception.SessionCreationFailureExceptionMapper;
 import uk.gov.ida.hub.policy.domain.exception.SessionNotFoundExceptionMapper;
@@ -38,6 +38,7 @@ import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanBundle;
 import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
 
 import javax.inject.Provider;
+import java.util.concurrent.ConcurrentMap;
 
 public class PolicyApplication extends Application<PolicyConfiguration> {
 
@@ -66,17 +67,30 @@ public class PolicyApplication extends Application<PolicyConfiguration> {
         bootstrap.addBundle(new LoggingBundle());
         bootstrap.addBundle(new PrometheusBundle());
         bootstrap.addBundle(new IdaJsonProcessingExceptionMapperBundle());
+
         final InfinispanBundle infinispanBundle = new InfinispanBundle();
-        // the infinispan cache manager needs to be lazy loaded because it is not initialized at this point.
         bootstrap.addBundle(infinispanBundle);
+
+        final SessionBundle sessionBundle = new SessionBundle(infinispanBundle.getInfinispanCacheManagerProvider());
+
+        // the infinispan cache manager needs to be lazy loaded because it is not initialized at this point.
+        bootstrap.addBundle(sessionBundle);
         guiceBundle = GuiceBundle.defaultBuilder(PolicyConfiguration.class)
-                .modules(getPolicyModule(), new EventEmitterModule(),  bindInfinispan(infinispanBundle.getInfinispanCacheManagerProvider()))
+                .modules(getPolicyModule(),
+                        new EventEmitterModule(),
+                        getSessionModule(infinispanBundle.getInfinispanCacheManagerProvider(),
+                                sessionBundle.getSessionStateStoreProvider()))
                 .build();
         bootstrap.addBundle(guiceBundle);
     }
 
     protected PolicyModule getPolicyModule() {
         return new PolicyModule();
+    }
+
+    protected SessionModule getSessionModule(Provider<InfinispanCacheManager> infinispanCacheManagerProvider,
+                                             Provider<ConcurrentMap<SessionId, State>> sessionStateStoreProvider) {
+        return new SessionModule(infinispanCacheManagerProvider, sessionStateStoreProvider);
     }
 
     @Override
@@ -111,14 +125,5 @@ public class PolicyApplication extends Application<PolicyConfiguration> {
             environment.jersey().register(CountriesResource.class);
             environment.jersey().register(EidasSessionResource.class);
         }
-    }
-
-    protected Module bindInfinispan(Provider<InfinispanCacheManager> cacheManagerProvider) {
-        return new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(InfinispanCacheManager.class).toProvider(cacheManagerProvider);
-            }
-        };
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -8,6 +8,7 @@ import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.configuration.ServiceNameConfiguration;
+import uk.gov.ida.hub.policy.configuration.SessionStoreConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanServiceConfiguration;
@@ -38,7 +39,7 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @Valid
     @NotNull
     @JsonProperty
-    protected InfinispanConfiguration infinispan;
+    protected SessionStoreConfiguration sessionStoreConfiguration;
 
     @Valid
     @NotNull
@@ -108,9 +109,8 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
         return new org.joda.time.Duration(matchingServiceResponseWaitPeriod.toMilliseconds());
     }
 
-    @Override
-    public InfinispanConfiguration getInfinispan() {
-        return infinispan;
+    public SessionStoreConfiguration getSessionStoreConfiguration() {
+        return sessionStoreConfiguration;
     }
 
     @Override
@@ -166,5 +166,10 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @Override
     public boolean isPrometheusEnabled() {
         return prometheusEnabled;
+    }
+
+    @Override
+    public InfinispanConfiguration getInfinispan() {
+        return sessionStoreConfiguration.getInfinispanConfiguration().getConfiguration();
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -9,6 +9,7 @@ import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.hub.policy.configuration.SessionStoreConfiguration;
+import uk.gov.ida.hub.policy.configuration.EventEmitterConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration;
 import uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanServiceConfiguration;

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -16,6 +16,7 @@ import uk.gov.ida.hub.policy.annotations.SamlEngine;
 import uk.gov.ida.hub.policy.annotations.SamlSoapProxy;
 import uk.gov.ida.hub.policy.controllogic.AuthnRequestFromTransactionHandler;
 import uk.gov.ida.hub.policy.controllogic.ResponseFromIdpHandler;
+import uk.gov.ida.hub.policy.controllogic.TransitionStore;
 import uk.gov.ida.hub.policy.domain.AssertionRestrictionsFactory;
 import uk.gov.ida.hub.policy.domain.ResponseFromHubFactory;
 import uk.gov.ida.hub.policy.domain.SessionId;
@@ -128,8 +129,10 @@ public class PolicyModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public ConcurrentMap<SessionId, State> sessionCache(InfinispanCacheManager infinispanCacheManager) {
-        return infinispanCacheManager.getCache("state_cache");
+    public ConcurrentMap<SessionId, State> getSessionStateStore(
+            InfinispanCacheManager infinispanCacheManager) {
+        ConcurrentMap<SessionId, State> infinispan = infinispanCacheManager.getCache("state_cache");
+        return new TransitionStore<>(infinispan, Optional.empty());
     }
 
     @Provides

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -53,6 +53,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.KeyStore;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
 public class PolicyModule extends AbstractModule {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -16,12 +16,9 @@ import uk.gov.ida.hub.policy.annotations.SamlEngine;
 import uk.gov.ida.hub.policy.annotations.SamlSoapProxy;
 import uk.gov.ida.hub.policy.controllogic.AuthnRequestFromTransactionHandler;
 import uk.gov.ida.hub.policy.controllogic.ResponseFromIdpHandler;
-import uk.gov.ida.hub.policy.controllogic.TransitionStore;
 import uk.gov.ida.hub.policy.domain.AssertionRestrictionsFactory;
 import uk.gov.ida.hub.policy.domain.ResponseFromHubFactory;
-import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.SessionRepository;
-import uk.gov.ida.hub.policy.domain.State;
 import uk.gov.ida.hub.policy.domain.controller.StateControllerFactory;
 import uk.gov.ida.hub.policy.factories.SamlAuthnResponseTranslatorDtoFactory;
 import uk.gov.ida.hub.policy.logging.HubEventLogger;
@@ -43,7 +40,6 @@ import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.restclient.ClientProvider;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
-import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.KeyStoreLoader;
 import uk.gov.ida.truststore.KeyStoreProvider;
@@ -53,8 +49,6 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.KeyStore;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentMap;
 
 public class PolicyModule extends AbstractModule {
 
@@ -126,14 +120,6 @@ public class PolicyModule extends AbstractModule {
                 "SamlSoapProxyClient").get();
         ErrorHandlingClient errorHandlingClient = new ErrorHandlingClient(client);
         return new JsonClient(errorHandlingClient, responseProcessor);
-    }
-
-    @Provides
-    @Singleton
-    public ConcurrentMap<SessionId, State> getSessionStateStore(
-            InfinispanCacheManager infinispanCacheManager) {
-        ConcurrentMap<SessionId, State> infinispan = infinispanCacheManager.getCache("state_cache");
-        return new TransitionStore<>(infinispan, Optional.empty());
     }
 
     @Provides

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/SessionBundle.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/SessionBundle.java
@@ -1,0 +1,57 @@
+package uk.gov.ida.hub.policy;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.health.HealthCheck;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import uk.gov.ida.hub.policy.controllogic.TransitionStore;
+import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.hub.policy.domain.State;
+import uk.gov.ida.hub.policy.factories.SessionStoreFactory;
+import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
+
+import javax.inject.Provider;
+import java.util.concurrent.ConcurrentMap;
+
+public class SessionBundle implements ConfiguredBundle<PolicyConfiguration> {
+
+    private static final String EXISTING_SESSION_STORE_ENTRY_COUNT = "existing_session_store_entry_count";
+    private static final String TRANSITION_SESSION_STORE_ENTRY_COUNT = "transition_session_store_entry_count";
+    private static final String TRANSITION_SESSION_STORE_DIFFERING_KEYS = "transition_session_store_differing_keys";
+    private TransitionStore<State> transitionStore;
+    private final Provider<InfinispanCacheManager> infinispanCacheManagerProvider;
+
+    public SessionBundle(Provider<InfinispanCacheManager> infinispanCacheManagerProvider) {
+        this.infinispanCacheManagerProvider = infinispanCacheManagerProvider;
+    }
+
+    @Override
+    public void run(PolicyConfiguration configuration, Environment environment) {
+        transitionStore = SessionStoreFactory.getSessionStateStore(infinispanCacheManagerProvider.get());
+
+        environment.metrics().register(EXISTING_SESSION_STORE_ENTRY_COUNT, getExistingSizeMetric());
+        environment.metrics().register(TRANSITION_SESSION_STORE_ENTRY_COUNT, getTransitionSizeMetric());
+        environment.healthChecks().register(TRANSITION_SESSION_STORE_DIFFERING_KEYS, new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.healthy(transitionStore.getDifferingSessionIds().toString());
+            }
+        });
+    }
+
+    private Gauge<Integer> getExistingSizeMetric() {
+        return () -> transitionStore.size();
+    }
+
+    private Gauge<Integer> getTransitionSizeMetric() {
+        return () -> transitionStore.transitionSize();
+    }
+
+    public Provider<ConcurrentMap<SessionId, State>> getSessionStateStoreProvider() {
+        return () -> transitionStore;
+    }
+
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {}
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/SessionModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/SessionModule.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.hub.policy;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.hub.policy.domain.State;
+import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
+
+import javax.inject.Provider;
+import java.util.concurrent.ConcurrentMap;
+
+public class SessionModule extends AbstractModule {
+    private final Provider<InfinispanCacheManager> infinispanCacheManagerProvider;
+    private final Provider<ConcurrentMap<SessionId, State>> sessionStateStoreProvider;
+
+    public SessionModule(Provider<InfinispanCacheManager> infinispanCacheManagerProvider,
+                         Provider<ConcurrentMap<SessionId, State>> sessionStateStoreProvider) {
+        this.infinispanCacheManagerProvider = infinispanCacheManagerProvider;
+        this.sessionStateStoreProvider = sessionStateStoreProvider;
+    }
+
+    @Override
+    protected void configure() {
+        bind(InfinispanCacheManager.class).toProvider(infinispanCacheManagerProvider);
+        bind(new TypeLiteral<ConcurrentMap<SessionId, State>>() {}).toProvider(sessionStateStoreProvider);
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/EventEmitterConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/EventEmitterConfiguration.java
@@ -1,4 +1,4 @@
-package uk.gov.ida.hub.policy;
+package uk.gov.ida.hub.policy.configuration;
 
 import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/InfinispanConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/InfinispanConfiguration.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.hub.policy.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+
+public class InfinispanConfiguration {
+
+    @Valid
+    @JsonProperty
+    protected boolean enabled;
+
+    @Valid
+    @JsonProperty
+    private uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration configuration;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public uk.gov.ida.shared.dropwizard.infinispan.config.InfinispanConfiguration getConfiguration() {
+        return configuration;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/SessionStoreConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/SessionStoreConfiguration.java
@@ -1,0 +1,16 @@
+package uk.gov.ida.hub.policy.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+
+public class SessionStoreConfiguration {
+
+    @Valid
+    @JsonProperty
+    protected InfinispanConfiguration infinispanConfiguration;
+
+    public InfinispanConfiguration getInfinispanConfiguration() {
+        return infinispanConfiguration;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/TransitionStore.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/TransitionStore.java
@@ -1,0 +1,126 @@
+package uk.gov.ida.hub.policy.controllogic;
+
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+/* This class is designed to transition all values from the existing
+ * to the transition store */
+public class TransitionStore<V> implements ConcurrentMap<SessionId, V> {
+
+    private ConcurrentMap<SessionId, V> existing;
+    private Optional<ConcurrentMap<SessionId, V>> transition;
+
+    public TransitionStore(ConcurrentMap<SessionId, V> existing, Optional<ConcurrentMap<SessionId, V>> transition) {
+        this.existing = existing;
+        this.transition = transition;
+    }
+
+    @Override
+    public int size() {
+        return existing.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return existing.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return existing.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return existing.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return existing.get(key);
+    }
+
+    @Override
+    public V put(SessionId key, V value) {
+        transition.ifPresent(t -> t.put(key, value));
+        return existing.put(key, value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        transition.ifPresent(t -> t.remove(key));
+        return existing.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends SessionId, ? extends V> m) {
+        transition.ifPresent(t -> t.putAll(m));
+        existing.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        transition.ifPresent(Map::clear);
+        existing.clear();
+    }
+
+    @Override
+    public Set<SessionId> keySet() {
+        return existing.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return existing.values();
+    }
+
+    @Override
+    public Set<Entry<SessionId, V>> entrySet() {
+        return existing.entrySet();
+    }
+
+    @Override
+    public V putIfAbsent(SessionId key, V value) {
+        V val = existing.putIfAbsent(key, value);
+        // If `value` was added to existing, add it to transition
+        if (val == null) {
+            transition.ifPresent(t -> t.put(key, value));
+        }
+        return val;
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        boolean remove = existing.remove(key, value);
+        // If entry was removed from existing, remove from transition
+        if (remove) {
+            transition.ifPresent(t -> t.remove(key));
+        }
+        return remove;
+    }
+
+    @Override
+    public boolean replace(SessionId key, V oldValue, V newValue) {
+        boolean replace = existing.replace(key, oldValue, newValue);
+        // If `oldValue` was replaced with `newValue` in existing, add `newValue` to transition
+        if (replace) {
+            transition.ifPresent(t -> t.put(key, newValue));
+        }
+        return replace;
+    }
+
+    @Override
+    public V replace(SessionId key, V value) {
+        V val = existing.replace(key, value);
+        // If `value` was added to existing, add it to transition
+        if (val != null) {
+            transition.ifPresent(t -> t.put(key, value));
+        }
+        return val;
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/TransitionStore.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/TransitionStore.java
@@ -1,12 +1,17 @@
 package uk.gov.ida.hub.policy.controllogic;
 
+import com.google.common.collect.Sets;
 import uk.gov.ida.hub.policy.domain.SessionId;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 
 /* This class is designed to transition all values from the existing
  * to the transition store */
@@ -122,5 +127,15 @@ public class TransitionStore<V> implements ConcurrentMap<SessionId, V> {
             transition.ifPresent(t -> t.put(key, value));
         }
         return val;
+    }
+
+    public int transitionSize() {
+        return transition.map(ConcurrentMap::size).orElse(0);
+    }
+
+    public List<SessionId> getDifferingSessionIds() {
+        return transition
+                .map(t -> Sets.difference(existing.keySet(),t.keySet()).stream().collect(toList()))
+                .orElse(emptyList());
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/factories/SessionStoreFactory.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/factories/SessionStoreFactory.java
@@ -1,0 +1,32 @@
+package uk.gov.ida.hub.policy.factories;
+
+import org.joda.time.DateTime;
+import uk.gov.ida.hub.policy.controllogic.TransitionStore;
+import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.hub.policy.domain.State;
+import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
+
+public class SessionStoreFactory {
+
+    private SessionStoreFactory() {}
+
+    public static TransitionStore<State> getSessionStateStore(
+            InfinispanCacheManager infinispanCacheManager
+    ) {
+        return getSessionStore(infinispanCacheManager, "state_cache");
+    }
+
+    public static ConcurrentMap<SessionId, DateTime> getSessionExpirationStore(
+            InfinispanCacheManager infinispanCacheManager
+    ) {
+        return getSessionStore(infinispanCacheManager, "datetime_cache");
+    }
+
+    private static <V> TransitionStore<V> getSessionStore(InfinispanCacheManager infinispanCacheManager, String storeName) {
+        ConcurrentMap<SessionId, V> infinispan = infinispanCacheManager.getCache(storeName);
+        return new TransitionStore<>(infinispan, Optional.empty());
+    }
+}

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/TransitionStoreTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/TransitionStoreTest.java
@@ -84,6 +84,18 @@ public class TransitionStoreTest {
     }
 
     @Test
+    public void putPutsValueInSingleMapAndReturnsThePreviousValue() {
+        final SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.put(key1, "value3")).isEqualTo("value1");
+        assertThat(existing.get(key1)).isEqualTo("value3");
+    }
+
+    @Test
     public void putPutsValueInBothMapsAndReturnsThePreviousValueFromExisting() {
         final SessionId key1 = new SessionId("key1");
         ConcurrentMap existing = new ConcurrentHashMap() {{
@@ -100,7 +112,7 @@ public class TransitionStoreTest {
     }
 
     @Test
-    public void removeRemovesFromBothQueuesAndReturnsValueFromExisting() {
+    public void removeRemovesFromBothMapsAndReturnsValueFromExisting() {
         final SessionId key1 = new SessionId("key1");
         ConcurrentMap existing = new ConcurrentHashMap() {{
             put(key1, "value1");
@@ -116,7 +128,19 @@ public class TransitionStoreTest {
     }
 
     @Test
-    public void putAllPutsAllInBothQueues() {
+    public void removeRemovesFromSingleMapsAndReturnsValue() {
+        final SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.remove(key1)).isEqualTo("value1");
+        assertThat(existing.containsKey(key1)).isFalse();
+    }
+
+    @Test
+    public void putAllPutsAllInBothMaps() {
         ConcurrentMap existing = new ConcurrentHashMap();
         ConcurrentMap transition = new ConcurrentHashMap();
         SessionId key3 = new SessionId("key3");
@@ -129,11 +153,26 @@ public class TransitionStoreTest {
         TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
         transitionStore.putAll(putAll);
         assertThat(existing.containsKey(key2) && existing.containsKey(key3)).isTrue();
+        assertThat(transition.containsKey(key2) && transition.containsKey(key3)).isTrue();
+    }
+
+    @Test
+    public void putAllPutsAllInSingleMap() {
+        ConcurrentMap existing = new ConcurrentHashMap();
+        SessionId key3 = new SessionId("key3");
+        SessionId key2 = new SessionId("key2");
+        Map putAll = new HashMap() {{
+            put(key2, "value2");
+            put(key3, "value3");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        transitionStore.putAll(putAll);
         assertThat(existing.containsKey(key2) && existing.containsKey(key3)).isTrue();
     }
 
     @Test
-    public void clearClearsBothQueues() {
+    public void clearClearsBothMaps() {
         ConcurrentMap existing = new ConcurrentHashMap() {{
             put(new SessionId("key1"), "value1");
         }};
@@ -145,6 +184,17 @@ public class TransitionStoreTest {
         transitionStore.clear();
         assertThat(existing.isEmpty()).isTrue();
         assertThat(transition.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void clearClearsSingleMap() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        transitionStore.clear();
+        assertThat(existing.isEmpty()).isTrue();
     }
 
     @Test
@@ -407,6 +457,16 @@ public class TransitionStoreTest {
     }
 
     @Test
+    public void transitionSizeShouldReturn0WhenNoMap() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.transitionSize()).isEqualTo(0);
+    }
+
+    @Test
     public void transitionSizeShouldReturnSizeOfTransitionMap() {
         ConcurrentMap existing = new ConcurrentHashMap() {{
             put(new SessionId("key1"), "value1");
@@ -434,5 +494,17 @@ public class TransitionStoreTest {
 
         TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
         assertThat(transitionStore.getDifferingSessionIds()).containsOnly(key1);
+    }
+
+    @Test
+    public void getDifferingKeysShouldReturnEmptyListWhenSingleMap() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.getDifferingSessionIds()).isEmpty();
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/TransitionStoreTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/TransitionStoreTest.java
@@ -405,4 +405,34 @@ public class TransitionStoreTest {
         assertThat(transitionStore.replace(key1, "value3")).isEqualTo("value1");
         assertThat(existing.get(key1)).isEqualTo("value3");
     }
+
+    @Test
+    public void transitionSizeShouldReturnSizeOfTransitionMap() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+            put(new SessionId("key3"), "value3");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.transitionSize()).isEqualTo(transition.size());
+    }
+
+    @Test
+    public void getDifferingKeysShouldGiveSessionIdsOnlyInExistingMap() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+            put(new SessionId("key2"), "value2");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+            put(new SessionId("key3"), "value3");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.getDifferingSessionIds()).containsOnly(key1);
+    }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/TransitionStoreTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/TransitionStoreTest.java
@@ -1,0 +1,408 @@
+package uk.gov.ida.hub.policy.controllogic;
+
+import org.junit.Test;
+import uk.gov.ida.hub.policy.domain.SessionId;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TransitionStoreTest {
+
+    @Test
+    public void sizeShouldReturnSizeOfExisting() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+            put(new SessionId("key2"), "value2");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.size()).isEqualTo(existing.size());
+    }
+
+    @Test
+    public void isEmptyReturnsIfExistingIsEmpty() {
+        ConcurrentMap existing = new ConcurrentHashMap();
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.isEmpty()).isEqualTo(existing.isEmpty());
+    }
+
+    @Test
+    public void containsKeyChecksIfExistingContainsKey() {
+        final SessionId key1 = new SessionId("key1");
+        final SessionId key2 = new SessionId("key2");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(key1, "value1");
+            put(key2, "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.containsKey(key1)).isTrue();
+        assertThat(transitionStore.containsKey(key2)).isFalse();
+    }
+
+    @Test
+    public void containsValueChecksIfExistingContainsValue() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.containsValue("value1")).isTrue();
+        assertThat(transitionStore.containsValue("value2")).isFalse();
+    }
+
+    @Test
+    public void getReturnsValueFromExisting() {
+        final SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(key1, "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.get(key1)).isEqualTo("value1");
+    }
+
+    @Test
+    public void putPutsValueInBothMapsAndReturnsThePreviousValueFromExisting() {
+        final SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(key1, "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.put(key1, "value3")).isEqualTo("value1");
+        assertThat(existing.get(key1)).isEqualTo("value3");
+        assertThat(transition.get(key1)).isEqualTo("value3");
+    }
+
+    @Test
+    public void removeRemovesFromBothQueuesAndReturnsValueFromExisting() {
+        final SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(key1, "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.remove(key1)).isEqualTo("value1");
+        assertThat(existing.containsKey(key1)).isFalse();
+        assertThat(transition.containsKey(key1)).isFalse();
+    }
+
+    @Test
+    public void putAllPutsAllInBothQueues() {
+        ConcurrentMap existing = new ConcurrentHashMap();
+        ConcurrentMap transition = new ConcurrentHashMap();
+        SessionId key3 = new SessionId("key3");
+        SessionId key2 = new SessionId("key2");
+        Map putAll = new HashMap() {{
+            put(key2, "value2");
+            put(key3, "value3");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        transitionStore.putAll(putAll);
+        assertThat(existing.containsKey(key2) && existing.containsKey(key3)).isTrue();
+        assertThat(existing.containsKey(key2) && existing.containsKey(key3)).isTrue();
+    }
+
+    @Test
+    public void clearClearsBothQueues() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        transitionStore.clear();
+        assertThat(existing.isEmpty()).isTrue();
+        assertThat(transition.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void keySetGetsKeySetFromExisting() {
+        final SessionId key1 = new SessionId("key1");
+        final SessionId key2 = new SessionId("key2");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(key2, "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.keySet().contains(key1)).isTrue();
+        assertThat(transitionStore.keySet().contains(key2)).isFalse();
+
+    }
+
+    @Test
+    public void valuesGetsValuesFromExisting() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.values().contains("value1")).isTrue();
+        assertThat(transitionStore.values().contains("value2")).isFalse();
+    }
+
+    @Test
+    public void entrySetReturnsEntrySetFromExisting() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.entrySet()).isEqualTo(existing.entrySet());
+        assertThat(transitionStore.entrySet()).isNotEqualTo(transition.entrySet());
+    }
+
+    @Test
+    public void putIfAbsentUpdatesBothMapsIfAbsentInExisting() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        SessionId key3 = new SessionId("key3");
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.putIfAbsent(key3, "value3")).isEqualTo(null);
+        assertThat(existing.containsKey(key3)).isTrue();
+        assertThat(transition.containsKey(key3)).isTrue();
+    }
+
+    @Test
+    public void putIfAbsentUpdatesNeitherMapIfAlreadyInExisting() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.putIfAbsent(key1, "value3")).isEqualTo("value1");
+        assertThat(existing.containsKey(key1)).isTrue();
+        assertThat(existing.get(key1)).isEqualTo("value1");
+        assertThat(transition.containsKey(key1)).isFalse();
+    }
+
+    @Test
+    public void putIfAbsentDoesSameWhenUsingSingleMapAndAbsent() {
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(new SessionId("key1"), "value1");
+        }};
+
+        SessionId key2 = new SessionId("key2");
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.putIfAbsent(key2, "value2")).isEqualTo(null);
+        assertThat(existing.containsKey(key2)).isTrue();
+    }
+
+    @Test
+    public void putIfAbsentDoesSameWhenUsingSingleMapAndPresent() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.putIfAbsent(key1, "value2")).isEqualTo("value1");
+        assertThat(existing.get(key1)).isEqualTo("value1");
+    }
+
+    @Test
+    public void removeRemovesFromBothMapsIfRemovedFromExisting() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(key1, "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.remove(key1, "value1")).isTrue();
+        assertThat(existing.containsKey(key1)).isFalse();
+        assertThat(transition.containsKey(key1)).isFalse();
+    }
+
+    @Test
+    public void removeRemovesFromNeitherMapIfNotRemovedFromExisting() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(key1, "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.remove(key1, "value3")).isFalse();
+        assertThat(existing.get(key1)).isEqualTo("value1");
+        assertThat(transition.get(key1)).isEqualTo("value2");
+    }
+
+    @Test
+    public void removeDoesSameAsRemoveWhenUsingSingleMapAndExists() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.remove(key1, "value1")).isTrue();
+        assertThat(existing.containsKey(key1)).isFalse();
+    }
+
+    @Test
+    public void removeDoesSameAsRemoveWhenUsingSingleMapAndDoesNotExist() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.remove(key1, "value2")).isFalse();
+        assertThat(existing.get(key1)).isEqualTo("value1");
+    }
+
+    @Test
+    public void replaceAddsValueToBothMapsIfReplacedInExisting() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.replace(key1, "value1", "value3")).isTrue();
+        assertThat(existing.get(key1)).isEqualTo("value3");
+        assertThat(transition.get(key1)).isEqualTo("value3");
+    }
+
+    @Test
+    public void replaceAddsValueToNeitherMapIfNotReplacedInExisting() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.replace(key1, "value2", "value3")).isFalse();
+        assertThat(existing.get(key1)).isEqualTo("value1");
+        assertThat(transition.containsKey(key1)).isFalse();
+    }
+
+    @Test
+    public void replaceDoesSameAsReplaceWhenUsingSingleMapAndExists() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.replace(key1, "value1", "value3")).isTrue();
+        assertThat(existing.get(key1)).isEqualTo("value3");
+    }
+
+    @Test
+    public void replaceDoesSameAsReplaceWhenUsingSingleMapAndDoesNotExist() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.replace(key1, "value2", "value3")).isFalse();
+        assertThat(existing.get(key1)).isEqualTo("value1");
+    }
+
+    @Test
+    public void replace2AddsValueToBothMapsIfReplacedInExisting() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        assertThat(transitionStore.replace(key1, "value3")).isEqualTo("value1");
+        assertThat(existing.get(key1)).isEqualTo("value3");
+        assertThat(transition.get(key1)).isEqualTo("value3");
+    }
+
+    @Test
+    public void replace2AddsValueToNeitherMapIfNotReplacedInExisting() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+        ConcurrentMap transition = new ConcurrentHashMap() {{
+            put(new SessionId("key2"), "value2");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.of(transition));
+        SessionId key3 = new SessionId("key3");
+        assertThat(transitionStore.replace(key3, "value3")).isEqualTo(null);
+        assertThat(existing.containsKey(key3)).isFalse();
+        assertThat(transition.containsKey(key3)).isFalse();
+    }
+
+    @Test
+    public void replace2DoesSameAsReplace2WhenUsingSingleMap() {
+        SessionId key1 = new SessionId("key1");
+        ConcurrentMap existing = new ConcurrentHashMap() {{
+            put(key1, "value1");
+        }};
+
+        TransitionStore transitionStore = new TransitionStore(existing, Optional.empty());
+        assertThat(transitionStore.replace(key1, "value3")).isEqualTo("value1");
+        assertThat(existing.get(key1)).isEqualTo("value3");
+    }
+}

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -30,14 +30,16 @@ logging:
       archivedFileCount: 7
     - type: console
 
-
-infinispan:
-  bindAddress: 
-  initialHosts: 
-  clusterName: 
-  type: standalone
-  expiration: 8h
-  persistenceToFileEnabled: false
+sessionStoreConfiguration:
+  infinispanConfiguration:
+    enabled: true
+    configuration:
+      bindAddress:
+      initialHosts:
+      clusterName:
+      type: standalone
+      expiration: 8h
+      persistenceToFileEnabled: false
 
 eventSinkUri: ${EVENTSINK_URI:-http://localhost:51100}
 


### PR DESCRIPTION
- I would recommend reviewing this on a per-commit basis
- Interesting things to note:
 * The tests in TransitionCacheTests (you should convince yourself that this is the correct behaviour for a read/write + write only cache)
 * This is essentially a no-op for the existing system (tests have only changed to handle new config format)
- The context here is that we would like to be able to use a second cache, either to support the transition to another serialization format or to another cache provider

Test diff: `2 files changed, 520 insertions(+), 8 deletions(-)` 🎉 
Non-test diff: ` 16 files changed, 394 insertions(+), 75 deletions(-)` 