### PR TITLE
Revert "fb: use new signature validators in saml-proxy"

### DIFF
--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/MetadataConsumerTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/MetadataConsumerTests.java
@@ -95,7 +95,7 @@ public class MetadataConsumerTests {
         SamlRequestDto samlRequestDto = new SamlRequestDto(samlResponseString,
                 sessionId.getSessionId(), "127.0.0.1");
 
-        assertThat(postSAML(samlRequestDto).getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode
+        assertThat(postSAML(samlRequestDto).getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode
                 ());
     }
 

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/SamlMessageReceiverApiResourceTest.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/SamlMessageReceiverApiResourceTest.java
@@ -135,7 +135,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         final Response response = postSAML(authnResponse, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_RESOURCE);
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
     }
 
     @Test

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
@@ -1,16 +1,12 @@
 package uk.gov.ida.hub.samlproxy;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import com.google.inject.AbstractModule;
-import com.google.inject.name.Names;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
@@ -24,7 +20,6 @@ import uk.gov.ida.hub.samlproxy.resources.HubMetadataResourceApi;
 import uk.gov.ida.hub.samlproxy.resources.SamlMessageReceiverApi;
 import uk.gov.ida.hub.samlproxy.resources.SamlMessageSenderApi;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
-import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
 
 import javax.servlet.DispatcherType;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -37,7 +32,6 @@ import static com.hubspot.dropwizard.guicier.GuiceBundle.defaultBuilder;
 public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
 
     private GuiceBundle<SamlProxyConfiguration> guiceBundle;
-    private MetadataResolverBundle<SamlProxyConfiguration> verifyMetadataBundle = new MetadataResolverBundle<>((SamlProxyConfiguration::getMetadataConfiguration));
 
     public static void main(String[] args) throws Exception {
         new SamlProxyApplication().run(args);
@@ -57,9 +51,8 @@ public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
                 )
         );
 
-        bootstrap.addBundle(verifyMetadataBundle);
         guiceBundle = defaultBuilder(SamlProxyConfiguration.class)
-                .modules(new SamlProxyModule(), new EventEmitterModule(), bindVerifyMetadata())
+                .modules(new SamlProxyModule(), new EventEmitterModule())
                 .build();
         bootstrap.addBundle(guiceBundle);
         bootstrap.addBundle(new ServiceStatusBundle());
@@ -67,28 +60,11 @@ public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
         bootstrap.addBundle(new LoggingBundle());
     }
 
-    private AbstractModule bindVerifyMetadata() {
-        return new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(MetadataResolver.class)
-                        .annotatedWith(Names.named(SamlProxyModule.VERIFY_METADATA_RESOLVER))
-                        .toProvider(verifyMetadataBundle.getMetadataResolverProvider());
-
-                bind(ExplicitKeySignatureTrustEngine.class)
-                        .annotatedWith(Names.named(SamlProxyModule.VERIFY_METADATA_TRUST_ENGINE))
-                        .toProvider(verifyMetadataBundle.getSignatureTrustEngineProvider());
-            }
-        };
-    }
-
-
     @Override
     public void run(SamlProxyConfiguration configuration, Environment environment) throws Exception {
         environment.getObjectMapper().setDateFormat(new ISO8601DateFormat());
 
         IdaSamlBootstrap.bootstrap();
-
 
         for (Class klass : getResources()) {
             environment.jersey().register(klass);

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -13,7 +13,6 @@ import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolve
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
 import org.w3c.dom.Element;
 import uk.gov.ida.common.IpFromXForwardedForHeader;
 import uk.gov.ida.common.ServiceInfoConfiguration;
@@ -47,12 +46,15 @@ import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogFormatter;
 import uk.gov.ida.hub.samlproxy.logging.ProtectiveMonitoringLogger;
 import uk.gov.ida.hub.samlproxy.proxy.SessionProxy;
 import uk.gov.ida.hub.samlproxy.security.AuthnRequestKeyStore;
+import uk.gov.ida.hub.samlproxy.security.AuthnResponseKeyStore;
+import uk.gov.ida.hub.samlproxy.security.HubSigningKeyStore;
 import uk.gov.ida.jerseyclient.DefaultClientProvider;
 import uk.gov.ida.jerseyclient.ErrorHandlingClient;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.restclient.ClientProvider;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
+import uk.gov.ida.saml.core.InternalPublicKeyStore;
 import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.core.security.RelayStateValidator;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
@@ -64,13 +66,15 @@ import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorHealthCheck;
 import uk.gov.ida.saml.metadata.EidasTrustAnchorResolver;
 import uk.gov.ida.saml.metadata.ExpiredCertificateMetadataFilter;
+import uk.gov.ida.saml.metadata.HubMetadataPublicKeyStore;
+import uk.gov.ida.saml.metadata.IdpMetadataPublicKeyStore;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
 import uk.gov.ida.saml.metadata.MetadataResolverConfigBuilder;
+import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
 import uk.gov.ida.saml.metadata.factories.MetadataSignatureTrustEngineFactory;
 import uk.gov.ida.saml.security.CredentialFactorySignatureValidator;
-import uk.gov.ida.saml.security.MetadataBackedSignatureValidator;
 import uk.gov.ida.saml.security.PublicKeyFactory;
 import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
 import uk.gov.ida.saml.security.SigningCredentialFactory;
@@ -98,8 +102,6 @@ public class SamlProxyModule extends AbstractModule {
 
     public static final String VERIFY_METADATA_HEALTH_CHECK = "VerifyMetadataHealthCheck";
     public static final String COUNTRY_METADATA_HEALTH_CHECK = "CountryMetadataHealthCheck";
-    public static final String VERIFY_METADATA_RESOLVER = "VerifyMetadataResolver";
-    public static final String VERIFY_METADATA_TRUST_ENGINE = "VerifyMetadataTrustEngine";
 
     @Override
     protected void configure() {
@@ -144,9 +146,18 @@ public class SamlProxyModule extends AbstractModule {
 
     @Provides
     @Singleton
+    @Named("VerifyMetadataResolver")
+    public MetadataResolver getVerifyMetadataResolver(Environment environment, SamlProxyConfiguration configuration) {
+        final MetadataResolver metadataResolver = new DropwizardMetadataResolverFactory().createMetadataResolver(environment, configuration.getMetadataConfiguration());
+        registerMetadataRefreshTask(environment, metadataResolver, configuration.getMetadataConfiguration(), "metadata");
+        return metadataResolver;
+    }
+
+    @Provides
+    @Singleton
     @Named(VERIFY_METADATA_HEALTH_CHECK)
     public MetadataHealthCheck getVerifyMetadataHealthCheck(
-        @Named(VERIFY_METADATA_RESOLVER) MetadataResolver metadataResolver,
+        @Named("VerifyMetadataResolver") MetadataResolver metadataResolver,
         Environment environment,
         SamlProxyConfiguration configuration) {
         MetadataHealthCheck metadataHealthCheck = new MetadataHealthCheck(metadataResolver, configuration.getMetadataConfiguration().getExpectedEntityId());
@@ -156,16 +167,11 @@ public class SamlProxyModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named("VERIFY_METADATA_REFRESH_TASK")
-    public Task registerMetadataRefreshTask(Environment environment, @Named(VERIFY_METADATA_RESOLVER) MetadataResolver metadataResolver) {
-        Task task = new Task("metadata-refresh") {
-            @Override
-            public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
-                ((AbstractReloadingMetadataResolver) metadataResolver).refresh();
-            }
-        };
-        environment.admin().addTask(task);
-        return task;
+    public InternalPublicKeyStore getHubMetadataPublicKeyStore(
+            @Named("VerifyMetadataResolver") MetadataResolver metadataResolver,
+            PublicKeyFactory publicKeyFactory,
+            @Named("HubEntityId") String hubEntityId) {
+        return new HubMetadataPublicKeyStore(metadataResolver, publicKeyFactory, hubEntityId);
     }
 
     @Provides
@@ -323,15 +329,34 @@ public class SamlProxyModule extends AbstractModule {
     }
 
     @Provides
-    @Singleton
-    public SamlMessageSignatureValidator getSamlMessageSignatureValidator(@Named(VERIFY_METADATA_TRUST_ENGINE) ExplicitKeySignatureTrustEngine metadataTrustEngine) {
-        return new SamlMessageSignatureValidator(MetadataBackedSignatureValidator.withoutCertificateChainValidation(metadataTrustEngine));
-    }
-
-    @Provides
     @Named("authnRequestPublicCredentialFactory")
     public SigningCredentialFactory getFactoryForAuthnRequests(ConfigServiceKeyStore configServiceKeyStore) {
         return new SigningCredentialFactory(new AuthnRequestKeyStore(configServiceKeyStore));
+    }
+
+    @Provides
+    @Singleton
+    @Named("VerifyIdpMetadataPublicKeyStore")
+    public IdpMetadataPublicKeyStore getVerifyIdpMetadataPublicKeyStore(@Named("VerifyMetadataResolver") MetadataResolver metadataResolver) {
+        return new IdpMetadataPublicKeyStore(metadataResolver);
+    }
+
+    @Provides
+    @Singleton
+    @Named("authnResponsePublicCredentialFactory")
+    public SigningCredentialFactory getFactoryForAuthnResponses(@Named("VerifyIdpMetadataPublicKeyStore") IdpMetadataPublicKeyStore idpMetadataPublicKeyStore) {
+        return new SigningCredentialFactory(new AuthnResponseKeyStore(idpMetadataPublicKeyStore));
+    }
+
+    @Provides
+    @Named("hubSigningCredentialFactory")
+    public SigningCredentialFactory getFactoryForHubSigning(InternalPublicKeyStore internalPublicKeyStore) {
+        return new SigningCredentialFactory(new HubSigningKeyStore(internalPublicKeyStore));
+    }
+
+    @Provides
+    public SamlMessageSignatureValidator getSamlMessageSignatureValidator(@Named("hubSigningCredentialFactory") SigningCredentialFactory signingCredentialFactory) {
+        return new SamlMessageSignatureValidator(new CredentialFactorySignatureValidator(signingCredentialFactory));
     }
 
     @Named("authnRequestSignatureValidator")
@@ -341,12 +366,11 @@ public class SamlProxyModule extends AbstractModule {
         return new SamlMessageSignatureValidator(new CredentialFactorySignatureValidator(signingCredentialFactory));
     }
 
-
     @Named("authnResponseSignatureValidator")
     @Provides
     @Singleton
-    public SamlMessageSignatureValidator getAuthnResponseSignatureValidator(@Named(VERIFY_METADATA_TRUST_ENGINE) ExplicitKeySignatureTrustEngine metadataTrustEngine) {
-        return new SamlMessageSignatureValidator(MetadataBackedSignatureValidator.withoutCertificateChainValidation(metadataTrustEngine));
+    public SamlMessageSignatureValidator getAuthnResponseSignatureValidator(@Named("authnResponsePublicCredentialFactory") SigningCredentialFactory signingCredentialFactory) {
+        return new SamlMessageSignatureValidator(new CredentialFactorySignatureValidator(signingCredentialFactory));
     }
 
     @Provides
@@ -375,6 +399,15 @@ public class SamlProxyModule extends AbstractModule {
     @Provides
     public ServiceInfoConfiguration serviceInfoConfiguration(SamlProxyConfiguration samlProxyConfiguration) {
         return samlProxyConfiguration.getServiceInfo();
+    }
+
+    private void registerMetadataRefreshTask(Environment environment, MetadataResolver metadataResolver, MetadataResolverConfiguration metadataResolverConfiguration, String name) {
+        environment.admin().addTask(new Task(name + "-refresh") {
+            @Override
+            public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
+                ((AbstractReloadingMetadataResolver) metadataResolver).refresh();
+            }
+        });
     }
 
     private void registerEidasMetadataRefreshTask(Environment environment, EidasMetadataResolverRepository eidasMetadataResolverRepository, String name){

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/factories/EidasValidatorFactory.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/factories/EidasValidatorFactory.java
@@ -1,13 +1,17 @@
 package uk.gov.ida.hub.samlproxy.factories;
 
 import com.google.inject.Inject;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.slf4j.event.Level;
+import uk.gov.ida.hub.samlproxy.security.AuthnResponseKeyStore;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.metadata.EidasMetadataResolverRepository;
-import uk.gov.ida.saml.security.MetadataBackedSignatureValidator;
+import uk.gov.ida.saml.metadata.IdpMetadataPublicKeyStore;
+import uk.gov.ida.saml.security.CredentialFactorySignatureValidator;
 import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
+import uk.gov.ida.saml.security.SigningCredentialFactory;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
 
@@ -29,10 +33,12 @@ public class EidasValidatorFactory {
     }
 
     private SamlMessageSignatureValidator getSamlMessageSignatureValidator(String entityId) {
-        return metadataResolverRepository
-                .getSignatureTrustEngine(entityId)
-                .map(MetadataBackedSignatureValidator::withoutCertificateChainValidation)
-                .map(SamlMessageSignatureValidator::new)
+        MetadataResolver metadataResolver = metadataResolverRepository.getMetadataResolver(entityId)
                 .orElseThrow(() -> new SamlTransformationErrorException(format("Unable to find metadata resolver for entity Id {0}", entityId), Level.ERROR));
+        return new SamlMessageSignatureValidator(
+                new CredentialFactorySignatureValidator(
+                        new SigningCredentialFactory(
+                                new AuthnResponseKeyStore(
+                                        new IdpMetadataPublicKeyStore(metadataResolver)))));
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/security/AuthnResponseKeyStore.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/security/AuthnResponseKeyStore.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.hub.samlproxy.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.saml.metadata.IdpMetadataPublicKeyStore;
+import uk.gov.ida.saml.security.SigningKeyStore;
+
+import javax.inject.Inject;
+import java.security.PublicKey;
+import java.util.List;
+
+public class AuthnResponseKeyStore implements SigningKeyStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuthnResponseKeyStore.class);
+    private final IdpMetadataPublicKeyStore idpMetadataPublicKeyStore;
+
+    @Inject
+    public AuthnResponseKeyStore(IdpMetadataPublicKeyStore idpMetadataPublicKeyStore) {
+        this.idpMetadataPublicKeyStore = idpMetadataPublicKeyStore;
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity(String entityId) {
+        LOG.info("Requesting signature verifying key for {} from federation", entityId);
+        return idpMetadataPublicKeyStore.getVerifyingKeysForEntity(entityId);
+    }
+}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/security/HubSigningKeyStore.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/security/HubSigningKeyStore.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.hub.samlproxy.security;
+
+import uk.gov.ida.saml.core.InternalPublicKeyStore;
+import uk.gov.ida.saml.metadata.exceptions.NoKeyConfiguredForEntityException;
+import uk.gov.ida.saml.security.SigningKeyStore;
+
+import java.security.PublicKey;
+import java.util.List;
+
+public class HubSigningKeyStore implements SigningKeyStore {
+
+    private final InternalPublicKeyStore internalPublicKeyStore;
+
+    public HubSigningKeyStore(InternalPublicKeyStore internalPublicKeyStore) {
+        this.internalPublicKeyStore = internalPublicKeyStore;
+    }
+
+    @Override
+    public List<PublicKey> getVerifyingKeysForEntity(String entityId) {
+        final List<PublicKey> verifyingKeysForEntity = internalPublicKeyStore.getVerifyingKeysForEntity();
+        if (!verifyingKeysForEntity.isEmpty()) {
+            return verifyingKeysForEntity;
+        }
+        throw new NoKeyConfiguredForEntityException(entityId);
+    }
+}

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -7,11 +7,27 @@ server:
       port: ${SAML_PROXY_ADMIN_PORT:-50221}
   requestLog:
     appenders:
+      - type: file
+        currentLogFilename: apps-home/saml-proxy.log
+        archivedLogFilenamePattern: apps-home/saml-proxy.log.%d.gz
+        logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
+      - type: logstash-file
+        currentLogFilename: apps-home/logstash/saml-proxy.log
+        archivedLogFilenamePattern: apps-home/logstash/saml-proxy.log.%d.gz
+        archivedFileCount: 7
       - type: console
 
 logging:
-  level: INFO
+  level: DEBUG
   appenders:
+    - type: file
+      currentLogFilename: apps-home/saml-proxy.log
+      archivedLogFilenamePattern: apps-home/saml-proxy.log.%d.gz
+      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %m%n%xEx'
+    - type: logstash-file
+      currentLogFilename: apps-home/logstash/saml-proxy.log
+      archivedLogFilenamePattern: apps-home/logstash/saml-proxy.log.%d.gz
+      archivedFileCount: 7
     - type: console
 
 


### PR DESCRIPTION
Reverts alphagov/verify-hub#48

This is causing some issues on joint and locally as the new code isn't able to find the Hub's eIDAS entity ID from the the normal federation metadata, which it needs to resolve the Hub's signing certificates. The previous code hardcoded the entity ID for lookup on the federation metadata.