### PR TITLE
EID-951: Use eIDAS specific logic for validation of authn responses from countries [1/2]

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/AuthenticationStatusFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/AuthenticationStatusFactory.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.saml.hub.domain;
+
+import uk.gov.ida.saml.core.domain.IdaStatus;
+
+public interface AuthenticationStatusFactory<T extends Enum, U extends IdaStatus> {
+    U create(T status, String message);
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/CountryAuthenticationStatus.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/CountryAuthenticationStatus.java
@@ -59,8 +59,8 @@ public final class CountryAuthenticationStatus implements IdaStatus {
             '}';
     }
 
-    public static class CountryAuthenticationStatusFactory {
-        public static CountryAuthenticationStatus create(final CountryAuthenticationStatus.Status statusCode, final String message) {
+    public static class CountryAuthenticationStatusFactory implements AuthenticationStatusFactory<Status, CountryAuthenticationStatus> {
+        public CountryAuthenticationStatus create(final CountryAuthenticationStatus.Status statusCode, final String message) {
 
             if (!statusCode.equals(Status.Failure)) {
                 return new CountryAuthenticationStatus(statusCode);

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/IdpIdaStatus.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/IdpIdaStatus.java
@@ -79,16 +79,16 @@ public final class IdpIdaStatus implements IdaStatus {
             '}';
     }
 
-    public static class IdpIdaStatusFactory {
+    public static class IdpIdaStatusFactory implements AuthenticationStatusFactory<Status, IdpIdaStatus> {
         public IdpIdaStatus create(
                 final IdpIdaStatus.Status statusCode,
-                final Optional<String> message) {
+                final String message) {
 
             if (!statusCode.equals(Status.RequesterError)) {
                 return new IdpIdaStatus(statusCode);
             }
 
-            return new IdpIdaStatus(statusCode, message);
+            return new IdpIdaStatus(statusCode, Optional.ofNullable(message));
         }
     }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/AuthenticationStatusUnmarshallerBase.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/AuthenticationStatusUnmarshallerBase.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusMessage;
+import uk.gov.ida.saml.core.domain.IdaStatus;
+import uk.gov.ida.saml.hub.domain.AuthenticationStatusFactory;
+
+import java.util.Optional;
+
+import static java.text.MessageFormat.format;
+
+public abstract class AuthenticationStatusUnmarshallerBase<T extends Enum, U extends IdaStatus> {
+
+    private final SamlStatusToAuthenticationStatusCodeMapper<T> statusMapper;
+    private final AuthenticationStatusFactory<T, U> statusFactory;
+
+    public AuthenticationStatusUnmarshallerBase(
+            final SamlStatusToAuthenticationStatusCodeMapper<T> statusMapper,
+            final AuthenticationStatusFactory<T, U> authenticationStatusFactory) {
+
+        this.statusMapper = statusMapper;
+        this.statusFactory = authenticationStatusFactory;
+    }
+
+    public U fromSaml(final Status samlStatus) {
+        final T status = getStatus(samlStatus);
+        final String message = getStatusMessage(samlStatus).orElse(null);
+        return statusFactory.create(status, message);
+    }
+
+    private T getStatus(final Status samlStatus) {
+        return statusMapper.map(samlStatus).orElseThrow(() -> new IllegalStateException(
+                format("Could not map status to an IdaStatus: {0}", SerializeSupport.nodeToString(samlStatus.getDOM()))
+        ));
+    }
+
+    private Optional<String> getStatusMessage(final Status samlStatus) {
+        final StatusMessage statusMessage = samlStatus.getStatusMessage();
+        return statusMessage != null ? Optional.of(statusMessage.getMessage()) : Optional.empty();
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshaller.java
@@ -9,16 +9,19 @@ import java.util.Optional;
 
 public class CountryAuthenticationStatusUnmarshaller {
 
+    private static final CountryAuthenticationStatusFactory authenticationStatusFactory = new CountryAuthenticationStatusFactory();
+    private static final SamlStatusToCountryAuthenticationStatusCodeMapper statusMapper = new SamlStatusToCountryAuthenticationStatusCodeMapper();
+
     private CountryAuthenticationStatusUnmarshaller() { }
 
     public static CountryAuthenticationStatus fromSaml(final Status samlStatus) {
         final CountryAuthenticationStatus.Status status = getStatus(samlStatus);
         final String message = getStatusMessage(samlStatus).orElse(null);
-        return CountryAuthenticationStatusFactory.create(status, message);
+        return authenticationStatusFactory.create(status, message);
     }
 
     private static CountryAuthenticationStatus.Status getStatus(final Status samlStatus) {
-        return SamlStatusToCountryAuthenticationStatusCodeMapper.map(samlStatus);
+        return statusMapper.map(samlStatus).get();
     }
 
     private static Optional<String> getStatusMessage(final Status samlStatus) {

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshaller.java
@@ -1,46 +1,9 @@
 package uk.gov.ida.saml.hub.transformers.inbound;
 
-import net.shibboleth.utilities.java.support.xml.SerializeSupport;
-import org.opensaml.saml.saml2.core.Status;
-import org.opensaml.saml.saml2.core.StatusMessage;
 import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
 
-import java.util.Optional;
-
-import static java.text.MessageFormat.format;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-
-public class IdpIdaStatusUnmarshaller {
-
-    private final SamlStatusToIdaStatusCodeMapper idpStatusMapper;
-    private final IdpIdaStatus.IdpIdaStatusFactory statusFactory;
-
-    public IdpIdaStatusUnmarshaller(
-            final IdpIdaStatus.IdpIdaStatusFactory statusFactory,
-            final SamlStatusToIdpIdaStatusMappingsFactory statusMappingsFactory) {
-
-        this.idpStatusMapper = new SamlStatusToIdaStatusCodeMapper(
-                statusMappingsFactory.getSamlToIdpIdaStatusMappings()
-        );
-        this.statusFactory = statusFactory;
+public class IdpIdaStatusUnmarshaller extends AuthenticationStatusUnmarshallerBase<IdpIdaStatus.Status, IdpIdaStatus> {
+    public IdpIdaStatusUnmarshaller() {
+        super(new SamlStatusToIdaStatusCodeMapper(), new IdpIdaStatus.IdpIdaStatusFactory());
     }
-
-    public IdpIdaStatus fromSaml(final Status samlStatus) {
-        final IdpIdaStatus.Status status = getStatus(samlStatus);
-        final Optional<String> message = getStatusMessage(samlStatus);
-        return statusFactory.create(status, message);
-    }
-
-    private IdpIdaStatus.Status getStatus(final Status samlStatus) {
-        return idpStatusMapper.map(samlStatus).orElseThrow(() -> new IllegalStateException(
-                format("Could not map status to a IdpIdaStatus: {0}", SerializeSupport.nodeToString(samlStatus.getDOM()))
-        ));
-    }
-
-    private Optional<String> getStatusMessage(final Status samlStatus) {
-        final StatusMessage statusMessage = samlStatus.getStatusMessage();
-        return statusMessage != null ? of(statusMessage.getMessage()) : empty();
-    }
-
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToAuthenticationStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToAuthenticationStatusCodeMapper.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.saml.hub.transformers.inbound;
+
+import org.opensaml.saml.saml2.core.Status;
+
+import java.util.Optional;
+
+public interface SamlStatusToAuthenticationStatusCodeMapper<T extends Enum> {
+    Optional<T> map(Status samlStatus);
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusCodeMapper.java
@@ -5,22 +5,31 @@ import org.opensaml.saml.saml2.core.Status;
 import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus;
 import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticationStatusMappingsFactory.SamlStatusDefinitions;
 
-public class SamlStatusToCountryAuthenticationStatusCodeMapper {
+import java.util.Optional;
 
-    private static final ImmutableMap<SamlStatusDefinitions, CountryAuthenticationStatus.Status> STATUS_MAPPINGS =
-            SamlStatusToCountryAuthenticationStatusMappingsFactory.getSamlToCountryAuthenticationStatusMappings();
+public class SamlStatusToCountryAuthenticationStatusCodeMapper implements SamlStatusToAuthenticationStatusCodeMapper<CountryAuthenticationStatus.Status> {
 
-    public static CountryAuthenticationStatus.Status map(Status samlStatus) {
-        final String statusCodeValue = getStatusCodeValue(samlStatus);
+    private final ImmutableMap<SamlStatusDefinitions, CountryAuthenticationStatus.Status> statusMappings;
 
-        return STATUS_MAPPINGS.keySet().stream()
-                .filter(k -> k.matches(statusCodeValue))
-                .findFirst()
-                .map(STATUS_MAPPINGS::get)
-                .orElse(CountryAuthenticationStatus.Status.Failure);
+    public SamlStatusToCountryAuthenticationStatusCodeMapper() {
+        this.statusMappings = SamlStatusToCountryAuthenticationStatusMappingsFactory.getSamlToCountryAuthenticationStatusMappings();
     }
 
-    private static String getStatusCodeValue(final Status status) {
+    @Override
+    public Optional<CountryAuthenticationStatus.Status> map(Status samlStatus) {
+        final String statusCodeValue = getStatusCodeValue(samlStatus);
+
+        final CountryAuthenticationStatus.Status mappedStatus =
+                statusMappings.keySet().stream()
+                        .filter(k -> k.matches(statusCodeValue))
+                        .findFirst()
+                        .map(statusMappings::get)
+                        .orElse(CountryAuthenticationStatus.Status.Failure);
+
+        return Optional.of(mappedStatus);
+    }
+
+    private String getStatusCodeValue(final Status status) {
         return status.getStatusCode().getValue();
     }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdaStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdaStatusCodeMapper.java
@@ -14,15 +14,15 @@ import java.util.Optional;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
-public class SamlStatusToIdaStatusCodeMapper {
+public class SamlStatusToIdaStatusCodeMapper implements SamlStatusToAuthenticationStatusCodeMapper<IdpIdaStatus.Status> {
 
     private final ImmutableMap<SamlStatusToIdpIdaStatusMappingsFactory.SamlStatusDefinitions, IdpIdaStatus.Status> statusMappings;
 
-    public SamlStatusToIdaStatusCodeMapper(
-            final ImmutableMap<SamlStatusToIdpIdaStatusMappingsFactory.SamlStatusDefinitions, IdpIdaStatus.Status> statusMappings) {
-        this.statusMappings = statusMappings;
+    public SamlStatusToIdaStatusCodeMapper() {
+        this.statusMappings = SamlStatusToIdpIdaStatusMappingsFactory.getSamlToIdpIdaStatusMappings();
     }
 
+    @Override
     public Optional<IdpIdaStatus.Status> map(Status samlStatus) {
         final String statusCodeValue = getStatusCodeValue(samlStatus);
         final Optional<String> subStatusCodeValue = getSubStatusCodeValue(samlStatus);

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdpIdaStatusMappingsFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdpIdaStatusMappingsFactory.java
@@ -35,7 +35,7 @@ public class SamlStatusToIdpIdaStatusMappingsFactory {
         }
     }
 
-    public ImmutableMap<SamlStatusDefinitions, IdpIdaStatus.Status> getSamlToIdpIdaStatusMappings() {
+    public static ImmutableMap<SamlStatusDefinitions, IdpIdaStatus.Status> getSamlToIdpIdaStatusMappings() {
         // Matching SAML statuses to their IdpIdaStatus counterparts is dependent on the ordering of these put()
         // statements. There must be a better way of doing this.
         return ImmutableMap.<SamlStatusDefinitions, IdpIdaStatus.Status>builder()

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidator.java
@@ -10,24 +10,31 @@ import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
 import uk.gov.ida.saml.hub.exception.SamlValidationException;
 import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdaStatusCodeMapper;
-import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
 import uk.gov.ida.saml.hub.validators.response.common.IssuerValidator;
 import uk.gov.ida.saml.hub.validators.response.common.RequestIdValidator;
 
 import java.util.List;
 import java.util.Optional;
 
-import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.*;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidStatusCode;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.invalidSubStatusCode;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingId;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingIssueInstant;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingSignature;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.missingSuccessUnEncryptedAssertions;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.nestedSubStatusCodesBreached;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.nonSuccessHasUnEncryptedAssertions;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.signatureNotSigned;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.unencryptedAssertion;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.unexpectedNumberOfAssertions;
 import static uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil.isSignaturePresent;
 
 public class EncryptedResponseFromIdpValidator {
     private static final int SUB_STATUS_CODE_LIMIT = 1;
     private SamlStatusToIdaStatusCodeMapper statusCodeMapper;
 
-    public EncryptedResponseFromIdpValidator(final SamlStatusToIdpIdaStatusMappingsFactory statusMappingsFactory) {
-        this.statusCodeMapper = new SamlStatusToIdaStatusCodeMapper(
-            statusMappingsFactory.getSamlToIdpIdaStatusMappings()
-        );
+    public EncryptedResponseFromIdpValidator() {
+        this.statusCodeMapper = new SamlStatusToIdaStatusCodeMapper();
     }
 
     protected void validateAssertionPresence(Response response) {

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshallerTest.java
@@ -28,22 +28,16 @@ import static uk.gov.ida.saml.core.test.builders.StatusMessageBuilder.aStatusMes
 public class IdpIdaStatusUnmarshallerTest {
 
     private IdpIdaStatusUnmarshaller unmarshaller;
-    private SamlStatusToIdpIdaStatusMappingsFactory statusMappingsFactory;
-    private StringToOpenSamlObjectTransformer<Response> stringtoOpenSamlObjectTransformer;
+    private StringToOpenSamlObjectTransformer<Response> stringToOpenSamlObjectTransformer;
 
     @Before
     public void setUp() throws Exception {
-        unmarshaller = new IdpIdaStatusUnmarshaller(
-                new IdpIdaStatus.IdpIdaStatusFactory(),
-                new SamlStatusToIdpIdaStatusMappingsFactory()
-        );
-        CoreTransformersFactory coreTransformersFactory = new CoreTransformersFactory();
-        stringtoOpenSamlObjectTransformer = coreTransformersFactory.
-                getStringtoOpenSamlObjectTransformer(input -> {});
+        unmarshaller = new IdpIdaStatusUnmarshaller();
+        stringToOpenSamlObjectTransformer = new CoreTransformersFactory().getStringtoOpenSamlObjectTransformer(input -> {});
     }
 
     @Test
-    public void transform_shouldTransformSuccessWithNoSubCode() throws Exception {
+    public void transform_shouldTransformSuccessWithNoSubCode() {
         OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
         Status originalStatus = samlObjectFactory.createStatus();
         StatusCode successStatusCode = samlObjectFactory.createStatusCode();
@@ -56,7 +50,7 @@ public class IdpIdaStatusUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformNoAuthenticationContext() throws Exception {
+    public void transform_shouldTransformNoAuthenticationContext() {
         OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
         Status originalStatus = samlObjectFactory.createStatus();
         StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
@@ -72,7 +66,7 @@ public class IdpIdaStatusUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformAuthnFailed() throws Exception {
+    public void transform_shouldTransformAuthnFailed() {
         OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
         Status status = samlObjectFactory.createStatus();
         StatusCode topLevelStatusCode = samlObjectFactory.createStatusCode();
@@ -87,7 +81,7 @@ public class IdpIdaStatusUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformRequesterErrorWithoutMessage() throws Exception {
+    public void transform_shouldTransformRequesterErrorWithoutMessage() {
         OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
 
         Status status = samlObjectFactory.createStatus();
@@ -101,7 +95,7 @@ public class IdpIdaStatusUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformRequesterErrorWithRequestDeniedSubstatus() throws Exception {
+    public void transform_shouldTransformRequesterErrorWithRequestDeniedSubstatus() {
         OpenSamlXmlObjectFactory samlObjectFactory = new OpenSamlXmlObjectFactory();
 
         Status status = samlObjectFactory.createStatus();
@@ -118,7 +112,7 @@ public class IdpIdaStatusUnmarshallerTest {
     }
 
     @Test
-    public void transform_shouldTransformRequesterErrorWithMessage() throws Exception {
+    public void transform_shouldTransformRequesterErrorWithMessage() {
         String message = "some message";
 
         StatusCode topLevelStatusCode = aStatusCode().withValue(StatusCode.REQUESTER).build();
@@ -137,7 +131,7 @@ public class IdpIdaStatusUnmarshallerTest {
     @Test
     public void shouldMapSamlStatusDetailOfAuthnCancelToAuthenticationCancelled() throws Exception {
         String cancelXml = readXmlFile("status-cancel.xml");
-        Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(cancelXml);
+        Response cancelResponse = stringToOpenSamlObjectTransformer.apply(cancelXml);
 
         IdpIdaStatus idpIdaStatus = getStatusFrom(cancelResponse);
 
@@ -147,7 +141,7 @@ public class IdpIdaStatusUnmarshallerTest {
     @Test
     public void shouldMapSamlStatusDetailOfLoaPendingToAuthenticationPending() throws Exception {
         String pendingXml = readXmlFile("status-pending.xml");
-        Response pendingResponse = stringtoOpenSamlObjectTransformer.apply(pendingXml);
+        Response pendingResponse = stringToOpenSamlObjectTransformer.apply(pendingXml);
 
         IdpIdaStatus idpIdaStatus = getStatusFrom(pendingResponse);
 
@@ -157,7 +151,7 @@ public class IdpIdaStatusUnmarshallerTest {
     @Test
     public void shouldRemainSuccessEvenIfStatusDetailCancelReturned() throws Exception {
         String successWithCancelXml = readXmlFile("status-success-with-cancel.xml");
-        Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(successWithCancelXml);
+        Response cancelResponse = stringToOpenSamlObjectTransformer.apply(successWithCancelXml);
 
         IdpIdaStatus idpIdaStatus = getStatusFrom(cancelResponse);
 
@@ -167,7 +161,7 @@ public class IdpIdaStatusUnmarshallerTest {
     @Test
     public void shouldRemainNoAuthnContextIfStatusDetailAbsent() throws Exception {
         String successWithCancelXml = readXmlFile("status-noauthncontext.xml");
-        Response cancelResponse = stringtoOpenSamlObjectTransformer.apply(successWithCancelXml);
+        Response cancelResponse = stringToOpenSamlObjectTransformer.apply(successWithCancelXml);
 
         IdpIdaStatus idpIdaStatus = getStatusFrom(cancelResponse);
 
@@ -182,8 +176,7 @@ public class IdpIdaStatusUnmarshallerTest {
     }
 
     private IdpIdaStatus getStatusFrom(Response pendingResponse) {
-        statusMappingsFactory = new SamlStatusToIdpIdaStatusMappingsFactory();
-        IdpIdaStatusUnmarshaller idpIdaStatusUnmarshaller = new IdpIdaStatusUnmarshaller(new IdpIdaStatus.IdpIdaStatusFactory(), statusMappingsFactory);
+        IdpIdaStatusUnmarshaller idpIdaStatusUnmarshaller = new IdpIdaStatusUnmarshaller();
         return idpIdaStatusUnmarshaller.fromSaml(pendingResponse.getStatus());
     }
 }

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidatorTest.java
@@ -34,7 +34,7 @@ public class EncryptedResponseFromIdpValidatorTest {
 
     @Before
     public void setup() {
-        validator = new EncryptedResponseFromIdpValidator(new SamlStatusToIdpIdaStatusMappingsFactory());
+        validator = new EncryptedResponseFromIdpValidator();
     }
 
     @Test

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -284,7 +284,7 @@ public class SamlEngineModule extends AbstractModule {
 
     @Provides
     public IdpIdaStatusUnmarshaller getIdpIdaStatusUnmarshaller() {
-        return new IdpIdaStatusUnmarshaller(new IdpIdaStatus.IdpIdaStatusFactory(), new SamlStatusToIdpIdaStatusMappingsFactory());
+        return new IdpIdaStatusUnmarshaller();
     }
 
     @Provides
@@ -414,7 +414,7 @@ public class SamlEngineModule extends AbstractModule {
     @Provides
     @Singleton
     private ResponseFromCountryValidator getResponseFromCountryValidator() {
-        return new ResponseFromCountryValidator(new SamlStatusToIdpIdaStatusMappingsFactory());
+        return new ResponseFromCountryValidator();
     }
 
     @Provides

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidator.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidator.java
@@ -5,15 +5,11 @@ import org.opensaml.saml.saml2.core.StatusCode;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
-import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
 import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
 
 public class ResponseFromCountryValidator extends EncryptedResponseFromIdpValidator {
 
-    public ResponseFromCountryValidator(
-            final SamlStatusToIdpIdaStatusMappingsFactory statusMappingsFactory) {
-        super(statusMappingsFactory);
-    }
+    public ResponseFromCountryValidator() { }
 
     protected void validateAssertionPresence(Response response) {
         boolean responseWasSuccessful = response.getStatus().getStatusCode().getValue().equals(StatusCode.SUCCESS);

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/IdpAuthnResponseTranslatorServiceTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/IdpAuthnResponseTranslatorServiceTest.java
@@ -87,7 +87,7 @@ public class IdpAuthnResponseTranslatorServiceTest {
 
     private IdpIdaStatus.Status statusCode = IdpIdaStatus.Status.Success;
     private String statusMessage = "status message";
-    private IdpIdaStatus status = new IdpIdaStatus.IdpIdaStatusFactory().create(statusCode, of(statusMessage));
+    private IdpIdaStatus status = new IdpIdaStatus.IdpIdaStatusFactory().create(statusCode, statusMessage);
     private String saml = "some saml";
     private String principalIpAddressSeenByIdp = "ip address";
     private String persistentIdName = "id name";

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
@@ -37,7 +37,7 @@ public class ResponseFromCountryValidatorTest {
     @Mock
     private EncryptedAssertion encryptedAssertion;
 
-    private ResponseFromCountryValidator validator = new ResponseFromCountryValidator(new SamlStatusToIdpIdaStatusMappingsFactory());
+    private ResponseFromCountryValidator validator = new ResponseFromCountryValidator();
 
     @Before
     public void setUp() {


### PR DESCRIPTION
Added a few interfaces and did some refactoring that will be needed later on to enable us to instantiate the response validator with an appropriate mapper class (either eIDAS or Country version).

New interfaces:
  - `AuthenticationStatusFactory`
  - `SamlStatusToAuthenticationStatusCodeMapper`

Refactored `IdpIdaStatusUnmarshaller` and `CountryAuthenticationStatusUnmarshaller` to inherit from a Base class as they both had identical logic