### PR TITLE
BAU: Add translations dir to local config

### DIFF
--- a/configuration/local/config.yml
+++ b/configuration/local/config.yml
@@ -19,6 +19,7 @@ serviceInfo:
   name: config
 
 rootDataDirectory: ${FED_CONFIG_PATH:-/data/stub-fed-config}
+translationsDirectory: ../display-locales/transactions
 
 clientTrustStoreConfiguration:
   path: /data/pki/hub.ts


### PR DESCRIPTION
- We were missing this key in the config file