### PR TITLE
Add support to set registration and authentication expiry dates in IDP configurations

### DIFF
--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStoreTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/HubMetadataPublicKeyStoreTest.java
@@ -6,12 +6,14 @@ import org.apache.xml.security.exceptions.Base64DecodingException;
 import org.apache.xml.security.utils.Base64;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.AbstractReloadingMetadataResolver;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.core.test.TestEntityIds;
-import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
 import uk.gov.ida.saml.metadata.exceptions.HubEntityMissingException;
+import uk.gov.ida.saml.metadata.test.factories.metadata.MetadataFactory;
 import uk.gov.ida.saml.security.PublicKeyFactory;
 
 import java.io.ByteArrayInputStream;
@@ -25,6 +27,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith(OpenSAMLMockitoRunner.class)
 public class HubMetadataPublicKeyStoreTest {
     private static MetadataResolver metadataResolver;
     private static MetadataResolver invalidMetadataResolver;

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStoreTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStoreTest.java
@@ -8,6 +8,7 @@ import org.apache.xml.security.utils.Base64;
 import org.joda.time.DateTime;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.core.xml.io.MarshallingException;
@@ -19,6 +20,7 @@ import org.opensaml.xmlsec.signature.KeyInfo;
 import org.opensaml.xmlsec.signature.X509Certificate;
 import org.opensaml.xmlsec.signature.X509Data;
 import org.opensaml.xmlsec.signature.support.SignatureException;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.saml.core.test.TestEntityIds;
 import uk.gov.ida.saml.core.test.builders.metadata.EntityDescriptorBuilder;
@@ -42,6 +44,7 @@ import static com.google.common.base.Throwables.propagate;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(OpenSAMLMockitoRunner.class)
 public class IdpMetadataPublicKeyStoreTest {
 
     private static MetadataResolver metadataResolver;

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -3,6 +3,7 @@ package uk.gov.ida.integrationtest.hub.config.apprule.support;
 import certificates.values.CACertificates;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
@@ -91,6 +92,7 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
     @Override
     protected void before() {
         mapper.registerModule(new Jdk8Module().configureAbsentsAsNulls(true));
+        mapper.registerModule(new JodaModule());
         clientTrustStore.create();
         rpTrustStore.create();
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
@@ -2,8 +2,11 @@ package uk.gov.ida.hub.config.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.collections.ListUtils;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
 import uk.gov.ida.hub.config.ConfigEntityData;
 
 import javax.validation.Valid;
@@ -50,6 +53,14 @@ public class IdentityProviderConfigEntityData implements ConfigEntityData {
     protected Boolean enabledForSingleIdp = false;
 
     @Valid
+    @JsonProperty
+    protected String provideRegistrationUntil;
+    
+    @Valid
+    @JsonProperty
+    protected String provideAuthenticationUntil;
+    
+    @Valid
     @NotNull
     @JsonProperty
     protected List<LevelOfAssurance> supportedLevelsOfAssurance;
@@ -84,6 +95,27 @@ public class IdentityProviderConfigEntityData implements ConfigEntityData {
 
     public Boolean isEnabled() {
         return enabled;
+    }
+    
+    public Boolean isRegistrationEnabled() {
+        if (Strings.isNullOrEmpty(provideRegistrationUntil)) {
+            return true;
+        }
+        
+        DateTime provideRegistrationUntilDate = DateTime.parse(provideRegistrationUntil, DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ"));
+        
+        return provideRegistrationUntilDate.isAfterNow();
+    }
+    
+    @JsonProperty("authenticationEnabled")
+    public Boolean isAuthenticationEnabled() {
+        if (Strings.isNullOrEmpty(provideAuthenticationUntil)) {
+            return true;
+        }
+
+        DateTime provideAuthenticationUntilDate = DateTime.parse(provideAuthenticationUntil, DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ"));
+        
+        return provideAuthenticationUntilDate.isAfterNow();
     }
 
     public Boolean isEnabledForSingleIdp() {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactory.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactory.java
@@ -30,7 +30,7 @@ public class IdpPredicateFactory {
     public Set<Predicate<IdentityProviderConfigEntityData>> createPredicatesForTransactionEntityAndLoa(String transactionEntity,
                                                                                                        LevelOfAssurance levelOfAssurance) {
         return Sets.newHashSet(new EnabledIdpPredicate(), new OnboardingIdpPredicate(transactionEntity, levelOfAssurance),
-                new SupportedLoaIdpPredicate(levelOfAssurance));
+                new SupportedLoaIdpPredicate(levelOfAssurance), new NewUserIdpPredicate());
     }
 
     public Set<Predicate<IdentityProviderConfigEntityData>> createPredicatesForSignIn(String transactionEntityId) {
@@ -38,6 +38,6 @@ public class IdpPredicateFactory {
     }
 
     public Set<Predicate<IdentityProviderConfigEntityData>> createPredicatesForSingleIdp(String transactionEntityId) {
-        return Sets.newHashSet(new EnabledIdpPredicate(), new OnboardingIdpPredicate(transactionEntityId, null), new SingleIdpEnabledPredicate());
+        return Sets.newHashSet(new EnabledIdpPredicate(), new OnboardingIdpPredicate(transactionEntityId, null), new SingleIdpEnabledPredicate(), new NewUserIdpPredicate());
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/NewUserIdpPredicate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/NewUserIdpPredicate.java
@@ -1,0 +1,13 @@
+package uk.gov.ida.hub.config.domain.filters;
+
+import com.google.common.base.Predicate;
+import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
+
+import javax.annotation.Nullable;
+
+public class NewUserIdpPredicate implements Predicate<IdentityProviderConfigEntityData> {
+	@Override
+	public boolean apply(@Nullable IdentityProviderConfigEntityData identityProviderConfigEntityData) {
+		return identityProviderConfigEntityData.isRegistrationEnabled();
+	}
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
@@ -11,15 +11,18 @@ public class IdpDto {
     private final String simpleId;
     private final String entityId;
     private final List<LevelOfAssurance> levelsOfAssurance;
+    private final boolean authenticationEnabled;
 
     @JsonCreator
     public IdpDto(
             @JsonProperty("simpleId") String simpleId,
             @JsonProperty("entityId") String entityId,
-            @JsonProperty("supportedLevelsOfAssurance") List<LevelOfAssurance> levelsOfAssurance) {
+            @JsonProperty("supportedLevelsOfAssurance") List<LevelOfAssurance> levelsOfAssurance,
+            @JsonProperty("authenticationEnabled") boolean authenticationEnabled) {
         this.simpleId = simpleId;
         this.entityId = entityId;
         this.levelsOfAssurance = levelsOfAssurance;
+        this.authenticationEnabled = authenticationEnabled;
     }
 
     public String getSimpleId() {
@@ -33,6 +36,8 @@ public class IdpDto {
     public List<LevelOfAssurance> getLevelsOfAssurance() {
         return levelsOfAssurance;
     }
+    
+    public boolean isAuthenticationEnabled() { return authenticationEnabled; }
 
     @Override
     public boolean equals(Object o) {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
@@ -56,7 +56,7 @@ public class IdentityProviderResource {
 
         Collection<IdentityProviderConfigEntityData> matchingIdps = getIdentityProviderConfigEntityData(transactionEntityId);
         return matchingIdps.stream().map(configData ->
-                new IdpDto(configData.getSimpleId(), configData.getEntityId(), configData.getSupportedLevelsOfAssurance())).collect(Collectors.toList());
+                new IdpDto(configData.getSimpleId(), configData.getEntityId(), configData.getSupportedLevelsOfAssurance(), configData.isAuthenticationEnabled())).collect(Collectors.toList());
     }
 
     @GET
@@ -70,7 +70,8 @@ public class IdentityProviderResource {
                         new IdpDto(
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
-                                configData.getSupportedLevelsOfAssurance()))
+                                configData.getSupportedLevelsOfAssurance(),
+                                configData.isAuthenticationEnabled()))
                 .collect(Collectors.toList());
     }
 
@@ -84,7 +85,8 @@ public class IdentityProviderResource {
                         new IdpDto(
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
-                                configData.getSupportedLevelsOfAssurance()))
+                                configData.getSupportedLevelsOfAssurance(),
+                                configData.isAuthenticationEnabled()))
                 .collect(Collectors.toList());
     }
 
@@ -98,7 +100,8 @@ public class IdentityProviderResource {
                         new IdpDto(
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
-                                configData.getSupportedLevelsOfAssurance()))
+                                configData.getSupportedLevelsOfAssurance(),
+                                configData.isAuthenticationEnabled()))
                 .collect(Collectors.toList());
     }
 

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityDataTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityDataTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.config.domain;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 import uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder;
 
@@ -14,11 +15,80 @@ public class IdentityProviderConfigEntityDataTest {
 
     private final IdentityProviderConfigDataBuilder dataBuilder = anIdentityProviderConfigData();
 
+    private final DateTime expiredDatetime = DateTime.now().minusDays(1);
+    private final DateTime futureDatetime = DateTime.now().plusDays(1);
+
     @Test
     public void should_defaultSupportedLevelsOfAssuranceToOnlyIncludeLOA2() {
         IdentityProviderConfigEntityData data = dataBuilder.build();
 
         assertThat(data.getSupportedLevelsOfAssurance()).containsExactly(LevelOfAssurance.LEVEL_2);
+    }
+    
+    @Test
+    public void shouldReturnTrueForRegistrationEnabled_whenProvideRegistrationUntilHasNotBeenSpecified() {
+        IdentityProviderConfigEntityData data = dataBuilder.build();
+        data.provideRegistrationUntil = "";
+
+        assertThat(data.isRegistrationEnabled()).isEqualTo(true);
+    }
+    
+    @Test
+    public void shouldReturnTrueForRegistrationEnabled_whenProvideRegistrationUntilDateHasNotExpired() {
+        IdentityProviderConfigEntityData data = dataBuilder
+            .withProvideRegistrationUntil(futureDatetime)
+            .build();
+        
+        assertThat(data.isRegistrationEnabled()).isEqualTo(true);
+    }
+    
+    @Test
+    public void shouldReturnFalseForRegistrationEnabled_whenProvideRegistrationUntilDateHasExpired() {
+        IdentityProviderConfigEntityData data = dataBuilder
+            .withProvideRegistrationUntil(expiredDatetime)
+            .build();
+        
+        assertThat(data.isRegistrationEnabled()).isEqualTo(false);
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void shouldThrowInvalidFormatException_whenProvideRegistrationUntilHasBeenSpecifiedButIsInvalid() {
+        IdentityProviderConfigEntityData data = dataBuilder.build();
+        data.provideRegistrationUntil = "2020-09-09";
+        data.isRegistrationEnabled();
+    }
+
+    @Test
+    public void shouldReturnTrueForAuthenticationEnabled_whenProvideAuthenticationUntilHasNotBeenSpecified() {
+        IdentityProviderConfigEntityData data = dataBuilder.build();
+        data.provideAuthenticationUntil = "";
+
+        assertThat(data.isAuthenticationEnabled()).isEqualTo(true);
+    }
+    
+    @Test
+    public void shouldReturnTrueForAuthenticationEnabled_whenProvideAuthenticationUntilDateHasNotExpired() {
+        IdentityProviderConfigEntityData data = dataBuilder
+            .withProvideAuthenticationUntil(futureDatetime)
+            .build();
+        
+        assertThat(data.isAuthenticationEnabled()).isEqualTo(true);
+    }
+    
+    @Test
+    public void shouldReturnFalseForAuthenticationEnabled_whenProvideAuthenticationUntilDateHasExpired() {
+        IdentityProviderConfigEntityData data = dataBuilder
+            .withProvideAuthenticationUntil(expiredDatetime)
+            .build();
+        
+        assertThat(data.isAuthenticationEnabled()).isEqualTo(false);
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void shouldThrowInvalidFormatException_whenProvideAuthenticationUntilHasBeenSpecifiedButIsInvalid() {
+        IdentityProviderConfigEntityData data = dataBuilder.build();
+        data.provideAuthenticationUntil = "2020-09-09";
+        data.isAuthenticationEnabled();
     }
 
     @Test

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/IdentityProviderConfigDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/IdentityProviderConfigDataBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.config.domain.builders;
 
 
 import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
 import uk.gov.ida.hub.config.domain.LevelOfAssurance;
 import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
@@ -22,6 +23,9 @@ public class IdentityProviderConfigDataBuilder {
     private List<LevelOfAssurance> onboardingLevelsOfAssurance = ImmutableList.of();
     private List<LevelOfAssurance> supportedLevelsOfAssurance = ImmutableList.of(LevelOfAssurance.LEVEL_2);
     private boolean useExactComparisonType = false;
+    private String provideRegistrationUntil;
+    private String provideAuthenticationUntil;
+
     public static IdentityProviderConfigDataBuilder anIdentityProviderConfigData() {
         return new IdentityProviderConfigDataBuilder();
     }
@@ -40,7 +44,9 @@ public class IdentityProviderConfigDataBuilder {
                 transactionEntityIdsTemp,
                 onboardingLevelsOfAssurance,
                 supportedLevelsOfAssurance,
-                useExactComparisonType
+                useExactComparisonType,
+                provideRegistrationUntil,
+                provideAuthenticationUntil
         );
     }
 
@@ -61,6 +67,16 @@ public class IdentityProviderConfigDataBuilder {
 
     public IdentityProviderConfigDataBuilder withEnabled(boolean enabled) {
         this.enabled = enabled;
+        return this;
+    }
+    
+    public IdentityProviderConfigDataBuilder withProvideRegistrationUntil(DateTime provideRegistrationUntil) {
+        this.provideRegistrationUntil = provideRegistrationUntil.toString("yyyy-MM-dd'T'HH:mm:ssZZ");
+        return this;
+    }
+    
+    public IdentityProviderConfigDataBuilder withProvideAuthenticationUntil(DateTime provideAuthenticationUntil) {
+        this.provideAuthenticationUntil = provideAuthenticationUntil.toString("yyyy-MM-dd'T'HH:mm:ssZZ");
         return this;
     }
 
@@ -106,7 +122,9 @@ public class IdentityProviderConfigDataBuilder {
                 List<String> transactionEntityIdsTemp,
                 List<LevelOfAssurance> onboardingLevelsOfAssurance,
                 List<LevelOfAssurance> supportedLevelsOfAssurance,
-                boolean useExactComparisonType) {
+                boolean useExactComparisonType,
+                String provideRegistrationUntil,
+                String provideAuthenticationUntil) {
 
             this.entityId = entityId;
             this.simpleId = simpleId;
@@ -117,6 +135,8 @@ public class IdentityProviderConfigDataBuilder {
             this.onboardingTransactionEntityIdsTemp = transactionEntityIdsTemp;
             this.supportedLevelsOfAssurance = supportedLevelsOfAssurance;
             this.useExactComparisonType = useExactComparisonType;
+            this.provideRegistrationUntil = provideRegistrationUntil;
+            this.provideAuthenticationUntil = provideAuthenticationUntil;
         }
     }
 }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryPredicatesTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryPredicatesTest.java
@@ -49,7 +49,8 @@ public class IdpPredicateFactoryPredicatesTest {
 
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp,
                 nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp,
-                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity, 
+                nonOnboardingSoftDisconnectingIdp, nonOnboardingHardDisconnectingIdp};
 
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
@@ -64,9 +65,10 @@ public class IdpPredicateFactoryPredicatesTest {
 
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp,
                 nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
-                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity, 
+                onboardingSoftDisconnectingIdp, onboardingHardDisconnectingIdp,
+                nonOnboardingSoftDisconnectingIdp, nonOnboardingHardDisconnectingIdp};
 
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
-
 }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryTest.java
@@ -30,11 +30,13 @@ public class IdpPredicateFactoryTest {
         Predicate<Predicate> findEnabled = input -> input instanceof EnabledIdpPredicate;
         Predicate<Predicate> findOnboarding = input -> input instanceof OnboardingIdpPredicate;
         Predicate<Predicate> supportedLoa = input -> input instanceof SupportedLoaIdpPredicate;
+        Predicate<Predicate> findNewUserIdp = input -> input instanceof NewUserIdpPredicate;
 
-        assertThat(predicates).hasSize(3);
+        assertThat(predicates).hasSize(4);
         assertThat(Collections2.filter(predicates, findEnabled)).hasSize(1);
         assertThat(Collections2.filter(predicates, findOnboarding)).hasSize(1);
         assertThat(Collections2.filter(predicates, supportedLoa)).hasSize(1);
+        assertThat(Collections2.filter(predicates, findNewUserIdp)).hasSize(1);
     }
 
     @Test

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/NewUserIdpPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/NewUserIdpPredicateTest.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.hub.config.domain.filters;
+
+import com.google.common.base.Predicate;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
+
+
+public class NewUserIdpPredicateTest {
+	@Test
+	public void apply_shouldReturnTrue_whenIdpRegistrationIsEnabled() {
+		Predicate<IdentityProviderConfigEntityData> newUserIdpPredicate = new NewUserIdpPredicate();
+		
+		IdentityProviderConfigEntityData disconnectingIdp = anIdentityProviderConfigData()
+				.withProvideRegistrationUntil(DateTime.now().plusDays(1))
+				.build();
+		
+		assertThat(newUserIdpPredicate.apply(disconnectingIdp)).isTrue();
+	}
+	
+	@Test
+	public void apply_shouldReturnFalse_whenIdpRegistrationIsDisabled() {
+		Predicate<IdentityProviderConfigEntityData> newUserIdpPredicate = new NewUserIdpPredicate();
+		
+		IdentityProviderConfigEntityData disconnectingIdp = anIdentityProviderConfigData()
+				.withProvideRegistrationUntil(DateTime.now().minusDays(1))
+				.build();
+		
+		assertThat(newUserIdpPredicate.apply(disconnectingIdp)).isFalse();
+	}
+}

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicateTest.java
@@ -16,8 +16,12 @@ public class OnboardingIdpPredicateTest {
         final OnboardingIdpPredicate loa1Predicate = new OnboardingIdpPredicate(transactionEntityNonOnboarding, LevelOfAssurance.LEVEL_1);
         final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, loa1Predicate);
 
+        // Doesn't need to contain the onboardingSoftDisconnectingIdp or onboardingHardDisconnectingIdp because these IDPs onboard at all levels,
+        // meaning that the second check in the OnboardingIdpPredicate's apply function will be evaluated (to false), excluding the IDP from the
+        // result set.
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp,
-                nonOnboardingAllLevelsIdp, onboardingLoa2Idp, onboardingLoa2IdpOtherOnboardingEntity};
+                nonOnboardingAllLevelsIdp, onboardingLoa2Idp, onboardingLoa2IdpOtherOnboardingEntity,
+                nonOnboardingSoftDisconnectingIdp, nonOnboardingHardDisconnectingIdp};
 
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
@@ -28,7 +32,9 @@ public class OnboardingIdpPredicateTest {
         final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, loa1PredicateOnboarding);
 
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp,
-                onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa2IdpOtherOnboardingEntity};
+                onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa2IdpOtherOnboardingEntity,
+                onboardingSoftDisconnectingIdp, onboardingHardDisconnectingIdp, nonOnboardingSoftDisconnectingIdp,
+                nonOnboardingHardDisconnectingIdp};
 
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
@@ -39,8 +45,12 @@ public class OnboardingIdpPredicateTest {
         final OnboardingIdpPredicate signInPredicateNonOnboarding = new OnboardingIdpPredicate(transactionEntityNonOnboarding, null);
         final Set<IdentityProviderConfigEntityData> filteredIdps = getFilteredIdps(allIdps, signInPredicateNonOnboarding);
 
+        // Doesn't need to contain the onboardingSoftDisconnectingIdp or onboardingHardDisconnectingIdp because these IDPs onboard at all levels,
+        // meaning that the second check in the OnboardingIdpPredicate's apply function will be evaluated (to false), excluding the IDP from the
+        // result set.
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp,
-                onboardingLoa1Idp, onboardingLoa2Idp, onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+                onboardingLoa1Idp, onboardingLoa2Idp, onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity,
+                nonOnboardingSoftDisconnectingIdp, nonOnboardingHardDisconnectingIdp};
 
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }
@@ -53,7 +63,9 @@ public class OnboardingIdpPredicateTest {
 
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingLoa2Idp,
                 nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
-                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity};
+                onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity,
+                onboardingSoftDisconnectingIdp, onboardingHardDisconnectingIdp,
+                nonOnboardingSoftDisconnectingIdp, nonOnboardingHardDisconnectingIdp};
 
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/PredicateTestHelper.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/PredicateTestHelper.java
@@ -3,6 +3,7 @@ package uk.gov.ida.hub.config.domain.filters;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Sets;
+import org.joda.time.DateTime;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
 import uk.gov.ida.hub.config.domain.LevelOfAssurance;
 import uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder;
@@ -23,61 +24,98 @@ final class PredicateTestHelper {
     static final String transactionEntityNonOnboarding = "transactionEntityNonOnboarding";
     static final String transactionEntityOnboarding = "transactionEntityOnboarding";
     static final String transactionEntityOnboardingOther = "transactionEntityOnboardingOther";
+    
+    static final DateTime expiredDatetime = DateTime.now().minusDays(1);
+    static final DateTime futureDatetime = DateTime.now().plusDays(1);
 
-    static final IdentityProviderConfigEntityData nonOnboardingLoa1Idp = builder
+    static final IdentityProviderConfigEntityData nonOnboardingLoa1Idp = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Collections.singletonList(LevelOfAssurance.LEVEL_1))
             .withoutOnboarding()
             .withSimpleId("nonOnboardingLoa1Idp")
             .build();
 
-    static final IdentityProviderConfigEntityData nonOnboardingLoa2Idp = builder
+    static final IdentityProviderConfigEntityData nonOnboardingLoa2Idp = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Collections.singletonList(LevelOfAssurance.LEVEL_2))
             .withoutOnboarding()
             .withSimpleId("nonOnboardingLoa2Idp")
             .build();
 
-    static final IdentityProviderConfigEntityData nonOnboardingAllLevelsIdp = builder
+    static final IdentityProviderConfigEntityData nonOnboardingAllLevelsIdp = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withoutOnboarding()
             .withSimpleId("nonOnboardingAllLevelsIdp")
             .build();
 
-    static final IdentityProviderConfigEntityData onboardingLoa1Idp = builder
+    static final IdentityProviderConfigEntityData nonOnboardingSoftDisconnectingIdp = anIdentityProviderConfigData()
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withoutOnboarding()
+            .withProvideRegistrationUntil(expiredDatetime)
+            .withProvideAuthenticationUntil(futureDatetime)
+            .withSimpleId("nonOnboardingSoftDisconnectingIdp")
+            .build();
+
+    static final IdentityProviderConfigEntityData nonOnboardingHardDisconnectingIdp = anIdentityProviderConfigData()
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withoutOnboarding()
+            .withProvideRegistrationUntil(expiredDatetime)
+            .withProvideAuthenticationUntil(expiredDatetime)
+            .withSimpleId("nonOnboardingHardDisconnectingIdp")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingLoa1Idp = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_1))
             .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
             .withSimpleId("onboardingLoa1Idp")
             .build();
 
-    static final IdentityProviderConfigEntityData onboardingLoa1IdpOtherOnboardingEntity = builder
+    static final IdentityProviderConfigEntityData onboardingSoftDisconnectingIdp = anIdentityProviderConfigData()
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
+            .withProvideRegistrationUntil(expiredDatetime)
+            .withProvideAuthenticationUntil(futureDatetime)
+            .withSimpleId("onboardingSoftDisconnectingIdp")
+            .build();
+
+    static final IdentityProviderConfigEntityData onboardingHardDisconnectingIdp = anIdentityProviderConfigData()
+            .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboardingLevels(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
+            .withProvideRegistrationUntil(expiredDatetime)
+            .withProvideAuthenticationUntil(expiredDatetime)
+            .withSimpleId("onboardingHardDisconnectingIdp")
+            .build();
+    
+    static final IdentityProviderConfigEntityData onboardingLoa1IdpOtherOnboardingEntity = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_1))
             .withOnboarding(Collections.singletonList(transactionEntityOnboardingOther))
             .withSimpleId("onboardingLoa1IdpOtherOnboardingEntity")
             .build();
 
-    static final IdentityProviderConfigEntityData onboardingLoa2Idp = builder
+    static final IdentityProviderConfigEntityData onboardingLoa2Idp = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_2))
             .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
             .withSimpleId("onboardingLoa2Idp")
             .build();
 
-    static final IdentityProviderConfigEntityData onboardingLoa2IdpOtherOnboardingEntity = builder
+    static final IdentityProviderConfigEntityData onboardingLoa2IdpOtherOnboardingEntity = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_2))
             .withOnboarding(Collections.singletonList(transactionEntityOnboardingOther))
             .withSimpleId("onboardingLoa2IdpOtherOnboardingEntity")
             .build();
 
-    static final IdentityProviderConfigEntityData onboardingAllLevelsIdp = builder
+    static final IdentityProviderConfigEntityData onboardingAllLevelsIdp = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboardingLevels(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboarding(Collections.singletonList(transactionEntityOnboarding))
             .withSimpleId("onboardingAllLevelsIdp")
             .build();
 
-    static final IdentityProviderConfigEntityData onboardingAllLevelsIdpOtherOnboardingEntity = builder
+    static final IdentityProviderConfigEntityData onboardingAllLevelsIdpOtherOnboardingEntity = anIdentityProviderConfigData()
             .withSupportedLevelsOfAssurance(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboardingLevels(Arrays.asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .withOnboarding(Collections.singletonList(transactionEntityOnboardingOther))
@@ -85,8 +123,10 @@ final class PredicateTestHelper {
             .build();
 
     static final Set<IdentityProviderConfigEntityData> allIdps = new HashSet<>(Arrays.asList(nonOnboardingLoa1Idp,
-            nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp, onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp,
-            onboardingLoa1IdpOtherOnboardingEntity, onboardingLoa2IdpOtherOnboardingEntity, onboardingAllLevelsIdpOtherOnboardingEntity));
+            nonOnboardingLoa2Idp, nonOnboardingAllLevelsIdp, nonOnboardingSoftDisconnectingIdp, nonOnboardingHardDisconnectingIdp,
+            onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa1IdpOtherOnboardingEntity, 
+            onboardingLoa2IdpOtherOnboardingEntity, onboardingAllLevelsIdpOtherOnboardingEntity, onboardingSoftDisconnectingIdp,
+            onboardingHardDisconnectingIdp));
 
     static Set<IdentityProviderConfigEntityData> getFilteredIdps(Set<IdentityProviderConfigEntityData> idpSet,
                                                                  Set<Predicate<IdentityProviderConfigEntityData>> predicateSet) {

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicateTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/SupportedLoaIdpPredicateTest.java
@@ -18,7 +18,9 @@ public class SupportedLoaIdpPredicateTest {
 
         final IdentityProviderConfigEntityData[] expectedFilteredIdps = {nonOnboardingLoa1Idp, nonOnboardingAllLevelsIdp,
                 onboardingLoa1Idp, onboardingLoa2Idp, onboardingAllLevelsIdp, onboardingLoa1IdpOtherOnboardingEntity,
-                onboardingLoa2IdpOtherOnboardingEntity, onboardingAllLevelsIdpOtherOnboardingEntity};
+                onboardingLoa2IdpOtherOnboardingEntity, onboardingAllLevelsIdpOtherOnboardingEntity, 
+                nonOnboardingSoftDisconnectingIdp, nonOnboardingHardDisconnectingIdp, onboardingSoftDisconnectingIdp,
+                onboardingHardDisconnectingIdp};
 
         assertThat(filteredIdps).containsOnly(expectedFilteredIdps);
     }


### PR DESCRIPTION
This PR updates the config service to handle the two new properties `provideRegistrationUntil` and `provideAuthenticationUntil` that can be set in IDP configurations. For the LOA endpoint, all IDPs will now be returned up until `provideRegistrationUntil`. For the sign-in endpoint, all IDPs will continue to be returned with an additional property `authenticationEnabled`, based on the `provideAuthenticationUntil` property.

The PR also includes a cherry-picked commit from @kerrr (on the recommendation of @rhowe-gds ) to fix the failing test in IdpMetadataPublicKeyStoreTest.java (on Travis).