### PR TITLE
BAU: Let puppet set memory allocations

### DIFF
--- a/debian/config/upstart/config
+++ b/debian/config/upstart/config
@@ -38,16 +38,16 @@ script
   fi
 
   export JAVA_OPTS="-Dservice.name=config \
-                        -XX:HeapDumpPath=/var/log/ida/debug \
-                        -XX:+HeapDumpOnOutOfMemoryError \
-                        -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
-                        -Dnetworkaddress.cache.ttl=5
-                        -Dnetworkaddress.cache.negative.ttl=5"
+                      -XX:HeapDumpPath=/var/log/ida/debug \
+                      -XX:+HeapDumpOnOutOfMemoryError \
+                      -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
+                      -Dnetworkaddress.cache.ttl=5 \
+                      -Dnetworkaddress.cache.negative.ttl=5 \
+                      $EXTRA_JAVA_OPTS"
 
   # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
   unset JAVA_HOME

--- a/debian/policy/upstart/policy
+++ b/debian/policy/upstart/policy
@@ -37,16 +37,16 @@ script
   fi
 
   export JAVA_OPTS="-Dservice.name=policy \
-                        -XX:HeapDumpPath=/var/log/ida/debug \
-                        -XX:+HeapDumpOnOutOfMemoryError \
-                        -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
-                        -Dnetworkaddress.cache.ttl=5
-                        -Dnetworkaddress.cache.negative.ttl=5"
+                      -XX:HeapDumpPath=/var/log/ida/debug \
+                      -XX:+HeapDumpOnOutOfMemoryError \
+                      -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
+                      -Dnetworkaddress.cache.ttl=5 \
+                      -Dnetworkaddress.cache.negative.ttl=5 \
+                      $EXTRA_JAVA_OPTS"
 
   # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
   unset JAVA_HOME

--- a/debian/saml-engine/upstart/saml-engine
+++ b/debian/saml-engine/upstart/saml-engine
@@ -34,16 +34,16 @@ script
   fi
 
   export JAVA_OPTS="-Dservice.name=saml-engine \
-                        -XX:HeapDumpPath=/var/log/ida/debug \
-                        -XX:+HeapDumpOnOutOfMemoryError \
-                        -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
-                        -Dnetworkaddress.cache.ttl=5
-                        -Dnetworkaddress.cache.negative.ttl=5"
+                      -XX:HeapDumpPath=/var/log/ida/debug \
+                      -XX:+HeapDumpOnOutOfMemoryError \
+                      -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
+                      -Dnetworkaddress.cache.ttl=5 \
+                      -Dnetworkaddress.cache.negative.ttl=5 \
+                      $EXTRA_JAVA_OPTS"
 
   # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
   unset JAVA_HOME

--- a/debian/saml-proxy/upstart/saml-proxy
+++ b/debian/saml-proxy/upstart/saml-proxy
@@ -37,16 +37,16 @@ script
   fi
 
   export JAVA_OPTS="-Dservice.name=saml-proxy \
-                        -XX:HeapDumpPath=/var/log/ida/debug \
-                        -XX:+HeapDumpOnOutOfMemoryError \
-                        -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
-                        -Dnetworkaddress.cache.ttl=5
-                        -Dnetworkaddress.cache.negative.ttl=5"
+                      -XX:HeapDumpPath=/var/log/ida/debug \
+                      -XX:+HeapDumpOnOutOfMemoryError \
+                      -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
+                      -Dnetworkaddress.cache.ttl=5 \
+                      -Dnetworkaddress.cache.negative.ttl=5 \
+                      $EXTRA_JAVA_OPTS"
 
   # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
   unset JAVA_HOME

--- a/debian/saml-soap-proxy/upstart/saml-soap-proxy
+++ b/debian/saml-soap-proxy/upstart/saml-soap-proxy
@@ -37,16 +37,16 @@ script
   fi
 
   export JAVA_OPTS="-Dservice.name=saml-soap-proxy \
-                        -XX:HeapDumpPath=/var/log/ida/debug \
-                        -XX:+HeapDumpOnOutOfMemoryError \
-                        -Xms256m -Xmx256m \
-                        -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
-                        -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
-                        -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
-                        -Dnetworkaddress.cache.ttl=5
-                        -Dnetworkaddress.cache.negative.ttl=5"
+                      -XX:HeapDumpPath=/var/log/ida/debug \
+                      -XX:+HeapDumpOnOutOfMemoryError \
+                      -Dhttp.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttp.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttps.proxyHost=\"${PROXY_HOST:-}\" \
+                      -Dhttps.proxyPort=\"${PROXY_PORT:-}\" \
+                      -Dhttp.nonProxyHosts=\"${NON_PROXY_HOSTS:-}\" \
+                      -Dnetworkaddress.cache.ttl=5 \
+                      -Dnetworkaddress.cache.negative.ttl=5 \
+                      $EXTRA_JAVA_OPTS"
 
   # JAVA_HOME is set wrong, but the `java` on the path is correct - unsetting this uses /usr/bin/java
   unset JAVA_HOME


### PR DESCRIPTION
- I mistakenly made all the memory allocations for the apps the same
- This puts the allocations into an env var so that puppet can set it as
  it used to when it layed down the upstart files