### PR TITLE
Revert "BAU: Remove hub SAML signing certificate from SAML Engine"

### DIFF
--- a/configuration/local/saml-engine.yml
+++ b/configuration/local/saml-engine.yml
@@ -48,6 +48,10 @@ readKeysFromFileDescriptors: false
 privateSigningKeyConfiguration:
   keyFile: /data/pki/hub_signing_primary.pk8
 
+publicSigningCert:
+   certFile: /data/pki/hub_signing_primary.crt
+   name: someId
+
 primaryPrivateEncryptionKeyConfiguration:
   keyFile: /data/pki/hub_encryption_primary.pk8
 

--- a/debian/saml-engine/saml-engine.yml
+++ b/debian/saml-engine/saml-engine.yml
@@ -41,6 +41,9 @@ saml:
 
 enableRetryTimeOutConnections: true
 
+publicSigningCert:
+  name: hub_signing_cert
+  certFile: ${PKI_PUBLIC_SIGNING_CERT_PATH}
 httpClient:
   timeout: 60s
   timeToLive: 10m

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -97,6 +97,7 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
                 config("server.adminConnectors[0].port", "0"),
                 config("privateSigningKeyConfiguration.key", HUB_TEST_PRIVATE_SIGNING_KEY),
                 config("privateSigningKeyConfiguration.type", "encoded"),
+                config("publicSigningCert.x509", HUB_TEST_PUBLIC_SIGNING_CERT),
                 config("primaryPrivateEncryptionKeyConfiguration.key", HUB_TEST_PRIVATE_ENCRYPTION_KEY),
                 config("primaryPrivateEncryptionKeyConfiguration.type", "encoded"),
                 config("secondaryPrivateEncryptionKeyConfiguration.key", TEST_PRIVATE_KEY),

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -6,6 +6,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
+import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
 import uk.gov.ida.common.shared.configuration.PrivateKeyConfiguration;
 import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.hub.samlengine.config.SamlConfiguration;
@@ -37,6 +38,11 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @Valid
     @JsonProperty
     protected PrivateKeyConfiguration privateSigningKeyConfiguration;
+
+    @Valid
+    @NotNull
+    @JsonProperty
+    protected DeserializablePublicKeyConfiguration publicSigningCert;
 
     @Valid
     @JsonProperty
@@ -143,6 +149,10 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
 
     public MetadataResolverConfiguration getMetadataConfiguration() {
         return metadata;
+    }
+
+    public DeserializablePublicKeyConfiguration getPublicSigningCert() {
+        return publicSigningCert;
     }
 
     @Override

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -24,6 +24,8 @@ import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import org.w3c.dom.Element;
 import uk.gov.ida.common.ServiceInfoConfiguration;
+import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.hub.samlengine.annotations.Config;
 import uk.gov.ida.hub.samlengine.attributequery.AttributeQueryGenerator;
 import uk.gov.ida.hub.samlengine.attributequery.HubAttributeQueryRequestBuilder;
@@ -136,6 +138,7 @@ import java.security.KeyException;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Timer;
@@ -439,8 +442,12 @@ public class SamlEngineModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private IdaKeyStore getKeyStore(SamlEngineConfiguration configuration) {
+    private IdaKeyStore getKeyStore(X509CertificateFactory certificateFactory, SamlEngineConfiguration configuration) {
         Map<KeyPosition, PrivateKey> privateKeyStore = privateEncryptionKeys(configuration);
+
+        DeserializablePublicKeyConfiguration publicSigningKeyConfiguration = configuration.getPublicSigningCert();
+        String encodedSigningCertificate = publicSigningKeyConfiguration.getCert();
+        X509Certificate signingCertificate = encodedSigningCertificate != null ? certificateFactory.createCertificate(encodedSigningCertificate) : null;
 
         try {
             PrivateKey primaryEncryptionKey = privateKeyStore.get(KeyPosition.PRIMARY);
@@ -451,7 +458,7 @@ public class SamlEngineModule extends AbstractModule {
             KeyPair secondaryEncryptionKeyPair = new KeyPair(KeySupport.derivePublicKey(secondaryEncryptionKey), secondaryEncryptionKey);
             KeyPair signingKeyPair = new KeyPair(KeySupport.derivePublicKey(signingKey), signingKey);
 
-            return new IdaKeyStore(signingKeyPair, asList(primaryEncryptionKeyPair, secondaryEncryptionKeyPair));
+            return new IdaKeyStore(signingCertificate, signingKeyPair, asList(primaryEncryptionKeyPair, secondaryEncryptionKeyPair));
         } catch (KeyException e) {
             throw new KeyLoadingException(e);
         }

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -73,6 +73,11 @@ privateSigningKeyConfiguration:
   type: base64
   key: ${HUB_SIGNING_KEY}
 
+publicSigningCert:
+  type: x509
+  x509: ${HUB_SIGNING_CERT}
+  name: ${HUB_SIGNING_CERT_NAME}
+
 primaryPrivateEncryptionKeyConfiguration:
   type: base64
   key: ${HUB_PRIMARY_ENC_KEY}


### PR DESCRIPTION
This reverts commit 736c581173a65e0a3fa244733c69699613f3ffd9.

Whilst we do not need the signing certificate for the regular Verify
federation, we do need it for communicating with EU countries via eIDAS.

The KeyInfo part of the SAML message needs the full X.509 certificate, not just
the public key.

Reintroduce the SAML signing certificate for now - we may be able to retrieve
it from SAML metadata in future.