### PR TITLE
BAU: Fix upstart scripts

### DIFF
--- a/debian/config/upstart/config
+++ b/debian/config/upstart/config
@@ -41,14 +41,16 @@ script
                         -XX:HeapDumpPath=/var/log/ida/debug \
                         -XX:+HeapDumpOnOutOfMemoryError \
                         -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=${PROXY_HOST:-} \
-                        -Dhttp.proxyPort=${PROXY_PORT:-} \
-                        -Dhttps.proxyHost=${PROXY_HOST:-} \
-                        -Dhttps.proxyPort=${PROXY_PORT:-} \
-                        -Dhttp.nonProxyHosts=${NON_PROXY_HOSTS:-} \
+                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
                         -Dnetworkaddress.cache.ttl=5
                         -Dnetworkaddress.cache.negative.ttl=5"
 
+  # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
+  unset JAVA_HOME
   exec /ida/config/bin/config \
     server /ida/config/config.yml \
     1>> /var/log/ida/config.console-log 2>&1

--- a/debian/policy/upstart/policy
+++ b/debian/policy/upstart/policy
@@ -40,14 +40,16 @@ script
                         -XX:HeapDumpPath=/var/log/ida/debug \
                         -XX:+HeapDumpOnOutOfMemoryError \
                         -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=${PROXY_HOST:-} \
-                        -Dhttp.proxyPort=${PROXY_PORT:-} \
-                        -Dhttps.proxyHost=${PROXY_HOST:-} \
-                        -Dhttps.proxyPort=${PROXY_PORT:-} \
-                        -Dhttp.nonProxyHosts=${NON_PROXY_HOSTS:-} \
+                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
                         -Dnetworkaddress.cache.ttl=5
                         -Dnetworkaddress.cache.negative.ttl=5
 
+  # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
+  unset JAVA_HOME
   exec /ida/policy/bin/policy \
     server /ida/policy/policy.yml \
     1>> /var/log/ida/policy.console-log 2>&1

--- a/debian/saml-engine/upstart/saml-engine
+++ b/debian/saml-engine/upstart/saml-engine
@@ -37,14 +37,16 @@ script
                         -XX:HeapDumpPath=/var/log/ida/debug \
                         -XX:+HeapDumpOnOutOfMemoryError \
                         -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=${PROXY_HOST:-} \
-                        -Dhttp.proxyPort=${PROXY_PORT:-} \
-                        -Dhttps.proxyHost=${PROXY_HOST:-} \
-                        -Dhttps.proxyPort=${PROXY_PORT:-} \
-                        -Dhttp.nonProxyHosts=${NON_PROXY_HOSTS:-} \
+                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
                         -Dnetworkaddress.cache.ttl=5
                         -Dnetworkaddress.cache.negative.ttl=5"
 
+  # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
+  unset JAVA_HOME
   exec start-stop-daemon \
     --start \
     -c saml-engine \

--- a/debian/saml-proxy/upstart/saml-proxy
+++ b/debian/saml-proxy/upstart/saml-proxy
@@ -40,14 +40,16 @@ script
                         -XX:HeapDumpPath=/var/log/ida/debug \
                         -XX:+HeapDumpOnOutOfMemoryError \
                         -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=${PROXY_HOST:-} \
-                        -Dhttp.proxyPort=${PROXY_PORT:-} \
-                        -Dhttps.proxyHost=${PROXY_HOST:-} \
-                        -Dhttps.proxyPort=${PROXY_PORT:-} \
-                        -Dhttp.nonProxyHosts=${NON_PROXY_HOSTS:-} \
+                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
                         -Dnetworkaddress.cache.ttl=5
                         -Dnetworkaddress.cache.negative.ttl=5"
 
+  # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
+  unset JAVA_HOME
   exec /ida/saml-proxy/bin/saml-proxy \
     server /ida/saml-proxy/saml-proxy.yml \
     1>> /var/log/ida/saml-proxy.console-log 2>&1

--- a/debian/saml-soap-proxy/upstart/saml-soap-proxy
+++ b/debian/saml-soap-proxy/upstart/saml-soap-proxy
@@ -40,14 +40,16 @@ script
                         -XX:HeapDumpPath=/var/log/ida/debug \
                         -XX:+HeapDumpOnOutOfMemoryError \
                         -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=${PROXY_HOST:-} \
-                        -Dhttp.proxyPort=${PROXY_PORT:-} \
-                        -Dhttps.proxyHost=${PROXY_HOST:-} \
-                        -Dhttps.proxyPort=${PROXY_PORT:-} \
-                        -Dhttp.nonProxyHosts=${NON_PROXY_HOSTS:-} \
+                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
                         -Dnetworkaddress.cache.ttl=5
                         -Dnetworkaddress.cache.negative.ttl=5"
 
+  # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
+  unset JAVA_HOME
   exec /ida/saml-soap-proxy/bin/saml-soap-proxy \
     server /ida/saml-soap-proxy/saml-soap-proxy.yml \
     1>> /var/log/ida/saml-soap-proxy.console-log 2>&1


### PR DESCRIPTION
- The JAVA_HOME doesn't work on our AWS envs so just unset it
- Also quote your variables.