### PR TITLE
Event emitter upgrade in hub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-52"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-53"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -67,6 +67,5 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -105,6 +105,5 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -98,6 +98,5 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}

--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -140,6 +140,5 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}

--- a/debian/saml-proxy/saml-proxy.yml
+++ b/debian/saml-proxy/saml-proxy.yml
@@ -162,6 +162,6 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+

--- a/debian/saml-soap-proxy/saml-soap-proxy.yml
+++ b/debian/saml-soap-proxy/saml-soap-proxy.yml
@@ -166,6 +166,6 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/EventEmitterConfiguration.java
@@ -5,21 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
+import java.net.URI;
 import java.util.Base64;
 
 public class EventEmitterConfiguration implements Configuration {
-
     @Valid
     @JsonProperty
     private boolean enabled;
-
-    @Valid
-    @JsonProperty
-    private String queueAccountId;
-
-    @Valid
-    @JsonProperty
-    private String sourceQueueName;
 
     @Valid
     @JsonProperty
@@ -37,11 +29,11 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private String encryptionKey;
 
-    private EventEmitterConfiguration() { }
+    @Valid
+    @JsonProperty
+    private URI apiGatewayUrl;
 
-    public EventEmitterConfiguration(String sourceQueueName) {
-        this.sourceQueueName = sourceQueueName;
-    }
+    private EventEmitterConfiguration() { }
 
     @Override
     public boolean isEnabled() { return enabled; }
@@ -62,17 +54,11 @@ public class EventEmitterConfiguration implements Configuration {
     }
 
     @Override
-    public String getSourceQueueName() {
-        return sourceQueueName;
-    }
-
-    @Override
-    public String getQueueAccountId() {
-        return queueAccountId;
-    }
-
-    @Override
     public byte[] getEncryptionKey() {
         return Base64.getDecoder().decode(encryptionKey);
     }
+
+    @Override
+    public URI getApiGatewayUrl() { return apiGatewayUrl; }
 }
+

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -84,6 +84,5 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL:-http://not.used}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
@@ -6,22 +6,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
+import java.net.URI;
 import java.util.Base64;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EventEmitterConfiguration implements Configuration {
-
     @Valid
     @JsonProperty
     private boolean enabled;
-
-    @Valid
-    @JsonProperty
-    private String queueAccountId;
-
-    @Valid
-    @JsonProperty
-    private String sourceQueueName;
 
     @Valid
     @JsonProperty
@@ -39,11 +31,11 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private String encryptionKey;
 
-    private EventEmitterConfiguration() { }
+    @Valid
+    @JsonProperty
+    private URI apiGatewayUrl;
 
-    public EventEmitterConfiguration(String sourceQueueName) {
-        this.sourceQueueName = sourceQueueName;
-    }
+    private EventEmitterConfiguration() { }
 
     @Override
     public boolean isEnabled() { return enabled; }
@@ -64,17 +56,11 @@ public class EventEmitterConfiguration implements Configuration {
     }
 
     @Override
-    public String getSourceQueueName() {
-        return sourceQueueName;
-    }
-
-    @Override
-    public String getQueueAccountId() {
-        return queueAccountId;
-    }
-
-    @Override
     public byte[] getEncryptionKey() {
         return Base64.getDecoder().decode(encryptionKey);
     }
+
+    @Override
+    public URI getApiGatewayUrl() { return apiGatewayUrl; }
 }
+

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -125,6 +125,5 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL:-http://not.used}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
@@ -5,20 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.eventemitter.Configuration;
 
 import javax.validation.Valid;
+import java.net.URI;
 import java.util.Base64;
 
 public class EventEmitterConfiguration implements Configuration {
     @Valid
     @JsonProperty
     private boolean enabled;
-
-    @Valid
-    @JsonProperty
-    private String queueAccountId;
-
-    @Valid
-    @JsonProperty
-    private String sourceQueueName;
 
     @Valid
     @JsonProperty
@@ -36,11 +29,11 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private String encryptionKey;
 
-    private EventEmitterConfiguration() { }
+    @Valid
+    @JsonProperty
+    private URI apiGatewayUrl;
 
-    public EventEmitterConfiguration(String sourceQueueName) {
-        this.sourceQueueName = sourceQueueName;
-    }
+    private EventEmitterConfiguration() { }
 
     @Override
     public boolean isEnabled() { return enabled; }
@@ -61,17 +54,10 @@ public class EventEmitterConfiguration implements Configuration {
     }
 
     @Override
-    public String getSourceQueueName() {
-        return sourceQueueName;
-    }
-
-    @Override
-    public String getQueueAccountId() {
-        return queueAccountId;
-    }
-
-    @Override
     public byte[] getEncryptionKey() {
         return Base64.getDecoder().decode(encryptionKey);
     }
+
+    @Override
+    public URI getApiGatewayUrl() { return apiGatewayUrl; }
 }

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -105,6 +105,5 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL:-http://not.used}


### PR DESCRIPTION
B&A: Upgrade Event Emitter Library in Hub.

https://trello.com/c/auJ7kBAx

Uplift Event Emitter library version.
Add url field and provide default values for event emitter url in config.

Co-authored-by: Brendan Butler <brendan.butler@digital.cabinet-office.gov.uk>