### PR TITLE
EID-951: Allow Country non-successful auth responses to contain unencrypted assertions

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidator.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidator.java
@@ -16,12 +16,13 @@ public class ResponseFromCountryValidator extends EncryptedResponseFromIdpValida
     }
 
     protected void validateAssertionPresence(Response response) {
-        if (!response.getAssertions().isEmpty()) {
+        boolean responseWasSuccessful = response.getStatus().getStatusCode().getValue().equals(StatusCode.SUCCESS);
+
+        if (responseWasSuccessful && !response.getAssertions().isEmpty()) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.unencryptedAssertion();
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
 
-        boolean responseWasSuccessful = response.getStatus().getStatusCode().getValue().equals(StatusCode.SUCCESS);
         if (responseWasSuccessful && response.getEncryptedAssertions().isEmpty()) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.missingSuccessUnEncryptedAssertions();
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
@@ -36,6 +37,5 @@ public class ResponseFromCountryValidator extends EncryptedResponseFromIdpValida
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.unexpectedNumberOfAssertions(1, response.getEncryptedAssertions().size());
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
-
     }
 }

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
@@ -40,15 +40,15 @@ public class ResponseFromCountryValidatorTest {
     private ResponseFromCountryValidator validator = new ResponseFromCountryValidator(new SamlStatusToIdpIdaStatusMappingsFactory());
 
     @Before
-    public void setup() {
+    public void setUp() {
         when(response.getStatus()).thenReturn(status);
         when(status.getStatusCode()).thenReturn(statusCode);
         when(statusCode.getValue()).thenReturn(StatusCode.SUCCESS);
         when(response.getAssertions()).thenReturn(Collections.emptyList());
     }
 
-    @Test()
-    public void shouldThrowIfResponseHasUnencryptedAssertions() {
+    @Test
+    public void shouldThrowIfResponseIsSuccessfulAndHasUnencryptedAssertions() {
         exception.expect(SamlTransformationErrorException.class);
         exception.expectMessage("Response has unencrypted assertion.");
         when(response.getAssertions()).thenReturn(ImmutableList.of(assertion));
@@ -56,7 +56,15 @@ public class ResponseFromCountryValidatorTest {
         validator.validateAssertionPresence(response);
     }
 
-    @Test()
+    @Test
+    public void shouldNotThrowIfResponseIsNotSuccessfulAndHasUnencryptedAssertions() {
+        when(statusCode.getValue()).thenReturn(StatusCode.AUTHN_FAILED);
+        when(response.getAssertions()).thenReturn(ImmutableList.of(assertion));
+
+        validator.validateAssertionPresence(response);
+    }
+
+    @Test
     public void shouldThrowIfResponseIsSuccessfulButHasNoEncryptedAssertions() {
         exception.expect(SamlTransformationErrorException.class);
         exception.expectMessage("Success response has no unencrypted assertions.");
@@ -75,7 +83,7 @@ public class ResponseFromCountryValidatorTest {
         validator.validateAssertionPresence(response);
     }
 
-    @Test()
+    @Test
     public void shouldThrowIfResponseIsSuccessfulButHasMultipleEncryptedAssertions() {
         exception.expect(SamlTransformationErrorException.class);
         exception.expectMessage("Response expected to contain 1 assertions. 2 assertion(s) found.");
@@ -83,5 +91,4 @@ public class ResponseFromCountryValidatorTest {
 
         validator.validateAssertionPresence(response);
     }
-
 }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="PMD rules to exclude"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        Defines rules to exclude from the PMD code analyser used by Codacy
+    </description>
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="JUnitTestsShouldIncludeAssert"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Make `ResponseFromCountryValidator` allow non-successful auth responses from Countries to contain unencrypted assertions.

In the eIDAS world, authn responses are allowed to have unencrypted assertions if they don't have the "Success" status. Some countries include such assertions in their Cancel responses but currently ResponseFromCountryValidator throws and exception and we can't handle this type of failure in a graceful manner, so the users see the "Service unavailable" error page. If we allow these to pass, then the users will see the new error page with a better message and a link to retry the journey.

Some of the countries that send such responses are Germany and any country that uses the CEF Reference Node (e.g. Belgium and Estonia).