### PR TITLE
EID-951: Add CountryAuthenticationStatus enum and unmarshaller

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/CountryAuthenticationStatus.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/CountryAuthenticationStatus.java
@@ -1,0 +1,72 @@
+package uk.gov.ida.saml.hub.domain;
+
+import uk.gov.ida.saml.core.domain.IdaStatus;
+
+import java.util.Optional;
+
+public final class CountryAuthenticationStatus implements IdaStatus {
+
+    public enum Status {
+        Success,
+        Failure
+    }
+
+    private Status status;
+    private String message;
+
+    public static CountryAuthenticationStatus success() { return new CountryAuthenticationStatus(Status.Success);}
+    public static CountryAuthenticationStatus failure() { return new CountryAuthenticationStatus(Status.Failure);}
+
+    private CountryAuthenticationStatus(Status status) {
+        this(status, null);
+    }
+
+    private CountryAuthenticationStatus(Status status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Status getStatusCode() {
+        return status;
+    }
+
+    public Optional<String> getMessage() {
+        return Optional.ofNullable(message);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CountryAuthenticationStatus countryAuthenticationStatus = (CountryAuthenticationStatus) o;
+
+        return status == countryAuthenticationStatus.status;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = status.hashCode();
+        result = 31 * result;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CountryAuthenticationStatus{" +
+            "status=" + getStatusCode() +
+            ", message=" + getMessage() +
+            '}';
+    }
+
+    public static class CountryAuthenticationStatusFactory {
+        public static CountryAuthenticationStatus create(final CountryAuthenticationStatus.Status statusCode, final String message) {
+
+            if (!statusCode.equals(Status.Failure)) {
+                return new CountryAuthenticationStatus(statusCode);
+            }
+
+            return new CountryAuthenticationStatus(statusCode, message);
+        }
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshaller.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusMessage;
+import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus;
+import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus.CountryAuthenticationStatusFactory;
+
+import java.util.Optional;
+
+public class CountryAuthenticationStatusUnmarshaller {
+
+    private CountryAuthenticationStatusUnmarshaller() { }
+
+    public static CountryAuthenticationStatus fromSaml(final Status samlStatus) {
+        final CountryAuthenticationStatus.Status status = getStatus(samlStatus);
+        final String message = getStatusMessage(samlStatus).orElse(null);
+        return CountryAuthenticationStatusFactory.create(status, message);
+    }
+
+    private static CountryAuthenticationStatus.Status getStatus(final Status samlStatus) {
+        return SamlStatusToCountryAuthenticationStatusCodeMapper.map(samlStatus);
+    }
+
+    private static Optional<String> getStatusMessage(final Status samlStatus) {
+        final StatusMessage statusMessage = samlStatus.getStatusMessage();
+        return statusMessage != null ? Optional.of(statusMessage.getMessage()) : Optional.empty();
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusCodeMapper.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableMap;
+import org.opensaml.saml.saml2.core.Status;
+import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticationStatusMappingsFactory.SamlStatusDefinitions;
+
+public class SamlStatusToCountryAuthenticationStatusCodeMapper {
+
+    private static final ImmutableMap<SamlStatusDefinitions, CountryAuthenticationStatus.Status> STATUS_MAPPINGS =
+            SamlStatusToCountryAuthenticationStatusMappingsFactory.getSamlToCountryAuthenticationStatusMappings();
+
+    public static CountryAuthenticationStatus.Status map(Status samlStatus) {
+        final String statusCodeValue = getStatusCodeValue(samlStatus);
+
+        return STATUS_MAPPINGS.keySet().stream()
+                .filter(k -> k.matches(statusCodeValue))
+                .findFirst()
+                .map(STATUS_MAPPINGS::get)
+                .orElse(CountryAuthenticationStatus.Status.Failure);
+    }
+
+    private static String getStatusCodeValue(final Status status) {
+        return status.getStatusCode().getValue();
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusMappingsFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusMappingsFactory.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import com.google.common.collect.ImmutableMap;
+import uk.gov.ida.saml.core.domain.DetailedStatusCode;
+import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus;
+
+public class SamlStatusToCountryAuthenticationStatusMappingsFactory {
+    enum SamlStatusDefinitions {
+        Success(DetailedStatusCode.Success);
+
+        private final DetailedStatusCode statusCode;
+
+        SamlStatusDefinitions(DetailedStatusCode statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        public boolean matches(String samlStatusValue) {
+            return statusCode.getStatus().equals(samlStatusValue);
+        }
+    }
+
+    public static ImmutableMap<SamlStatusDefinitions, CountryAuthenticationStatus.Status> getSamlToCountryAuthenticationStatusMappings() {
+        // Matching SAML statuses to their CountryAuthenticationStatus counterparts is dependent on the ordering of these put()
+        // statements. There must be a better way of doing this.
+        return ImmutableMap.<SamlStatusDefinitions, CountryAuthenticationStatus.Status>builder()
+                .put(SamlStatusDefinitions.Success, CountryAuthenticationStatus.Status.Success)
+                .build();
+    }
+}

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshallerTest.java
@@ -1,0 +1,263 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.StatusMessage;
+import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
+import uk.gov.ida.saml.core.api.CoreTransformersFactory;
+import uk.gov.ida.saml.core.test.OpenSAMLRunner;
+import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
+import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
+import static uk.gov.ida.saml.core.test.builders.StatusMessageBuilder.aStatusMessage;
+
+@RunWith(OpenSAMLRunner.class)
+public class CountryAuthenticationStatusUnmarshallerTest {
+
+    private OpenSamlXmlObjectFactory samlObjectFactory;
+    private StringToOpenSamlObjectTransformer<Response> stringToOpenSamlObjectTransformer;
+
+    @Before
+    public void setUp() throws Exception {
+        samlObjectFactory = new OpenSamlXmlObjectFactory();
+        stringToOpenSamlObjectTransformer = new CoreTransformersFactory().getStringtoOpenSamlObjectTransformer(input -> {});
+    }
+
+    @Test
+    public void shouldTransformSuccessWithNoSubCode() {
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode successStatusCode = samlObjectFactory.createStatusCode();
+        successStatusCode.setValue(StatusCode.SUCCESS);
+        originalStatus.setStatusCode(successStatusCode);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.success());
+    }
+
+    @Test
+    public void shouldTransformSuccessWithMessage() {
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode successStatusCode = samlObjectFactory.createStatusCode();
+        successStatusCode.setValue(StatusCode.SUCCESS);
+        StatusMessage statusMessage = samlObjectFactory.createStatusMessage();
+        statusMessage.setMessage(StatusCode.SUCCESS);
+        originalStatus.setStatusCode(successStatusCode);
+        originalStatus.setStatusMessage(statusMessage);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.success());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldTransformNoAuthenticationContext() {
+        Status originalStatus = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.NO_AUTHN_CONTEXT);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+        originalStatus.setStatusCode(topLevelStatusCode);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+    }
+
+    @Test
+    public void shouldTransformAuthnFailed() {
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        status.setStatusCode(topLevelStatusCode);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.AUTHN_FAILED);
+        topLevelStatusCode.setStatusCode(subStatusCode);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+    }
+
+    @Test
+    public void shouldTransformAuthnFailedWithoutSubstatus() {
+        String message = "error detail";
+        StatusCode topLevelStatusCode = aStatusCode().withValue(StatusCode.AUTHN_FAILED).build();
+        Status status = aStatus()
+                .withStatusCode(topLevelStatusCode)
+                .withMessage(aStatusMessage().withMessage(message).build())
+                .build();
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
+        assertThat(transformedStatus.getMessage().get()).isEqualTo(message);
+    }
+
+    @Test
+    public void shouldTransformRequestDeniedWithoutSubstatus() {
+        String message = "error detail";
+        StatusCode topLevelStatusCode = aStatusCode().withValue(StatusCode.REQUEST_DENIED).build();
+        Status status = aStatus()
+                .withStatusCode(topLevelStatusCode)
+                .withMessage(aStatusMessage().withMessage(message).build())
+                .build();
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
+        assertThat(transformedStatus.getMessage().get()).isEqualTo(message);
+    }
+
+    @Test
+    public void shouldTransformRequesterErrorWithoutMessage() {
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.REQUESTER);
+        status.setStatusCode(topLevelStatusCode);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldTransformRequesterErrorWithMessage() {
+        String message = "some message";
+
+        StatusCode topLevelStatusCode = aStatusCode().withValue(StatusCode.REQUESTER).build();
+        Status status = aStatus()
+                .withStatusCode(topLevelStatusCode)
+                .withMessage(aStatusMessage().withMessage(message).build())
+                .build();
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
+        assertThat(transformedStatus.getMessage().get()).isEqualTo(message);
+    }
+
+    @Test
+    public void shouldTransformRequesterErrorWithRequestDeniedSubstatus() {
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.REQUESTER);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue(StatusCode.REQUEST_DENIED);
+        status.setStatusCode(topLevelStatusCode);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+    }
+
+    @Test
+    public void shouldTransformResponderErrorWithoutMessage() {
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        status.setStatusCode(topLevelStatusCode);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldTransformResponderErrorWithMessage() {
+        String message = "some message";
+
+        StatusCode topLevelStatusCode = aStatusCode().withValue(StatusCode.RESPONDER).build();
+        Status status = aStatus()
+                .withStatusCode(topLevelStatusCode)
+                .withMessage(aStatusMessage().withMessage(message).build())
+                .build();
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+        assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
+        assertThat(transformedStatus.getMessage().get()).isEqualTo(message);
+    }
+
+    @Test
+    public void shouldTransformResponderErrorWithCanceledSubstatus() {
+        Status status = samlObjectFactory.createStatus();
+        StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
+        topLevelStatusCode.setValue(StatusCode.RESPONDER);
+        StatusCode subStatusCode = samlObjectFactory.createStatusCode();
+        subStatusCode.setValue("Canceled");
+        status.setStatusCode(topLevelStatusCode);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
+    }
+
+    @Test
+    public void shouldMapSamlStatusDetailOfAuthnCancelToAuthenticationCancelled() throws Exception {
+        String cancelXml = readXmlFile("status-cancel.xml");
+        Response cancelResponse = stringToOpenSamlObjectTransformer.apply(cancelXml);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
+
+        assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Failure);
+    }
+
+    @Test
+    public void shouldMapSamlStatusDetailOfLoaPendingToAuthenticationPending() throws Exception {
+        String pendingXml = readXmlFile("status-pending.xml");
+        Response pendingResponse = stringToOpenSamlObjectTransformer.apply(pendingXml);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(pendingResponse.getStatus());
+
+        assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Failure);
+    }
+
+    @Test
+    public void shouldRemainSuccessEvenIfStatusDetailCancelReturned() throws Exception {
+        String successWithCancelXml = readXmlFile("status-success-with-cancel.xml");
+        Response cancelResponse = stringToOpenSamlObjectTransformer.apply(successWithCancelXml);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
+
+        assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Success);
+    }
+
+    @Test
+    public void shouldRemainNoAuthnContextIfStatusDetailAbsent() throws Exception {
+        String successWithCancelXml = readXmlFile("status-noauthncontext.xml");
+        Response cancelResponse = stringToOpenSamlObjectTransformer.apply(successWithCancelXml);
+
+        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
+
+        assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Failure);
+    }
+
+    private String readXmlFile(String xmlFile) throws IOException, URISyntaxException {
+        Base64.Encoder encoder = Base64.getEncoder();
+        URL resource = getClass().getClassLoader().getResource(xmlFile);
+        return new String(encoder.encode(Files.readAllBytes(Paths.get(resource.toURI()))));
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/CountryAuthenticationStatus.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/CountryAuthenticationStatus.java
@@ -1,0 +1,66 @@
+package uk.gov.ida.hub.policy.domain;
+
+import java.util.Optional;
+
+public final class CountryAuthenticationStatus {
+
+    public enum Status {
+        Success,
+        Failure
+    }
+
+    private Status status;
+    private String message = null;
+
+    public static CountryAuthenticationStatus success() { return new CountryAuthenticationStatus(Status.Success);}
+
+    @SuppressWarnings("unused") // needed for JAXB
+    private CountryAuthenticationStatus() {
+    }
+
+    private CountryAuthenticationStatus(Status status) {
+        this(status, null);
+    }
+
+    private CountryAuthenticationStatus(Status status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Status getStatusCode() {
+        return status;
+    }
+
+    public Optional<String> getMessage() {
+        return Optional.ofNullable(message);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CountryAuthenticationStatus countryAuthenticationStatus = (CountryAuthenticationStatus) o;
+
+        return status == countryAuthenticationStatus.status;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = status.hashCode();
+        result = 31 * result;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "IdpIdaStatus{" +
+                "status=" + status +
+                ", message=" + message +
+                '}';
+    }
+}


### PR DESCRIPTION
Add the new CountryAuthenticationStatus enum and unmarshaller so we can handle authn responses specific to eIDAS and Countries.

Currently, we're re-using IdpIdaStatus enum to handle authn responses from Countries. This enum is not well-fitted for eIDAS, though, because the SAML responses from IDPs and Countries and their properties vary significantly for any journey that's not a success. The Country status definitions will allow us to handle eIDAS-specific responses better and customise them without affecting the Verify flow.

At the moment, we're only interested in mapping all the authn responses from Countries to either of the two outcomes - Success or Failure (defined in the `CountryAuthenticationStatus` enum). If in the future we need to get more granular, we can easily add more definitions and mappings to the enum, mapper and the mappings factory.

The mapping logic to map a SAML state a CountryAuthenticationState is defined in `AuthenticationStatusCodeMapper`. It simply verifies that the SAML status code matches of one of the enums values. We disregard any other properties such as sub-status codes or status detail values. We're only really interested in the top level status and whether its code is 'Success' or something else, in which case it will get mapped to 'Failure.' Again, this can be easily extended in the future if need be.

We also need a mirror definition of `CountryAuthenticationStatus` on the receiving end in Policy so it's aware of and can handle the new status codes.