### PR TITLE
BAU: Change test behaviour when no Eidas Metadata.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-44",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-34',
-            saml_libs:"$opensaml_version-159",
+            saml_libs:"$opensaml_version-160",
         ]
 
 subprojects {


### PR DESCRIPTION
Uplift verify-saml-libs version to import changes in the library.

https://github.com/alphagov/verify-saml-libs/commit/d6f871b7d942e828e0ba6ec90032959aac847687

Healthcheck and unit tests now succeed when there are no trust anchors.
Changed healthcheck output to be more structured.
Returns details on each failure.

Co-authored-by: Simon Worthington <simon.worthington@digital.cabinet-office.gov.uk>
Co-authored-by: dbes-gds <daniel.besbrode@digital.cabinet-office.gov.uk>