### PR TITLE
BAU: Update to use ObjectMapper provided by DropWizard

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
@@ -1,12 +1,12 @@
 package uk.gov.ida.hub.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import io.dropwizard.configuration.ConfigurationFactoryFactory;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
+import io.dropwizard.setup.Environment;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.OCSPCertificateChainValidator;
@@ -43,6 +43,7 @@ import uk.gov.ida.truststore.KeyStoreLoader;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 public class ConfigModule extends AbstractModule {
 
@@ -73,7 +74,6 @@ public class ConfigModule extends AbstractModule {
         bind(new TypeLiteral<ConfigEntityDataRepository<CountriesConfigEntityData>>(){}).asEagerSingleton();
         bind(new TypeLiteral<ConfigEntityDataRepository<MatchingServiceConfigEntityData>>(){}).asEagerSingleton();
         bind(new TypeLiteral<ConfigEntityDataRepository<IdentityProviderConfigEntityData>>(){}).asEagerSingleton();
-        bind(ObjectMapper.class).toInstance(new ObjectMapper().registerModule(new GuavaModule()));
         bind(LevelsOfAssuranceConfigValidator.class).toInstance(new LevelsOfAssuranceConfigValidator());
         bind(CertificateChainValidator.class);
         bind(TrustStoreForCertificateProvider.class);
@@ -89,6 +89,13 @@ public class ConfigModule extends AbstractModule {
         bind(PKIXParametersProvider.class).toInstance(new PKIXParametersProvider());
         bind(CertificateService.class);
         bind(MatchingServiceAdapterService.class);
+    }
+
+    @Provides
+    @Singleton
+    @SuppressWarnings("unused")
+    private ObjectMapper getObjectMapper(Environment environment) {
+        return environment.getObjectMapper();
     }
 
     @Provides

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -65,7 +65,6 @@ public class PolicyModule extends AbstractModule {
         bind(KeyStoreLoader.class).toInstance(new KeyStoreLoader());
         bind(InfinispanStartupTasks.class).asEagerSingleton();
         bind(JsonResponseProcessor.class);
-        bind(ObjectMapper.class).toInstance(new ObjectMapper());
         bind(EventSinkProxy.class).to(EventSinkHttpProxy.class);
         bind(HubEventLogger.class);
         bind(SessionService.class);
@@ -88,6 +87,13 @@ public class PolicyModule extends AbstractModule {
         bind(Cycle3Service.class);
         bind(MatchingServiceResponseService.class);
         bind(ResponseFromIdpHandler.class);
+    }
+
+    @Provides
+    @Singleton
+    @SuppressWarnings("unused")
+    private ObjectMapper getObjectMapper(Environment environment) {
+        return environment.getObjectMapper();
     }
 
     @Provides

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -99,7 +99,13 @@ import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappings
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer;
-import uk.gov.ida.saml.hub.transformers.outbound.*;
+import uk.gov.ida.saml.hub.transformers.outbound.AssertionFromIdpToAssertionTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunctionSHA256;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunctionSHA256;
+import uk.gov.ida.saml.hub.transformers.outbound.SimpleProfileOutboundResponseFromHubToSamlResponseTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.SimpleProfileTransactionIdaStatusMarshaller;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.ResponseToUnsignedStringTransformer;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.SimpleProfileOutboundResponseFromHubToResponseTransformerProvider;
 import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestIdKey;
@@ -172,7 +178,6 @@ public class SamlEngineModule extends AbstractModule {
         bind(RpErrorResponseGeneratorService.class);
         bind(TransactionsConfigProxy.class);
         bind(MatchingServiceHealthcheckRequestGeneratorService.class);
-        bind(ObjectMapper.class).toInstance(new ObjectMapper());
         bind(ExpiredCertificateMetadataFilter.class).toInstance(new ExpiredCertificateMetadataFilter());
         bind(new TypeLiteral<LevelLoggerFactory<SamlEngineExceptionMapper>>() {})
             .toInstance(new LevelLoggerFactory<>());
@@ -193,6 +198,13 @@ public class SamlEngineModule extends AbstractModule {
         bind(IdaAuthnRequestTranslator.class);
         bind(EidasAuthnRequestTranslator.class);
         bind(MatchingServiceHealthcheckResponseTranslatorService.class);
+    }
+
+    @Provides
+    @Singleton
+    @SuppressWarnings("unused")
+    private ObjectMapper getObjectMapper(Environment environment) {
+        return environment.getObjectMapper();
     }
 
     @Provides

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -121,7 +121,6 @@ public class SamlProxyModule extends AbstractModule {
         bind(TrustStoreForCertificateProvider.class);
         bind(StringSizeValidator.class).toInstance(new StringSizeValidator());
         bind(JsonResponseProcessor.class);
-        bind(ObjectMapper.class).toInstance(new ObjectMapper());
         bind(PKIXParametersProvider.class).toInstance(new PKIXParametersProvider());
         bind(RelayStateValidator.class).toInstance(new RelayStateValidator());
         bind(ProtectiveMonitoringLogFormatter.class).toInstance(new ProtectiveMonitoringLogFormatter());
@@ -137,6 +136,13 @@ public class SamlProxyModule extends AbstractModule {
         bind(SamlMessageSenderHandler.class);
         bind(ExternalCommunicationEventLogger.class);
         bind(IpAddressResolver.class).toInstance(new IpAddressResolver());
+    }
+
+    @Provides
+    @Singleton
+    @SuppressWarnings("unused")
+    private ObjectMapper getObjectMapper(Environment environment) {
+        return environment.getObjectMapper();
     }
 
     @Provides

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -81,7 +81,6 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.cert.CertificateException;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
@@ -110,7 +109,6 @@ public class SamlSoapProxyModule extends AbstractModule {
         bind(UrlConfigurationSourceProvider.class).toInstance(new UrlConfigurationSourceProvider());
         bind(TrustStoreForCertificateProvider.class);
         bind(JsonResponseProcessor.class);
-        bind(ObjectMapper.class).toInstance(new ObjectMapper());
         bind(X509CertificateFactory.class).toInstance(new X509CertificateFactory());
         bind(CertificateChainValidator.class);
         bind(CertificatesConfigProxy.class);
@@ -135,6 +133,13 @@ public class SamlSoapProxyModule extends AbstractModule {
         bind(IpAddressResolver.class).toInstance(new IpAddressResolver());
         bind(TimeoutEvaluator.class).toInstance(new TimeoutEvaluator());
         bind(MetadataHealthCheckRegistry.class).asEagerSingleton();
+    }
+
+    @Provides
+    @Singleton
+    @SuppressWarnings("unused")
+    private ObjectMapper getObjectMapper(Environment environment) {
+        return environment.getObjectMapper();
     }
 
     @Provides


### PR DESCRIPTION
Modules classes create a new instance of ObjectMapper that is not same as the instance of ObjectMapper provided by DropWizard. This results in logging timestamp not following the ISO8601DateFormat. The fix is to get Modules classes to use the existing ObjectMapper provided by the DropWizard instead of a new instance of ObjectMapper. This will allow applications to log timestamp in the ISO8601DateFormat.

I ran pre-commit and hub acceptance test. They passed.

Authors: @adityapahuja