### PR TITLE
EID-939 - Update latest saml-libs to fix bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-44",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-34',
-            saml_libs:"$opensaml_version-157",
+            saml_libs:"$opensaml_version-159",
         ]
 
 subprojects {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -749,7 +749,7 @@ public class SamlEngineModule extends AbstractModule {
             DigestAlgorithm digestAlgorithm) {
         return hubTransformersFactory.getEidasAuthnRequestFromHubToStringTransformer(
                 keyStore,
-                new SignatureRSASHA256(), //TODO: needs to be refactored once TT-71 is complete
+                new SignatureRSASHA256(),
                 digestAlgorithm
         );
     }


### PR DESCRIPTION
- The bug in saml-libs means that it will not throw an exception
when keyinfo is required and the signing cert is not there. This has been
resolved in the latest version of saml-libs.
- Remove meaningless comment in code
- Add test to ensure exception is thrown when signing cert is not present