### PR TITLE
BAU: Fix typo in env var

### DIFF
--- a/configuration/local/policy.yml
+++ b/configuration/local/policy.yml
@@ -68,4 +68,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -106,4 +106,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -99,4 +99,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}

--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -141,4 +141,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}

--- a/debian/saml-proxy/saml-proxy.yml
+++ b/debian/saml-proxy/saml-proxy.yml
@@ -163,5 +163,5 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
 

--- a/debian/saml-soap-proxy/saml-soap-proxy.yml
+++ b/debian/saml-soap-proxy/saml-soap-proxy.yml
@@ -167,5 +167,5 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
 

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -85,4 +85,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL:-http://not.used}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -126,4 +126,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL:-http://not.used}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -106,4 +106,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEYWAY_URL:-http://not.used}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}


### PR DESCRIPTION
- GATEYWAY sounds more friendly but Puppet expects to use GATEWAY