### PR TITLE
remove an unnecessary infinispan cache in policy - datetime_cache

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionRepository.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionRepository.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule.support;
 
-import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;
 
@@ -10,17 +9,14 @@ import java.util.concurrent.ConcurrentMap;
 public class TestSessionRepository {
 
     private final ConcurrentMap<SessionId, State> dataStore;
-    private final ConcurrentMap<SessionId, DateTime> sessionStartedMap;
 
     @Inject
-    public TestSessionRepository(ConcurrentMap<SessionId, State> dataStore, ConcurrentMap<SessionId, DateTime> sessionStartedMap) {
+    public TestSessionRepository(ConcurrentMap<SessionId, State> dataStore) {
         this.dataStore = dataStore;
-        this.sessionStartedMap = sessionStartedMap;
     }
 
     public void createSession(SessionId sessionId, State state) {
         dataStore.put(sessionId, state);
-        sessionStartedMap.put(sessionId, state.getSessionExpiryTimestamp());
     }
 
     public State getSession(SessionId sessionId) {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/InfinispanStartupTasks.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/InfinispanStartupTasks.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.policy;
 
 import io.dropwizard.lifecycle.Managed;
-import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;
 
@@ -11,19 +10,16 @@ import java.util.concurrent.ConcurrentMap;
 public class InfinispanStartupTasks implements Managed {
 
     private final ConcurrentMap<SessionId, State> sessionCache;
-    private final ConcurrentMap<SessionId, DateTime> expirationCache;
 
     @Inject
-    public InfinispanStartupTasks(ConcurrentMap<SessionId, State> sessionCache, ConcurrentMap<SessionId, DateTime> expirationCache) {
+    public InfinispanStartupTasks(ConcurrentMap<SessionId, State> sessionCache) {
         this.sessionCache = sessionCache;
-        this.expirationCache = expirationCache;
     }
 
     @Override
     public void start() throws Exception {
         SessionId newSessionId = SessionId.createNewSessionId();
         sessionCache.get(newSessionId);
-        expirationCache.get(newSessionId);
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -5,7 +5,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import io.dropwizard.setup.Environment;
-import org.joda.time.DateTime;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.common.shared.security.IdGenerator;
 import uk.gov.ida.eventemitter.Configuration;
@@ -126,12 +125,6 @@ public class PolicyModule extends AbstractModule {
     @Singleton
     public ConcurrentMap<SessionId, State> sessionCache(InfinispanCacheManager infinispanCacheManager) {
         return infinispanCacheManager.getCache("state_cache");
-    }
-
-    @Provides
-    @Singleton
-    public ConcurrentMap<SessionId, DateTime> datetime_cache(InfinispanCacheManager infinispanCacheManager) {
-        return infinispanCacheManager.getCache("datetime_cache");
     }
 
     @Provides

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
@@ -28,17 +28,14 @@ public class SessionRepository {
     private static final Logger LOG = LoggerFactory.getLogger(SessionRepository.class);
 
     private final ConcurrentMap<SessionId, State> dataStore;
-    private final ConcurrentMap<SessionId, DateTime> sessionStartedMap;
     private final StateControllerFactory controllerFactory;
 
     @Inject
     public SessionRepository(
             ConcurrentMap<SessionId, State> dataStore,
-            ConcurrentMap<SessionId, DateTime> sessionStartedMap,
             StateControllerFactory controllerFactory) {
 
         this.dataStore = dataStore;
-        this.sessionStartedMap = sessionStartedMap;
         this.controllerFactory = controllerFactory;
     }
 
@@ -46,7 +43,6 @@ public class SessionRepository {
         SessionId sessionId = startedState.getSessionId();
 
         dataStore.put(sessionId, startedState);
-        sessionStartedMap.put(sessionId, startedState.getSessionExpiryTimestamp());
         LOG.info(format("Session {0} created", sessionId.getSessionId()));
 
         return sessionId;
@@ -154,8 +150,8 @@ public class SessionRepository {
     }
 
     private boolean isTimedOut(SessionId sessionId) {
-        if (sessionStartedMap.containsKey(sessionId)) {
-            DateTime expiryTime = sessionStartedMap.get(sessionId);
+        if (dataStore.containsKey(sessionId)) {
+            DateTime expiryTime = dataStore.get(sessionId).getSessionExpiryTimestamp();
             return DateTime.now().isAfter(expiryTime);
         } else {
             throw new SessionNotFoundException(sessionId);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
@@ -36,7 +36,6 @@ public class SessionRepositoryTest {
 
     private SessionRepository sessionRepository;
     private ConcurrentMap<SessionId, State> dataStore;
-    private ConcurrentMap<SessionId, DateTime> sessionStartedMap;
     private DateTime defaultSessionExpiry = DateTime.now().plusDays(8);
 
     @Mock
@@ -51,8 +50,7 @@ public class SessionRepositoryTest {
     @Before
     public void setup() {
         dataStore = new ConcurrentHashMap<>();
-        sessionStartedMap = new ConcurrentHashMap<>();
-        sessionRepository = new SessionRepository(dataStore, sessionStartedMap, controllerFactory);
+        sessionRepository = new SessionRepository(dataStore, controllerFactory);
     }
 
     @Test(expected = InvalidSessionStateException.class)
@@ -73,7 +71,6 @@ public class SessionRepositoryTest {
 
         assertThat(sessionId).isEqualTo(expectedSessionId);
         assertThat(dataStore.containsKey(expectedSessionId)).isEqualTo(true);
-        assertThat(sessionStartedMap.containsKey(expectedSessionId)).isEqualTo(true);
         verify(controllerFactory).build(eq(sessionStartedState), any(StateTransitionAction.class));
     }
 


### PR DESCRIPTION
the info contained within the datetime_cache is available in the state_cache,
datetime_cache only contains SessionId mapped to state.getSessionExpiryTimestamp()

This commit removes the datetime_cache so only one session cache exists

Following this coming up in a chat with @andy-paine 