### PR TITLE
EID-951: Use ResponseFromCountryVaidator for validation of authn responses from countries [2/2]

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
@@ -56,6 +56,7 @@ import uk.gov.ida.saml.hub.transformers.inbound.InboundHealthCheckResponseFromMa
 import uk.gov.ida.saml.hub.transformers.inbound.InboundResponseFromMatchingServiceUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatusUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.PassthroughAssertionUnmarshaller;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdaStatusCodeMapper;
 import uk.gov.ida.saml.hub.transformers.inbound.decorators.AuthnRequestSizeValidator;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer;
@@ -414,7 +415,7 @@ public class HubTransformersFactory {
         IdpResponseValidator validator = new IdpResponseValidator(this.getSamlResponseSignatureValidator(idpSignatureValidator),
             this.getSamlResponseAssertionDecrypter(keyStore),
                 getSamlAssertionsSignatureValidator(idpSignatureValidator),
-                new EncryptedResponseFromIdpValidator(),
+                new EncryptedResponseFromIdpValidator<>(new SamlStatusToIdaStatusCodeMapper()),
             new DestinationValidator(expectedDestinationHost, expectedEndpoint),
             getResponseAssertionsFromIdpValidator(assertionIdCache, hubEntityId));
 

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshaller.java
@@ -1,31 +1,9 @@
 package uk.gov.ida.saml.hub.transformers.inbound;
 
-import org.opensaml.saml.saml2.core.Status;
-import org.opensaml.saml.saml2.core.StatusMessage;
 import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus;
-import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus.CountryAuthenticationStatusFactory;
 
-import java.util.Optional;
-
-public class CountryAuthenticationStatusUnmarshaller {
-
-    private static final CountryAuthenticationStatusFactory authenticationStatusFactory = new CountryAuthenticationStatusFactory();
-    private static final SamlStatusToCountryAuthenticationStatusCodeMapper statusMapper = new SamlStatusToCountryAuthenticationStatusCodeMapper();
-
-    private CountryAuthenticationStatusUnmarshaller() { }
-
-    public static CountryAuthenticationStatus fromSaml(final Status samlStatus) {
-        final CountryAuthenticationStatus.Status status = getStatus(samlStatus);
-        final String message = getStatusMessage(samlStatus).orElse(null);
-        return authenticationStatusFactory.create(status, message);
-    }
-
-    private static CountryAuthenticationStatus.Status getStatus(final Status samlStatus) {
-        return statusMapper.map(samlStatus).get();
-    }
-
-    private static Optional<String> getStatusMessage(final Status samlStatus) {
-        final StatusMessage statusMessage = samlStatus.getStatusMessage();
-        return statusMessage != null ? Optional.of(statusMessage.getMessage()) : Optional.empty();
+public class CountryAuthenticationStatusUnmarshaller extends AuthenticationStatusUnmarshallerBase<CountryAuthenticationStatus.Status, CountryAuthenticationStatus> {
+    public CountryAuthenticationStatusUnmarshaller() {
+        super(new SamlStatusToCountryAuthenticationStatusCodeMapper(), new CountryAuthenticationStatus.CountryAuthenticationStatusFactory());
     }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToAuthenticationStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToAuthenticationStatusCodeMapper.java
@@ -4,6 +4,11 @@ import org.opensaml.saml.saml2.core.Status;
 
 import java.util.Optional;
 
-public interface SamlStatusToAuthenticationStatusCodeMapper<T extends Enum> {
-    Optional<T> map(Status samlStatus);
+public abstract class SamlStatusToAuthenticationStatusCodeMapper<T extends Enum> {
+
+    public abstract Optional<T> map(Status samlStatus);
+
+    protected String getStatusCodeValue(final Status status) {
+        return status.getStatusCode().getValue();
+    }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToCountryAuthenticationStatusCodeMapper.java
@@ -7,7 +7,7 @@ import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticatio
 
 import java.util.Optional;
 
-public class SamlStatusToCountryAuthenticationStatusCodeMapper implements SamlStatusToAuthenticationStatusCodeMapper<CountryAuthenticationStatus.Status> {
+public class SamlStatusToCountryAuthenticationStatusCodeMapper extends SamlStatusToAuthenticationStatusCodeMapper<CountryAuthenticationStatus.Status> {
 
     private final ImmutableMap<SamlStatusDefinitions, CountryAuthenticationStatus.Status> statusMappings;
 
@@ -27,9 +27,5 @@ public class SamlStatusToCountryAuthenticationStatusCodeMapper implements SamlSt
                         .orElse(CountryAuthenticationStatus.Status.Failure);
 
         return Optional.of(mappedStatus);
-    }
-
-    private String getStatusCodeValue(final Status status) {
-        return status.getStatusCode().getValue();
     }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdaStatusCodeMapper.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdaStatusCodeMapper.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
-public class SamlStatusToIdaStatusCodeMapper implements SamlStatusToAuthenticationStatusCodeMapper<IdpIdaStatus.Status> {
+public class SamlStatusToIdaStatusCodeMapper extends SamlStatusToAuthenticationStatusCodeMapper<IdpIdaStatus.Status> {
 
     private final ImmutableMap<SamlStatusToIdpIdaStatusMappingsFactory.SamlStatusDefinitions, IdpIdaStatus.Status> statusMappings;
 
@@ -32,10 +32,6 @@ public class SamlStatusToIdaStatusCodeMapper implements SamlStatusToAuthenticati
                 .filter(k -> k.matches(statusCodeValue, subStatusCodeValue, statusDetailValues))
                 .findFirst()
                 .map(statusMappings::get);
-    }
-
-    private String getStatusCodeValue(final Status status) {
-        return status.getStatusCode().getValue();
     }
 
     private Optional<String> getSubStatusCodeValue(final Status status) {

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/components/EncryptedResponseFromIdpValidator.java
@@ -7,9 +7,8 @@ import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.xmlsec.signature.Signature;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
-import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
 import uk.gov.ida.saml.hub.exception.SamlValidationException;
-import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdaStatusCodeMapper;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToAuthenticationStatusCodeMapper;
 import uk.gov.ida.saml.hub.validators.response.common.IssuerValidator;
 import uk.gov.ida.saml.hub.validators.response.common.RequestIdValidator;
 
@@ -29,12 +28,12 @@ import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.unencry
 import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.unexpectedNumberOfAssertions;
 import static uk.gov.ida.saml.security.validators.signature.SamlSignatureUtil.isSignaturePresent;
 
-public class EncryptedResponseFromIdpValidator {
+public class EncryptedResponseFromIdpValidator<T extends Enum> {
     private static final int SUB_STATUS_CODE_LIMIT = 1;
-    private SamlStatusToIdaStatusCodeMapper statusCodeMapper;
+    private SamlStatusToAuthenticationStatusCodeMapper<T> statusCodeMapper;
 
-    public EncryptedResponseFromIdpValidator() {
-        this.statusCodeMapper = new SamlStatusToIdaStatusCodeMapper();
+    public EncryptedResponseFromIdpValidator(final SamlStatusToAuthenticationStatusCodeMapper<T> statusCodeMapper) {
+        this.statusCodeMapper = statusCodeMapper;
     }
 
     protected void validateAssertionPresence(Response response) {
@@ -77,7 +76,7 @@ public class EncryptedResponseFromIdpValidator {
     private void validateStatus(Status status) {
         validateStatusCode(status.getStatusCode(), 0);
 
-        Optional<IdpIdaStatus.Status> mappedStatus = statusCodeMapper.map(status);
+        Optional<T> mappedStatus = statusCodeMapper.map(status);
         if (!mappedStatus.isPresent()) fail(status);
     }
 

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/CountryAuthenticationStatusUnmarshallerTest.java
@@ -30,11 +30,13 @@ public class CountryAuthenticationStatusUnmarshallerTest {
 
     private OpenSamlXmlObjectFactory samlObjectFactory;
     private StringToOpenSamlObjectTransformer<Response> stringToOpenSamlObjectTransformer;
+    private CountryAuthenticationStatusUnmarshaller countryAuthenticationStatusUnmarshaller;
 
     @Before
     public void setUp() throws Exception {
         samlObjectFactory = new OpenSamlXmlObjectFactory();
         stringToOpenSamlObjectTransformer = new CoreTransformersFactory().getStringtoOpenSamlObjectTransformer(input -> {});
+        countryAuthenticationStatusUnmarshaller = new CountryAuthenticationStatusUnmarshaller();
     }
 
     @Test
@@ -44,7 +46,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         successStatusCode.setValue(StatusCode.SUCCESS);
         originalStatus.setStatusCode(successStatusCode);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.success());
     }
@@ -59,7 +61,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         originalStatus.setStatusCode(successStatusCode);
         originalStatus.setStatusMessage(statusMessage);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.success());
         assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(false);
@@ -75,7 +77,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         topLevelStatusCode.setStatusCode(subStatusCode);
         originalStatus.setStatusCode(topLevelStatusCode);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(originalStatus);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
     }
@@ -90,7 +92,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         subStatusCode.setValue(StatusCode.AUTHN_FAILED);
         topLevelStatusCode.setStatusCode(subStatusCode);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
     }
@@ -104,7 +106,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
                 .withMessage(aStatusMessage().withMessage(message).build())
                 .build();
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
         assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
@@ -120,7 +122,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
                 .withMessage(aStatusMessage().withMessage(message).build())
                 .build();
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
         assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
@@ -134,7 +136,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         topLevelStatusCode.setValue(StatusCode.REQUESTER);
         status.setStatusCode(topLevelStatusCode);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
         assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(false);
@@ -150,7 +152,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
                 .withMessage(aStatusMessage().withMessage(message).build())
                 .build();
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
         assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
@@ -166,7 +168,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         subStatusCode.setValue(StatusCode.REQUEST_DENIED);
         status.setStatusCode(topLevelStatusCode);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
     }
@@ -178,7 +180,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         topLevelStatusCode.setValue(StatusCode.RESPONDER);
         status.setStatusCode(topLevelStatusCode);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
         assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(false);
@@ -194,7 +196,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
                 .withMessage(aStatusMessage().withMessage(message).build())
                 .build();
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
         assertThat(transformedStatus.getMessage().isPresent()).isEqualTo(true);
@@ -210,7 +212,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         subStatusCode.setValue("Canceled");
         status.setStatusCode(topLevelStatusCode);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(status);
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(status);
 
         assertThat(transformedStatus).isEqualTo(CountryAuthenticationStatus.failure());
     }
@@ -220,7 +222,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         String cancelXml = readXmlFile("status-cancel.xml");
         Response cancelResponse = stringToOpenSamlObjectTransformer.apply(cancelXml);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
 
         assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Failure);
     }
@@ -230,7 +232,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         String pendingXml = readXmlFile("status-pending.xml");
         Response pendingResponse = stringToOpenSamlObjectTransformer.apply(pendingXml);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(pendingResponse.getStatus());
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(pendingResponse.getStatus());
 
         assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Failure);
     }
@@ -240,7 +242,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         String successWithCancelXml = readXmlFile("status-success-with-cancel.xml");
         Response cancelResponse = stringToOpenSamlObjectTransformer.apply(successWithCancelXml);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
 
         assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Success);
     }
@@ -250,7 +252,7 @@ public class CountryAuthenticationStatusUnmarshallerTest {
         String successWithCancelXml = readXmlFile("status-noauthncontext.xml");
         Response cancelResponse = stringToOpenSamlObjectTransformer.apply(successWithCancelXml);
 
-        final CountryAuthenticationStatus transformedStatus = CountryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
+        final CountryAuthenticationStatus transformedStatus = countryAuthenticationStatusUnmarshaller.fromSaml(cancelResponse.getStatus());
 
         assertThat(transformedStatus.getStatusCode()).isEqualTo(CountryAuthenticationStatus.Status.Failure);
     }

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -92,7 +92,6 @@ import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.saml.hub.domain.MatchingServiceHealthCheckRequest;
 import uk.gov.ida.saml.hub.transformers.inbound.AuthnRequestToIdaRequestFromRelyingPartyTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.CountryAuthenticationStatusUnmarshaller;
-import uk.gov.ida.saml.hub.transformers.inbound.IdpIdaStatusUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.InboundResponseFromIdpDataGenerator;
 import uk.gov.ida.saml.hub.transformers.inbound.PassthroughAssertionUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticationStatusCodeMapper;
@@ -258,8 +257,7 @@ public class SamlEngineModule extends AbstractModule {
                                                                                            @Named("EidasAssertionDecrypter") AssertionDecrypter assertionDecrypter,
                                                                                            AssertionBlobEncrypter assertionBlobEncrypter,
                                                                                            Optional<EidasValidatorFactory> eidasValidatorFactory,
-                                                                                           PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller,
-                                                                                           CountryAuthenticationStatusUnmarshaller countryAuthenticationStatusUnmarshaller) {
+                                                                                           PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller) {
         if (!responseAssertionFromCountryValidator.isPresent() || !validateSamlResponseIssuedByIdpDestination.isPresent() || !eidasValidatorFactory.isPresent()) {
             throw new InvalidConfigurationException("Eidas not configured correctly");
         }
@@ -271,7 +269,7 @@ public class SamlEngineModule extends AbstractModule {
                 assertionBlobEncrypter,
                 eidasValidatorFactory.get(),
                 passthroughAssertionUnmarshaller,
-                countryAuthenticationStatusUnmarshaller);
+                new CountryAuthenticationStatusUnmarshaller());
     }
 
     @Provides
@@ -282,16 +280,6 @@ public class SamlEngineModule extends AbstractModule {
     @Provides
     public Optional<DestinationValidator> getValidateSamlResponseIssuedByIdpDestination(@Named("ExpectedEidasDestination") Optional<URI> expectedDestination) {
         return expectedDestination.map(d -> new DestinationValidator(d, Urls.FrontendUrls.SAML2_SSO_EIDAS_RESPONSE_ENDPOINT));
-    }
-
-    @Provides
-    public CountryAuthenticationStatusUnmarshaller getCountryAuthenticationStatusUnmarshaller() {
-        return new CountryAuthenticationStatusUnmarshaller();
-    }
-
-    @Provides
-    public IdpIdaStatusUnmarshaller getIdpIdaStatusUnmarshaller() {
-        return new IdpIdaStatusUnmarshaller();
     }
 
     @Provides
@@ -319,7 +307,6 @@ public class SamlEngineModule extends AbstractModule {
         environment.admin().addTask(task);
         return task;
     }
-
 
     @Provides
     @Singleton

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -89,13 +89,13 @@ import uk.gov.ida.saml.hub.domain.EidasAuthnRequestFromHub;
 import uk.gov.ida.saml.hub.domain.HubAttributeQueryRequest;
 import uk.gov.ida.saml.hub.domain.HubEidasAttributeQueryRequest;
 import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
-import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
 import uk.gov.ida.saml.hub.domain.MatchingServiceHealthCheckRequest;
 import uk.gov.ida.saml.hub.transformers.inbound.AuthnRequestToIdaRequestFromRelyingPartyTransformer;
+import uk.gov.ida.saml.hub.transformers.inbound.CountryAuthenticationStatusUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.IdpIdaStatusUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.InboundResponseFromIdpDataGenerator;
 import uk.gov.ida.saml.hub.transformers.inbound.PassthroughAssertionUnmarshaller;
-import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticationStatusCodeMapper;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundHealthCheckResponseFromMatchingServiceTransformer;
 import uk.gov.ida.saml.hub.transformers.inbound.providers.DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer;
@@ -258,7 +258,8 @@ public class SamlEngineModule extends AbstractModule {
                                                                                            @Named("EidasAssertionDecrypter") AssertionDecrypter assertionDecrypter,
                                                                                            AssertionBlobEncrypter assertionBlobEncrypter,
                                                                                            Optional<EidasValidatorFactory> eidasValidatorFactory,
-                                                                                           PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller) {
+                                                                                           PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller,
+                                                                                           CountryAuthenticationStatusUnmarshaller countryAuthenticationStatusUnmarshaller) {
         if (!responseAssertionFromCountryValidator.isPresent() || !validateSamlResponseIssuedByIdpDestination.isPresent() || !eidasValidatorFactory.isPresent()) {
             throw new InvalidConfigurationException("Eidas not configured correctly");
         }
@@ -269,7 +270,8 @@ public class SamlEngineModule extends AbstractModule {
                 assertionDecrypter,
                 assertionBlobEncrypter,
                 eidasValidatorFactory.get(),
-                passthroughAssertionUnmarshaller);
+                passthroughAssertionUnmarshaller,
+                countryAuthenticationStatusUnmarshaller);
     }
 
     @Provides
@@ -280,6 +282,11 @@ public class SamlEngineModule extends AbstractModule {
     @Provides
     public Optional<DestinationValidator> getValidateSamlResponseIssuedByIdpDestination(@Named("ExpectedEidasDestination") Optional<URI> expectedDestination) {
         return expectedDestination.map(d -> new DestinationValidator(d, Urls.FrontendUrls.SAML2_SSO_EIDAS_RESPONSE_ENDPOINT));
+    }
+
+    @Provides
+    public CountryAuthenticationStatusUnmarshaller getCountryAuthenticationStatusUnmarshaller() {
+        return new CountryAuthenticationStatusUnmarshaller();
     }
 
     @Provides
@@ -414,7 +421,7 @@ public class SamlEngineModule extends AbstractModule {
     @Provides
     @Singleton
     private ResponseFromCountryValidator getResponseFromCountryValidator() {
-        return new ResponseFromCountryValidator();
+        return new ResponseFromCountryValidator(new SamlStatusToCountryAuthenticationStatusCodeMapper());
     }
 
     @Provides

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorService.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorService.java
@@ -38,6 +38,7 @@ public class CountryAuthnResponseTranslatorService {
     private final PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller;
     private final ResponseAssertionsFromCountryValidator responseAssertionFromCountryValidator;
     private final EidasValidatorFactory eidasValidatorFactory;
+    private final CountryAuthenticationStatusUnmarshaller countryAuthenticationStatusUnmarshaller;
 
     @Inject
     public CountryAuthnResponseTranslatorService(StringToOpenSamlObjectTransformer<Response> stringToOpenSamlResponseTransformer,
@@ -47,7 +48,8 @@ public class CountryAuthnResponseTranslatorService {
                                                  AssertionDecrypter assertionDecrypter,
                                                  AssertionBlobEncrypter assertionBlobEncrypter,
                                                  EidasValidatorFactory eidasValidatorFactory,
-                                                 PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller) {
+                                                 PassthroughAssertionUnmarshaller passthroughAssertionUnmarshaller,
+                                                 CountryAuthenticationStatusUnmarshaller countryAuthenticationStatusUnmarshaller) {
         this.stringToOpenSamlResponseTransformer = stringToOpenSamlResponseTransformer;
         this.responseFromCountryValidator = responseFromCountryValidator;
         this.responseAssertionFromCountryValidator = responseAssertionFromCountryValidator;
@@ -56,6 +58,7 @@ public class CountryAuthnResponseTranslatorService {
         this.assertionBlobEncrypter = assertionBlobEncrypter;
         this.eidasValidatorFactory = eidasValidatorFactory;
         this.passthroughAssertionUnmarshaller = passthroughAssertionUnmarshaller;
+        this.countryAuthenticationStatusUnmarshaller = countryAuthenticationStatusUnmarshaller;
     }
 
     public InboundResponseFromCountry translate(SamlAuthnResponseTranslatorDto samlResponseDto) {
@@ -95,7 +98,7 @@ public class CountryAuthnResponseTranslatorService {
                 .filter(string -> !isNullOrEmpty(string))
                 .map(LevelOfAssurance::valueOf);
 
-        CountryAuthenticationStatus status = CountryAuthenticationStatusUnmarshaller.fromSaml(response.getStatus());
+        CountryAuthenticationStatus status = countryAuthenticationStatusUnmarshaller.fromSaml(response.getStatus());
 
         return new InboundResponseFromCountry(
             response.getIssuer().getValue(),

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidator.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidator.java
@@ -5,11 +5,15 @@ import org.opensaml.saml.saml2.core.StatusCode;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+import uk.gov.ida.saml.hub.domain.CountryAuthenticationStatus;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticationStatusCodeMapper;
 import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
 
-public class ResponseFromCountryValidator extends EncryptedResponseFromIdpValidator {
+public class ResponseFromCountryValidator extends EncryptedResponseFromIdpValidator<CountryAuthenticationStatus.Status> {
 
-    public ResponseFromCountryValidator() { }
+    public ResponseFromCountryValidator(SamlStatusToCountryAuthenticationStatusCodeMapper samlStatusToCountryAuthenticationStatusCodeMapper) {
+        super(samlStatusToCountryAuthenticationStatusCodeMapper);
+    }
 
     protected void validateAssertionPresence(Response response) {
         boolean responseWasSuccessful = response.getStatus().getStatusCode().getValue().equals(StatusCode.SUCCESS);

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorServiceTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/CountryAuthnResponseTranslatorServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.ida.saml.core.transformers.outbound.decorators.AssertionBlobEncryp
 import uk.gov.ida.saml.core.validators.DestinationValidator;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.deserializers.parser.SamlObjectParser;
+import uk.gov.ida.saml.hub.transformers.inbound.CountryAuthenticationStatusUnmarshaller;
 import uk.gov.ida.saml.hub.transformers.inbound.PassthroughAssertionUnmarshaller;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
@@ -78,7 +79,8 @@ public class CountryAuthnResponseTranslatorServiceTest {
                 assertionDecrypter,
                 assertionBlobEncrypter,
                 eidasValidatorFactory,
-                new PassthroughAssertionUnmarshaller(new XmlObjectToBase64EncodedStringTransformer<>(), new AuthnContextFactory()));
+                new PassthroughAssertionUnmarshaller(new XmlObjectToBase64EncodedStringTransformer<>(), new AuthnContextFactory()),
+                new CountryAuthenticationStatusUnmarshaller());
 
         Response eidasSAMLResponse = (Response) buildResponseFromFile();
         ValidatedResponse validateEIDASSAMLResponse = new ValidatedResponse(eidasSAMLResponse);

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
@@ -7,20 +7,23 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
-import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToIdpIdaStatusMappingsFactory;
+import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticationStatusCodeMapper;
 
 import java.util.Collections;
 
 import static org.mockito.Mockito.when;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
+import static uk.gov.ida.saml.core.test.builders.StatusBuilder.aStatus;
+import static uk.gov.ida.saml.core.test.builders.StatusCodeBuilder.aStatusCode;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(OpenSAMLMockitoRunner.class)
 public class ResponseFromCountryValidatorTest {
 
     @Rule
@@ -37,7 +40,7 @@ public class ResponseFromCountryValidatorTest {
     @Mock
     private EncryptedAssertion encryptedAssertion;
 
-    private ResponseFromCountryValidator validator = new ResponseFromCountryValidator();
+    private ResponseFromCountryValidator validator = new ResponseFromCountryValidator(new SamlStatusToCountryAuthenticationStatusCodeMapper());
 
     @Before
     public void setUp() {
@@ -90,5 +93,13 @@ public class ResponseFromCountryValidatorTest {
         when(response.getEncryptedAssertions()).thenReturn(ImmutableList.of(encryptedAssertion, encryptedAssertion));
 
         validator.validateAssertionPresence(response);
+    }
+
+    @Test
+    public void validateStatus_shouldNotThrowIfStatusIsResponderWithNoSubStatus() throws Exception {
+        Status status = aStatus().withStatusCode(aStatusCode().withValue(StatusCode.RESPONDER).build()).build();
+        Response response = aResponse().withStatus(status).withNoDefaultAssertion().build();
+
+        validator.validate(response);
     }
 }


### PR DESCRIPTION
Use `ResponseFromCountryVaidator` so that we use eIDAS specific logic for validation of authn responses from countries
_These changes depend on the refactoring in #150_

   - Refactor `CountryAuthenticationStatusUnmarshaller` to inherit from the Base class
   - Change the `EncryptedResponseFromIdpValidator` to work with Countries or IDPs by passing in the appropriate mapper to the constructor