### PR TITLE
EID-951: Use CountryAuthenticationStatus when handling authn responses from Countries

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
@@ -19,9 +19,9 @@ import uk.gov.ida.hub.policy.contracts.AttributeQueryContainerDto;
 import uk.gov.ida.hub.policy.contracts.InboundResponseFromMatchingServiceDto;
 import uk.gov.ida.hub.policy.contracts.SamlResponseDto;
 import uk.gov.ida.hub.policy.contracts.SamlResponseWithAuthnRequestInformationDto;
+import uk.gov.ida.hub.policy.domain.CountryAuthenticationStatus;
 import uk.gov.ida.hub.policy.domain.Cycle3UserInput;
 import uk.gov.ida.hub.policy.domain.EidasCountryDto;
-import uk.gov.ida.hub.policy.domain.IdpIdaStatus;
 import uk.gov.ida.hub.policy.domain.InboundResponseFromCountry;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.MatchingServiceIdaStatus;
@@ -391,7 +391,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
 
     private void stubSamlEngineTranslationLOAForCountry(final LevelOfAssurance loa, final EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        InboundResponseFromCountry translationDto = new InboundResponseFromCountry(IdpIdaStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa));
+        InboundResponseFromCountry translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa));
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
@@ -14,8 +14,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.hub.policy.Urls;
 import uk.gov.ida.hub.policy.contracts.AttributeQueryContainerDto;
+import uk.gov.ida.hub.policy.domain.CountryAuthenticationStatus;
 import uk.gov.ida.hub.policy.domain.EidasCountryDto;
-import uk.gov.ida.hub.policy.domain.IdpIdaStatus;
 import uk.gov.ida.hub.policy.domain.InboundResponseFromCountry;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.ResponseAction;
@@ -38,7 +38,6 @@ import java.util.Arrays;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static uk.gov.ida.hub.policy.domain.ResponseAction.IdpResult.OTHER;
 import static uk.gov.ida.integrationtest.hub.policy.apprule.support.TestSessionResource.COUNTRY_SELECTED_STATE;
 import static uk.gov.ida.integrationtest.hub.policy.builders.SamlAuthnResponseContainerDtoBuilder.aSamlAuthnResponseContainerDto;
@@ -200,13 +199,13 @@ public class EidasSessionResourceIntegrationTest {
 
     private void stubSamlEngineTranslationLOAForCountry(LevelOfAssurance loa, EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        translationDto = new InboundResponseFromCountry(IdpIdaStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa));
+        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa));
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 
     private void stubSamlEngineTranslationToFailForCountry(EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        translationDto = new InboundResponseFromCountry(IdpIdaStatus.Status.RequesterError, Optional.absent(), country.getEntityId(), Optional.absent(), Optional.absent(), Optional.absent());
+        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Failure, Optional.absent(), country.getEntityId(), Optional.absent(), Optional.absent(), Optional.absent());
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromCountry.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromCountry.java
@@ -6,14 +6,14 @@ import com.google.common.base.Optional;
 // This annotation is required for ZDD where we may add fields to newer versions of this DTO
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InboundResponseFromCountry {
-    private IdpIdaStatus.Status status;
+    private CountryAuthenticationStatus.Status status;
     private String issuer;
     private Optional<String> persistentId;
     private Optional<String> statusMessage;
     private Optional<String> encryptedIdentityAssertionBlob;
     private Optional<LevelOfAssurance> levelOfAssurance;
 
-    public InboundResponseFromCountry(IdpIdaStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedIdentityAssertionBlob, Optional<String> persistentId, Optional<LevelOfAssurance> levelOfAssurance) {
+    public InboundResponseFromCountry(CountryAuthenticationStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedIdentityAssertionBlob, Optional<String> persistentId, Optional<LevelOfAssurance> levelOfAssurance) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.issuer = issuer;
@@ -25,7 +25,7 @@ public class InboundResponseFromCountry {
     protected InboundResponseFromCountry() {
     }
 
-    public IdpIdaStatus.Status getStatus() {
+    public CountryAuthenticationStatus.Status getStatus() {
         return status;
     }
 
@@ -49,4 +49,3 @@ public class InboundResponseFromCountry {
         return encryptedIdentityAssertionBlob;
     }
 }
-

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
@@ -62,7 +62,7 @@ public class AuthnResponseFromCountryService {
             case Success:
                 responseAction = handleSuccessResponse(translatedResponse, responseFromCountry, sessionId, stateController);
                 break;
-            case AuthenticationFailed:
+            case Failure:
                 responseAction = handleAuthenticationFailedResponse(responseFromCountry, sessionId, stateController);
                 break;
             default:

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/CountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/CountrySelectedStateControllerTest.java
@@ -18,7 +18,7 @@ import uk.gov.ida.common.shared.security.IdGenerator;
 import uk.gov.ida.hub.policy.PolicyConfiguration;
 import uk.gov.ida.hub.policy.contracts.EidasAttributeQueryRequestDto;
 import uk.gov.ida.hub.policy.domain.AssertionRestrictionsFactory;
-import uk.gov.ida.hub.policy.domain.IdpIdaStatus;
+import uk.gov.ida.hub.policy.domain.CountryAuthenticationStatus;
 import uk.gov.ida.hub.policy.domain.InboundResponseFromCountry;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.ResponseFromHub;
@@ -56,7 +56,7 @@ public class CountrySelectedStateControllerTest {
     private static final String SELECTED_COUNTRY = STUB_COUNTRY_ONE;
 
     private static final InboundResponseFromCountry INBOUND_RESPONSE_FROM_COUNTRY  = new InboundResponseFromCountry(
-            IdpIdaStatus.Status.Success,
+            CountryAuthenticationStatus.Status.Success,
             Optional.absent(),
             STUB_COUNTRY_ONE,
             Optional.of(BLOB),
@@ -124,7 +124,7 @@ public class CountrySelectedStateControllerTest {
         exception.expectMessage(String.format("Authn translation for request %s failed with missing mandatory attribute %s", state.getRequestId(), "persistentId"));
 
         final InboundResponseFromCountry inboundResponseFromCountry = new InboundResponseFromCountry(
-                IdpIdaStatus.Status.Success,
+                CountryAuthenticationStatus.Status.Success,
                 Optional.absent(),
                 STUB_COUNTRY_ONE,
                 Optional.of(BLOB),
@@ -140,7 +140,7 @@ public class CountrySelectedStateControllerTest {
         exception.expectMessage(String.format("Authn translation for request %s failed with missing mandatory attribute %s", state.getRequestId(), "encryptedIdentityAssertionBlob"));
 
         final InboundResponseFromCountry inboundResponseFromCountry = new InboundResponseFromCountry(
-                IdpIdaStatus.Status.Success,
+                CountryAuthenticationStatus.Status.Success,
                 Optional.absent(),
                 STUB_COUNTRY_ONE,
                 Optional.absent(),
@@ -156,7 +156,7 @@ public class CountrySelectedStateControllerTest {
         exception.expectMessage("No level of assurance in the response.");
 
         final InboundResponseFromCountry inboundResponseFromCountry = new InboundResponseFromCountry(
-                IdpIdaStatus.Status.Success,
+                CountryAuthenticationStatus.Status.Success,
                 Optional.absent(),
                 STUB_COUNTRY_ONE,
                 Optional.of(BLOB),
@@ -174,7 +174,7 @@ public class CountrySelectedStateControllerTest {
                         LEVEL_1, ImmutableList.of(LEVEL_2)));
 
         final InboundResponseFromCountry inboundResponseFromCountry = new InboundResponseFromCountry(
-                IdpIdaStatus.Status.Success,
+                CountryAuthenticationStatus.Status.Success,
                 Optional.absent(),
                 STUB_IDP_ONE,
                 Optional.of(BLOB),
@@ -210,7 +210,7 @@ public class CountrySelectedStateControllerTest {
         );
 
         InboundResponseFromCountry inboundResponseFromCountry = new InboundResponseFromCountry(
-                IdpIdaStatus.Status.Success,
+                CountryAuthenticationStatus.Status.Success,
                 Optional.absent(),
                 STUB_COUNTRY_ONE,
                 Optional.of(eidasAttributeQueryRequestDto.getEncryptedIdentityAssertion()),

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -99,7 +99,13 @@ import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappings
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer;
-import uk.gov.ida.saml.hub.transformers.outbound.*;
+import uk.gov.ida.saml.hub.transformers.outbound.AssertionFromIdpToAssertionTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundLegacyResponseFromHubToStringFunctionSHA256;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunction;
+import uk.gov.ida.saml.hub.transformers.outbound.OutboundSamlProfileResponseFromHubToStringFunctionSHA256;
+import uk.gov.ida.saml.hub.transformers.outbound.SimpleProfileOutboundResponseFromHubToSamlResponseTransformer;
+import uk.gov.ida.saml.hub.transformers.outbound.SimpleProfileTransactionIdaStatusMarshaller;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.ResponseToUnsignedStringTransformer;
 import uk.gov.ida.saml.hub.transformers.outbound.providers.SimpleProfileOutboundResponseFromHubToResponseTransformerProvider;
 import uk.gov.ida.saml.hub.validators.authnrequest.AuthnRequestIdKey;
@@ -247,7 +253,6 @@ public class SamlEngineModule extends AbstractModule {
     @Provides
     private CountryAuthnResponseTranslatorService getCountryAuthnResponseTranslatorService(StringToOpenSamlObjectTransformer<Response> stringToOpenSamlResponseTransformer,
                                                                                            ResponseFromCountryValidator responseFromCountryValidator,
-                                                                                           IdpIdaStatusUnmarshaller idpIdaStatusUnmarshaller,
                                                                                            @Named("ResponseAssertionsFromCountryValidator") Optional<ResponseAssertionsFromCountryValidator> responseAssertionFromCountryValidator,
                                                                                            Optional<DestinationValidator> validateSamlResponseIssuedByIdpDestination,
                                                                                            @Named("EidasAssertionDecrypter") AssertionDecrypter assertionDecrypter,
@@ -259,7 +264,6 @@ public class SamlEngineModule extends AbstractModule {
         }
         return new CountryAuthnResponseTranslatorService(stringToOpenSamlResponseTransformer,
                 responseFromCountryValidator,
-                idpIdaStatusUnmarshaller,
                 responseAssertionFromCountryValidator.get(),
                 validateSamlResponseIssuedByIdpDestination.get(),
                 assertionDecrypter,

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/resources/translators/CountryAuthnResponseTranslatorResource.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/resources/translators/CountryAuthnResponseTranslatorResource.java
@@ -1,11 +1,10 @@
 package uk.gov.ida.hub.samlengine.resources.translators;
 
 import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.ida.hub.samlengine.Urls;
 import uk.gov.ida.hub.samlengine.contracts.SamlAuthnResponseTranslatorDto;
-import uk.gov.ida.hub.samlengine.services.CountryAuthnResponseTranslatorService;
 import uk.gov.ida.hub.samlengine.domain.InboundResponseFromCountry;
+import uk.gov.ida.hub.samlengine.services.CountryAuthnResponseTranslatorService;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -30,10 +29,9 @@ public class CountryAuthnResponseTranslatorResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
-    public Response translate(@Valid SamlAuthnResponseTranslatorDto samlResponseDto) throws JsonProcessingException {
+    public Response translate(@Valid SamlAuthnResponseTranslatorDto samlResponseDto) {
         InboundResponseFromCountry translated = countryAuthnResponseTranslatorService.translate(samlResponseDto);
 
         return Response.ok().entity(translated).type(MediaType.APPLICATION_JSON_TYPE).build();
     }
 }
-

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorServiceTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorServiceTest.java
@@ -20,10 +20,7 @@ import uk.gov.ida.saml.core.transformers.outbound.decorators.AssertionBlobEncryp
 import uk.gov.ida.saml.core.validators.DestinationValidator;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
-import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
-import uk.gov.ida.saml.hub.transformers.inbound.IdpIdaStatusUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.PassthroughAssertionUnmarshaller;
-import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
@@ -76,7 +73,6 @@ public class CountryAuthnResponseTranslatorServiceTest {
         service = new CountryAuthnResponseTranslatorService(
                 stringToOpenSamlResponseTransformer,
                 responseFromCountryValidator,
-                new IdpIdaStatusUnmarshaller(new IdpIdaStatus.IdpIdaStatusFactory(), new SamlStatusToIdpIdaStatusMappingsFactory()),
                 responseAssertionsFromCountryValidator,
                 validateSamlResponseIssuedByIdpDestination,
                 assertionDecrypter,


### PR DESCRIPTION
_These changes depend on_ #147

Switch to using the new eIDAS specific `CountryAuthenticationStatus` when handling authn responses from Countries

In **saml-engine**:
- Make `CountryAuthnResponseTranslatorService` use the new `CountryAuthenticationStatusUnmarshaller` instead of the IDP one to map the status of an authn response from a country
- `CountryAuthnResponseTranslatorResource` will return one of the values in the new CountryAuthenticationStatus.Status enum to the caller

In **policy**:
- Make the type of the Status field in `InboundResponseFromCountry` to be the new `CountryAuthenticationStatus` instead of re-using `IdpIdaStatus` for eIDAS journeys
- `AuthnResponseFromCountryService` now handles the country specific mapped responses. At the moment this can only be Success or Failure - with the possibility for extension in the future if needed