### PR TITLE
BAU: Rationalise Java SDK versions used by Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,11 @@ env:
   - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
   - openjdk8
-  - openjdk9
   - openjdk10
   - openjdk11
 matrix:
   allow_failures:
-  - jdk: oraclejdk9
-  - jdk: oraclejdk10
-  - jdk: openjdk9
-  - jdk: openjdk10
   - jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Oracle JDK10 now end of life.
Java 9 SDKs not required to be supported by the Hub.
openjdk10 failures not ignored.