### PR TITLE
EID-1004: Fix switching between Verify and eIDAS journeys (part 2/2)

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/AuthnRequestFromTransactionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/AuthnRequestFromTransactionResourceIntegrationTest.java
@@ -176,11 +176,11 @@ public class AuthnRequestFromTransactionResourceIntegrationTest {
     }
 
     @Test
-    public void shouldRestartEidasJourney() {
+    public void shouldRestartIdpJourney() {
         sessionId = SessionId.createNewSessionId();
-        TestSessionResourceHelper.createSessionInEidasAuthnFailedErrorState(sessionId, client, buildUriForTestSession(EIDAS_AUTHN_FAILED_STATE, sessionId));
+        TestSessionResourceHelper.createSessionInIdpSelectedState(sessionId, samlResponse.getIssuer(), idpEntityId, client, buildUriForTestSession(IDP_SELECTED_STATE, sessionId));
 
-        URI uri = UriBuilder.fromPath("/policy/received-authn-request" + Urls.PolicyUrls.AUTHN_REQUEST_RESTART_EIDAS_JOURNEY_PATH).build(sessionId);
+        URI uri = UriBuilder.fromPath("/policy/received-authn-request" + Urls.PolicyUrls.AUTHN_REQUEST_RESTART_JOURNEY_PATH).build(sessionId);
         Response response = client.target(policy.uri(uri.toASCIIString())).request().post(null);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
@@ -190,7 +190,7 @@ public class AuthnRequestFromTransactionResourceIntegrationTest {
     }
 
     @Test
-    public void shouldRestartJourney() {
+    public void shouldRestartEidasJourney() {
         sessionId = SessionId.createNewSessionId();
         TestSessionResourceHelper.createSessionInEidasAuthnFailedErrorState(sessionId, client, buildUriForTestSession(EIDAS_AUTHN_FAILED_STATE, sessionId));
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/Urls.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/Urls.java
@@ -83,9 +83,6 @@ public interface Urls {
 
         // End of new saml-engine is a real microservice resources
 
-        // TODO: Remove after a frontend release for ZDD
-        String AUTHN_REQUEST_RESTART_EIDAS_JOURNEY_PATH = AUTHN_SESSION_ID_PATH + "/restart-eidas-journey";
-
         String AUTHN_REQUEST_RESTART_JOURNEY_PATH = AUTHN_SESSION_ID_PATH + "/restart-journey";
         String AUTHN_REQUEST_TRY_ANOTHER_IDP_PATH = AUTHN_SESSION_ID_PATH + "/try-another-idp";
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 
 import static uk.gov.ida.hub.policy.domain.exception.StateProcessingValidationException.wrongResponseIssuer;
 
-public class IdpSelectedStateController implements StateController, ErrorResponsePreparedStateController, IdpSelectingStateController, AuthnRequestCapableController {
+public class IdpSelectedStateController implements ErrorResponsePreparedStateController, IdpSelectingStateController, AuthnRequestCapableController, RestartJourneyStateController {
 
     private final IdpSelectedState state;
     private final HubEventLogger hubEventLogger;
@@ -323,5 +323,12 @@ public class IdpSelectedStateController implements StateController, ErrorRespons
         return new AuthnRequestSignInProcess(
                 state.getRequestIssuerEntityId(),
                 state.getTransactionSupportsEidas());
+    }
+
+    @Override
+    public void transitionToSessionStartedState() {
+        final SessionStartedState sessionStartedState = createSessionStartedState();
+        stateTransitionAction.transitionTo(sessionStartedState);
+        hubEventLogger.logSessionMovedToStartStateEvent(sessionStartedState);
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCountrySelectedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCountrySelectedState.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 
-public class EidasCountrySelectedState extends AbstractState implements EidasCountrySelectingState, Serializable, RestartJourneyState {
+public class EidasCountrySelectedState extends AbstractState implements EidasCountrySelectingState, RestartJourneyState, Serializable {
 
     private static final long serialVersionUID = -285602589000108606L;
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/IdpSelectedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/IdpSelectedState.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 
-public class IdpSelectedState extends AbstractState implements IdpSelectingState, Serializable {
+public class IdpSelectedState extends AbstractState implements IdpSelectingState, RestartJourneyState, Serializable {
 
     private static final long serialVersionUID = -2851353851977677375L;
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/resources/AuthnRequestFromTransactionResource.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/resources/AuthnRequestFromTransactionResource.java
@@ -49,14 +49,6 @@ public class AuthnRequestFromTransactionResource {
         authnRequestFromTransactionHandler.tryAnotherIdp(sessionId);
     }
 
-    // TODO: Remove after a frontend release for ZDD
-    @POST
-    @Path(Urls.PolicyUrls.AUTHN_REQUEST_RESTART_EIDAS_JOURNEY_PATH)
-    @Timed
-    public void restartEidasJourney(@PathParam(SESSION_ID_PARAM) SessionId sessionId) {
-        authnRequestFromTransactionHandler.restartJourney(sessionId);
-    }
-
     @POST
     @Path(Urls.PolicyUrls.AUTHN_REQUEST_RESTART_JOURNEY_PATH)
     @Timed

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.hub.policy.builder.MatchingServiceConfigEntityDataDtoBuilder.aMatchingServiceConfigEntityDataDto;
@@ -191,6 +192,19 @@ public class IdpSelectedStateControllerTest {
         ArgumentCaptor<State> stateArgumentCaptor = ArgumentCaptor.forClass(State.class);
         verify(stateTransitionAction).transitionTo(stateArgumentCaptor.capture());
         assertThat(stateArgumentCaptor.getValue()).isInstanceOf(PausedRegistrationState.class);
+    }
+
+    @Test
+    public void shouldTransitionToSessionStartedStateAndLogEvent() {
+        controller.transitionToSessionStartedState();
+        ArgumentCaptor<SessionStartedState> capturedState = ArgumentCaptor.forClass(SessionStartedState.class);
+
+        verify(stateTransitionAction, times(1)).transitionTo(capturedState.capture());
+        verify(hubEventLogger, times(1)).logSessionMovedToStartStateEvent(capturedState.getValue());
+
+        assertThat(capturedState.getValue().getSessionId()).isEqualTo(idpSelectedState.getSessionId());
+        assertThat(capturedState.getValue().getRequestIssuerEntityId()).isEqualTo(idpSelectedState.getRequestIssuerEntityId());
+        assertThat(capturedState.getValue().getForceAuthentication()).isEqualTo(idpSelectedState.getForceAuthentication());
     }
 
     @Test(expected = IdpDisabledException.class)


### PR DESCRIPTION
Currently, if a user selects an IDP without completing verification and clicks the back button to the journey picker page and then attempts an eIDAS journey, they receive a "service unavailable" error page as Policy doesn't allow transitions from `IdpSelected` to `EidasCountrySelected` states. The solution to this is to allow the frontend to ask Policy to restart the journey back to `SessionStartedState` when a user goes back to the journey picker page (`/prove-identity`) and selects a an eIDAS journey. We already allow this for eIDAS journeys when a user goes back and selects a Verify journey.

This piece of work enables transitions from a Verify journey to an eIDAS journey. Transitions on the opposite direction were enabled in [part 1](https://github.com/alphagov/verify-hub/pull/155).

Summary of changes:
  - Remove the no longer used restart-eidas-journey references as they have been generalised to restart-journey
  - Make the `IdpSelected` state and controller implement the `RestartJourney` interface to give the `IdpSelectedState` the ability to be reset to `SessionStartedState`
  - Add tests to reflect the above changes

_Note: This has to be merged and released after the related changes in alphagov/verify-hub#155 and alphagov/verify-frontend#589_