### PR TITLE
Add prometheus support to Policy behind a feature flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ subprojects {
         dev_pki
         trust_anchor
         saml_libs
+        prometheus
     }
 
     dependencies {
@@ -118,6 +119,8 @@ subprojects {
         dev_pki "uk.gov.ida:ida-dev-pki:$dependencyVersions.dev_pki"
 
         dropwizard_infinispan "uk.gov.ida:dropwizard-infinispan:$dependencyVersions.dropwizard_infinispan"
+
+        prometheus 'engineering.gds-reliability:gds-metrics-dropwizard:0.1.0'
 
         saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
              "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_libs",

--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -142,3 +142,5 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
+
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/policy/build.gradle
+++ b/hub/policy/build.gradle
@@ -9,7 +9,8 @@ dependencies {
             configurations.verify_event_emitter,
             configurations.common,
             configurations.dropwizard,
-            configurations.dropwizard_infinispan
+            configurations.dropwizard_infinispan,
+            configurations.prometheus
 }
 
 apply plugin: 'application'

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyApplication.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
+import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -63,6 +64,7 @@ public class PolicyApplication extends Application<PolicyConfiguration> {
         bootstrap.addBundle(new ServiceStatusBundle());
         bootstrap.addBundle(new MonitoringBundle());
         bootstrap.addBundle(new LoggingBundle());
+        bootstrap.addBundle(new PrometheusBundle());
         bootstrap.addBundle(new IdaJsonProcessingExceptionMapperBundle());
         final InfinispanBundle infinispanBundle = new InfinispanBundle();
         // the infinispan cache manager needs to be lazy loaded because it is not initialized at this point.

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.policy;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
@@ -17,7 +18,7 @@ import javax.validation.constraints.NotNull;
 import java.net.URI;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PolicyConfiguration extends Configuration implements RestfulClientConfiguration, ServiceNameConfiguration, InfinispanServiceConfiguration, AssertionLifetimeConfiguration {
+public class PolicyConfiguration extends Configuration implements RestfulClientConfiguration, ServiceNameConfiguration, InfinispanServiceConfiguration, AssertionLifetimeConfiguration, PrometheusConfiguration {
 
     @Valid
     @JsonProperty
@@ -91,6 +92,10 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
 
+    @Valid
+    @JsonProperty
+    protected Boolean prometheusEnabled = false;
+
     protected PolicyConfiguration() {}
 
     public URI getSamlSoapProxyUri() { return samlSoapProxyUri;  }
@@ -156,5 +161,10 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
 
     public EventEmitterConfiguration getEventEmitterConfiguration() {
         return eventEmitterConfiguration;
+    }
+
+    @Override
+    public boolean isPrometheusEnabled() {
+        return prometheusEnabled;
     }
 }


### PR DESCRIPTION
This adds PrometheusBundle from alphagov/gds_metrics_dropwizard.  This
adds configurable support for prometheus metrics to be exposed at
/prometheus/metrics on the admin port.  By default, this endpoint is
disabled; it is activated by adding `prometheusEnabled: true` to
policy.yml.

Policy was chosen arbitrarily as a proof of concept; there's no reason
we couldn't do the same for all apps.

In order for this to work, the gds-metrics-dropwizard dependency will
need to be added to artifactory.