### PR TITLE
EID-1004: Fix transition between Verify and eIDAS journeys (part 1/2)

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/AuthnRequestFromTransactionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/AuthnRequestFromTransactionResourceIntegrationTest.java
@@ -190,6 +190,20 @@ public class AuthnRequestFromTransactionResourceIntegrationTest {
     }
 
     @Test
+    public void shouldRestartJourney() {
+        sessionId = SessionId.createNewSessionId();
+        TestSessionResourceHelper.createSessionInEidasAuthnFailedErrorState(sessionId, client, buildUriForTestSession(EIDAS_AUTHN_FAILED_STATE, sessionId));
+
+        URI uri = UriBuilder.fromPath("/policy/received-authn-request" + Urls.PolicyUrls.AUTHN_REQUEST_RESTART_JOURNEY_PATH).build(sessionId);
+        Response response = client.target(policy.uri(uri.toASCIIString())).request().post(null);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+
+        Response checkStateChanged = client.target(buildUriForTestSession(GET_SESSION_STATE_NAME, sessionId)).request().get();
+        assertThat(checkStateChanged.readEntity(String.class)).isEqualTo(SessionStartedState.class.getName());
+    }
+
+    @Test
     public void getSignInProcessDto_shouldReturnSignInDetailsDto(){
         SessionId session = SessionId.createNewSessionId();
         TestSessionResourceHelper.createSessionInIdpSelectedState(session, samlResponse.getIssuer(), idpEntityId, client,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/Urls.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/Urls.java
@@ -83,7 +83,10 @@ public interface Urls {
 
         // End of new saml-engine is a real microservice resources
 
+        // TODO: Remove after a frontend release for ZDD
         String AUTHN_REQUEST_RESTART_EIDAS_JOURNEY_PATH = AUTHN_SESSION_ID_PATH + "/restart-eidas-journey";
+
+        String AUTHN_REQUEST_RESTART_JOURNEY_PATH = AUTHN_SESSION_ID_PATH + "/restart-journey";
         String AUTHN_REQUEST_TRY_ANOTHER_IDP_PATH = AUTHN_SESSION_ID_PATH + "/try-another-idp";
 
         String AUTHN_REQUEST_SELECT_IDP_PATH    = AUTHN_SESSION_ID_PATH + "/select-identity-provider";

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandler.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandler.java
@@ -14,13 +14,13 @@ import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.SessionRepository;
 import uk.gov.ida.hub.policy.domain.controller.AuthnFailedErrorStateController;
 import uk.gov.ida.hub.policy.domain.controller.AuthnRequestCapableController;
-import uk.gov.ida.hub.policy.domain.controller.EidasUnsuccessfulJourneyStateController;
+import uk.gov.ida.hub.policy.domain.controller.RestartJourneyStateController;
 import uk.gov.ida.hub.policy.domain.controller.ErrorResponsePreparedStateController;
 import uk.gov.ida.hub.policy.domain.controller.IdpSelectingStateController;
 import uk.gov.ida.hub.policy.domain.controller.ResponsePreparedStateController;
 import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
 import uk.gov.ida.hub.policy.domain.state.EidasCountrySelectedState;
-import uk.gov.ida.hub.policy.domain.state.EidasUnsuccessfulJourneyState;
+import uk.gov.ida.hub.policy.domain.state.RestartJourneyState;
 import uk.gov.ida.hub.policy.domain.state.ErrorResponsePreparedState;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectingState;
@@ -79,9 +79,9 @@ public class AuthnRequestFromTransactionHandler {
         stateController.tryAnotherIdpResponse();
     }
 
-    public void restartEidasUnsuccessfulJourney(final SessionId sessionId) {
-        final EidasUnsuccessfulJourneyStateController stateController =
-                (EidasUnsuccessfulJourneyStateController) sessionRepository.getStateController(sessionId, EidasUnsuccessfulJourneyState.class);
+    public void restartJourney(final SessionId sessionId) {
+        final RestartJourneyStateController stateController =
+                (RestartJourneyStateController) sessionRepository.getStateController(sessionId, RestartJourneyState.class);
         stateController.transitionToSessionStartedState();
     }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasAuthnFailedErrorStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasAuthnFailedErrorStateController.java
@@ -6,7 +6,7 @@ import uk.gov.ida.hub.policy.domain.state.EidasAuthnFailedErrorState;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
 import uk.gov.ida.hub.policy.logging.HubEventLogger;
 
-public class EidasAuthnFailedErrorStateController extends AbstractAuthnFailedErrorStateController<EidasAuthnFailedErrorState> implements EidasUnsuccessfulJourneyStateController {
+public class EidasAuthnFailedErrorStateController extends AbstractAuthnFailedErrorStateController<EidasAuthnFailedErrorState> implements RestartJourneyStateController {
 
     public EidasAuthnFailedErrorStateController(
             EidasAuthnFailedErrorState state,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasUserAccountCreationFailedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasUserAccountCreationFailedStateController.java
@@ -6,7 +6,7 @@ import uk.gov.ida.hub.policy.domain.state.EidasUserAccountCreationFailedState;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
 import uk.gov.ida.hub.policy.logging.HubEventLogger;
 
-public class EidasUserAccountCreationFailedStateController extends AbstractUserAccountCreationFailedStateController<EidasUserAccountCreationFailedState> implements EidasUnsuccessfulJourneyStateController {
+public class EidasUserAccountCreationFailedStateController extends AbstractUserAccountCreationFailedStateController<EidasUserAccountCreationFailedState> implements RestartJourneyStateController {
 
     private StateTransitionAction stateTransitionAction;
     private HubEventLogger hubEventLogger;

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/RestartJourneyStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/RestartJourneyStateController.java
@@ -2,6 +2,6 @@ package uk.gov.ida.hub.policy.domain.controller;
 
 import uk.gov.ida.hub.policy.domain.StateController;
 
-public interface EidasUnsuccessfulJourneyStateController extends StateController {
+public interface RestartJourneyStateController extends StateController {
     void transitionToSessionStartedState();
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasAuthnFailedErrorState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasAuthnFailedErrorState.java
@@ -7,7 +7,7 @@ import uk.gov.ida.hub.policy.domain.SessionId;
 import java.net.URI;
 import java.util.List;
 
-public class EidasAuthnFailedErrorState extends AbstractAuthnFailedErrorState implements EidasCountrySelectingState, EidasUnsuccessfulJourneyState {
+public class EidasAuthnFailedErrorState extends AbstractAuthnFailedErrorState implements EidasCountrySelectingState, RestartJourneyState {
 
     private static final long serialVersionUID = -6087079428518232137L;
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCountrySelectedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCountrySelectedState.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 
-public class EidasCountrySelectedState extends AbstractState implements EidasCountrySelectingState, Serializable {
+public class EidasCountrySelectedState extends AbstractState implements EidasCountrySelectingState, Serializable, RestartJourneyState {
 
     private static final long serialVersionUID = -285602589000108606L;
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasUserAccountCreationFailedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasUserAccountCreationFailedState.java
@@ -6,7 +6,7 @@ import uk.gov.ida.hub.policy.domain.SessionId;
 
 import java.net.URI;
 
-public class EidasUserAccountCreationFailedState extends AbstractUserAccountCreationFailedState implements EidasUnsuccessfulJourneyState {
+public class EidasUserAccountCreationFailedState extends AbstractUserAccountCreationFailedState implements RestartJourneyState {
 
     private static final long serialVersionUID = -2561859918430555052L;
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/RestartJourneyState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/RestartJourneyState.java
@@ -2,5 +2,5 @@ package uk.gov.ida.hub.policy.domain.state;
 
 import uk.gov.ida.hub.policy.domain.State;
 
-public interface EidasUnsuccessfulJourneyState extends State {
+public interface RestartJourneyState extends State {
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/resources/AuthnRequestFromTransactionResource.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/resources/AuthnRequestFromTransactionResource.java
@@ -49,11 +49,19 @@ public class AuthnRequestFromTransactionResource {
         authnRequestFromTransactionHandler.tryAnotherIdp(sessionId);
     }
 
+    // TODO: Remove after a frontend release for ZDD
     @POST
     @Path(Urls.PolicyUrls.AUTHN_REQUEST_RESTART_EIDAS_JOURNEY_PATH)
     @Timed
     public void restartEidasJourney(@PathParam(SESSION_ID_PARAM) SessionId sessionId) {
-        authnRequestFromTransactionHandler.restartEidasUnsuccessfulJourney(sessionId);
+        authnRequestFromTransactionHandler.restartJourney(sessionId);
+    }
+
+    @POST
+    @Path(Urls.PolicyUrls.AUTHN_REQUEST_RESTART_JOURNEY_PATH)
+    @Timed
+    public void restartJourney(@PathParam(SESSION_ID_PARAM) SessionId sessionId) {
+        authnRequestFromTransactionHandler.restartJourney(sessionId);
     }
 
     @GET

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandlerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandlerTest.java
@@ -17,9 +17,9 @@ import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.SessionRepository;
 import uk.gov.ida.hub.policy.domain.StateController;
-import uk.gov.ida.hub.policy.domain.controller.EidasUnsuccessfulJourneyStateController;
+import uk.gov.ida.hub.policy.domain.controller.RestartJourneyStateController;
 import uk.gov.ida.hub.policy.domain.controller.IdpSelectingStateController;
-import uk.gov.ida.hub.policy.domain.state.EidasUnsuccessfulJourneyState;
+import uk.gov.ida.hub.policy.domain.state.RestartJourneyState;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectingState;
 import uk.gov.ida.hub.policy.logging.HubEventLogger;
 import uk.gov.ida.hub.policy.proxy.SamlResponseWithAuthnRequestInformationDtoBuilder;
@@ -50,7 +50,7 @@ public class AuthnRequestFromTransactionHandlerTest {
     @Mock
     private TransactionsConfigProxy transactionsConfigProxy;
     @Mock
-    private EidasUnsuccessfulJourneyStateController eidasUnsuccessfulJourneyStateController;
+    private RestartJourneyStateController restartJourneyStateController;
 
     private AuthnRequestFromTransactionHandler authnRequestFromTransactionHandler;
 
@@ -92,13 +92,13 @@ public class AuthnRequestFromTransactionHandlerTest {
     }
 
     @Test
-    public void restartsEidasUnsuccessfulJourney() {
+    public void restartsJourney() {
         SessionId sessionId = new SessionId("sessionId");
-        when(sessionRepository.getStateController(sessionId, EidasUnsuccessfulJourneyState.class)).thenReturn(eidasUnsuccessfulJourneyStateController);
+        when(sessionRepository.getStateController(sessionId, RestartJourneyState.class)).thenReturn(restartJourneyStateController);
 
-        authnRequestFromTransactionHandler.restartEidasUnsuccessfulJourney(sessionId);
+        authnRequestFromTransactionHandler.restartJourney(sessionId);
 
-        verify(eidasUnsuccessfulJourneyStateController).transitionToSessionStartedState();
+        verify(restartJourneyStateController).transitionToSessionStartedState();
     }
 
     private class IdpSelectingStateControllerSpy implements IdpSelectingStateController, StateController {


### PR DESCRIPTION
Currently, if a user selects a country or an IDP without completing verification and clicks the back button to the journey picker page and then attempts a different type of journey, they receive a "service unavailable" error page as Policy doesn't allow a transition between `IdpSelected` and `EidasCountrySelected` states. The solution to this is to allow the frontend to ask Policy to restart the journey back to `SessionStartedState` when a user goes back to the journey picker page (`/prove-identity`) and selects a different type of journey. We already allow this for some eIDAS states.

This piece of work makes the interfaces more general so that we can apply the same to the `IdpSelected` state later. This commit only affects eIDAS -> Verify transitions. Transitions in the opposite direction will be enabled in a later release.

Summary of changes:
  - Rename `EidasUnsuccessfulJourney` state and controller interfaces to `RestartJourneyState` to make them more general
  - Make the `EidasCountrySelected` state and controller implement the above interface to give the `EidasCountrySelectedState` the ability to be reset to SessionStartedState
  - Add new more general URL to Policy that frontend can call to restart a journey. The old URL will be removed in a later release after a frontend release
  - Add tests to reflect the above changes

_Note:_ This has to be released before the related frontend changes in alphagov/verify-frontend#589