### PR TITLE
EID-885: Correct some tests names in EidasMatchingServiceResourceIntegrationTest

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
@@ -145,7 +145,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
     }
 
     @Test
-    public void shouldTransitionToEidasUserAccountCreationStateWhenNoMatchIsReceivedForEidasCycle0And1WithCycle3DisabledAndUACEnabled() throws Exception {
+    public void shouldTransitionToEidasUserAccountCreationRequestSentStateWhenNoMatchIsReceivedForEidasCycle0And1WithCycle3DisabledAndUACEnabled() throws Exception {
         final SessionId sessionId = aSessionIsCreated();
         aCountryWasSelected(sessionId, NETHERLANDS);
         samlSoapProxyProxyStub.setUpStubForSendHubMatchingServiceRequest(sessionId);
@@ -205,7 +205,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
     }
 
     @Test
-    public void shouldTransitionToEidasUserAccountCreationSentStateWhenNoMatchIsReceivedForEidasCycle3WhenUACEnabled() throws Exception {
+    public void shouldTransitionToEidasUserAccountCreationRequestSentStateWhenNoMatchIsReceivedForEidasCycle3WhenUACEnabled() throws Exception {
         SessionId sessionId = aSessionIsCreated();
         aCountryWasSelected(sessionId, NETHERLANDS);
         samlSoapProxyProxyStub.setUpStubForSendHubMatchingServiceRequest(sessionId);
@@ -247,7 +247,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
     }
 
     @Test
-    public void shouldTransitionToCountryUserAccountCreatedStateWhenUACreatedResponseIsReceivedForEidasCycle3WhenUACEnabled() throws Exception {
+    public void shouldTransitionToCountryUserAccountCreationFailedStateWhenUACFailedResponseIsReceivedForEidasCycle3WhenUACEnabled() throws Exception {
         SessionId sessionId = aSessionIsCreated();
         aCountryWasSelected(sessionId, NETHERLANDS);
         samlSoapProxyProxyStub.setUpStubForSendHubMatchingServiceRequest(sessionId);
@@ -271,7 +271,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
     }
 
     @Test
-    public void shouldTransitionToCountryUserAccountCreationFailedStateWhenUACFailedResponseIsReceivedForEidasCycle3WhenUACEnabled() throws Exception {
+    public void shouldTransitionToUserAccountCreatedStateWhenUACreatedResponseIsReceivedForEidasCycle3WhenUACEnabled() throws Exception {
         SessionId sessionId = aSessionIsCreated();
         aCountryWasSelected(sessionId, NETHERLANDS);
         samlSoapProxyProxyStub.setUpStubForSendHubMatchingServiceRequest(sessionId);


### PR DESCRIPTION
Some tests in EidasMatchingServiceResourceIntegrationTest got incorrect or mixed up names whilst merging b1633eed0da49c9bac616d6b36e415b5a41037b3.

This was spotted whilst going through the tests during sign-off