### PR TITLE
Revert "remove an unnecessary infinispan cache in policy - datetime_cache"

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionRepository.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule.support;
 
+import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;
 
@@ -9,14 +10,17 @@ import java.util.concurrent.ConcurrentMap;
 public class TestSessionRepository {
 
     private final ConcurrentMap<SessionId, State> dataStore;
+    private final ConcurrentMap<SessionId, DateTime> sessionStartedMap;
 
     @Inject
-    public TestSessionRepository(ConcurrentMap<SessionId, State> dataStore) {
+    public TestSessionRepository(ConcurrentMap<SessionId, State> dataStore, ConcurrentMap<SessionId, DateTime> sessionStartedMap) {
         this.dataStore = dataStore;
+        this.sessionStartedMap = sessionStartedMap;
     }
 
     public void createSession(SessionId sessionId, State state) {
         dataStore.put(sessionId, state);
+        sessionStartedMap.put(sessionId, state.getSessionExpiryTimestamp());
     }
 
     public State getSession(SessionId sessionId) {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/InfinispanStartupTasks.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/InfinispanStartupTasks.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.hub.policy;
 
 import io.dropwizard.lifecycle.Managed;
+import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;
 
@@ -10,16 +11,19 @@ import java.util.concurrent.ConcurrentMap;
 public class InfinispanStartupTasks implements Managed {
 
     private final ConcurrentMap<SessionId, State> sessionCache;
+    private final ConcurrentMap<SessionId, DateTime> expirationCache;
 
     @Inject
-    public InfinispanStartupTasks(ConcurrentMap<SessionId, State> sessionCache) {
+    public InfinispanStartupTasks(ConcurrentMap<SessionId, State> sessionCache, ConcurrentMap<SessionId, DateTime> expirationCache) {
         this.sessionCache = sessionCache;
+        this.expirationCache = expirationCache;
     }
 
     @Override
     public void start() throws Exception {
         SessionId newSessionId = SessionId.createNewSessionId();
         sessionCache.get(newSessionId);
+        expirationCache.get(newSessionId);
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -5,6 +5,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import io.dropwizard.setup.Environment;
+import org.joda.time.DateTime;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.common.shared.security.IdGenerator;
 import uk.gov.ida.eventemitter.Configuration;
@@ -125,6 +126,12 @@ public class PolicyModule extends AbstractModule {
     @Singleton
     public ConcurrentMap<SessionId, State> sessionCache(InfinispanCacheManager infinispanCacheManager) {
         return infinispanCacheManager.getCache("state_cache");
+    }
+
+    @Provides
+    @Singleton
+    public ConcurrentMap<SessionId, DateTime> datetime_cache(InfinispanCacheManager infinispanCacheManager) {
+        return infinispanCacheManager.getCache("datetime_cache");
     }
 
     @Provides

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
@@ -36,6 +36,7 @@ public class SessionRepositoryTest {
 
     private SessionRepository sessionRepository;
     private ConcurrentMap<SessionId, State> dataStore;
+    private ConcurrentMap<SessionId, DateTime> sessionStartedMap;
     private DateTime defaultSessionExpiry = DateTime.now().plusDays(8);
 
     @Mock
@@ -50,7 +51,8 @@ public class SessionRepositoryTest {
     @Before
     public void setup() {
         dataStore = new ConcurrentHashMap<>();
-        sessionRepository = new SessionRepository(dataStore, controllerFactory);
+        sessionStartedMap = new ConcurrentHashMap<>();
+        sessionRepository = new SessionRepository(dataStore, sessionStartedMap, controllerFactory);
     }
 
     @Test(expected = InvalidSessionStateException.class)
@@ -71,6 +73,7 @@ public class SessionRepositoryTest {
 
         assertThat(sessionId).isEqualTo(expectedSessionId);
         assertThat(dataStore.containsKey(expectedSessionId)).isEqualTo(true);
+        assertThat(sessionStartedMap.containsKey(expectedSessionId)).isEqualTo(true);
         verify(controllerFactory).build(eq(sessionStartedState), any(StateTransitionAction.class));
     }
 


### PR DESCRIPTION
Reverts alphagov/verify-hub#113

I've been thinking about this - we need to stop using the cache before finally removing it

If this gets deployed then when a new session is started on a new policy, it won't be in the datetime_cache in an old policy - so an incorrect SessionNotFoundException will be thrown if the load balancer points the user to the older policy.  

Firstly the change need to be made to switch to checking the state_cache instead of datetime_cache, but still populate the datetime_cache, then the datetime_cache can be removed.