### PR TITLE
stop using unnecessary infinispan cache in policy - datetime_cache

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -53,7 +53,6 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.KeyStore;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
 public class PolicyModule extends AbstractModule {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
@@ -154,8 +154,8 @@ public class SessionRepository {
     }
 
     private boolean isTimedOut(SessionId sessionId) {
-        if (sessionStartedMap.containsKey(sessionId)) {
-            DateTime expiryTime = sessionStartedMap.get(sessionId);
+        if (dataStore.containsKey(sessionId)) {
+            DateTime expiryTime = dataStore.get(sessionId).getSessionExpiryTimestamp();
             return DateTime.now().isAfter(expiryTime);
         } else {
             throw new SessionNotFoundException(sessionId);


### PR DESCRIPTION
the info contained within the datetime_cache is available in the state_cache,
datetime_cache only contains SessionId mapped to state.getSessionExpiryTimestamp()

This commit keeps datetime_cache populated so that old policy instances can
keep working without interruption for users, and after a release another commit
will remove the cache entirely.