### PR TITLE
HUB-274: Support alternative service URLs in single IDP journeys

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfigEntityData.java
@@ -103,6 +103,10 @@ public class TransactionConfigEntityData implements ConfigEntityData, Certificat
     @JsonProperty
     protected URI headlessStartpage;
 
+    @Valid
+    @JsonProperty
+    protected URI singleIdpStartpage;
+
     @SuppressWarnings("unused") // needed to prevent guice injection
     protected TransactionConfigEntityData() {
     }
@@ -220,5 +224,9 @@ public class TransactionConfigEntityData implements ConfigEntityData, Certificat
 
     public URI getHeadlessStartpage() {
         return headlessStartpage;
+    }
+
+    public Optional<URI> getSingleIdpStartPage() {
+        return ofNullable(singleIdpStartpage);
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/dto/TransactionSingleIdpData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/dto/TransactionSingleIdpData.java
@@ -6,28 +6,28 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
-public class TransactionDetailedDisplayData {
+public class TransactionSingleIdpData {
     private String simpleId;
-    private URI serviceHomepage;
+    private URI redirectUrl;
     private List<LevelOfAssurance> loaList;
     private String entityId;
 
     // Needed by jaxb for integration test :(
-    protected TransactionDetailedDisplayData() {
+    protected TransactionSingleIdpData() {
     }
 
-    public TransactionDetailedDisplayData(String simpleId,
-                                          URI serviceHomepage,
-                                          List<LevelOfAssurance> loaList,
-                                          String entityId) {
+    public TransactionSingleIdpData(String simpleId,
+                                    URI redirectUrl,
+                                    List<LevelOfAssurance> loaList,
+                                    String entityId) {
 
         this.simpleId = simpleId;
-        this.serviceHomepage = serviceHomepage;
+        this.redirectUrl = redirectUrl;
         this.loaList = loaList;
         this.entityId = entityId;
     }
 
-    public URI getServiceHomepage() { return serviceHomepage; }
+    public URI getRedirectUrl() { return redirectUrl; }
 
     public Optional<String> getSimpleId() {
         return Optional.ofNullable(simpleId);

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/TransactionsResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/TransactionsResource.java
@@ -10,7 +10,7 @@ import uk.gov.ida.hub.config.domain.TranslationData;
 import uk.gov.ida.hub.config.domain.UserAccountCreationAttribute;
 import uk.gov.ida.hub.config.dto.MatchingProcessDto;
 import uk.gov.ida.hub.config.dto.ResourceLocationDto;
-import uk.gov.ida.hub.config.dto.TransactionDetailedDisplayData;
+import uk.gov.ida.hub.config.dto.TransactionSingleIdpData;
 import uk.gov.ida.hub.config.dto.TransactionDisplayData;
 import uk.gov.ida.hub.config.exceptions.ExceptionFactory;
 
@@ -113,13 +113,13 @@ public class TransactionsResource {
     @GET
     @Path(Urls.ConfigUrls.SINGLE_IDP_ENABLED_LIST_PATH)
     @Timed
-    public List<TransactionDetailedDisplayData> getSingleIDPEnabledServiceListTransactions(){
+    public List<TransactionSingleIdpData> getSingleIDPEnabledServiceListTransactions(){
         Set<TransactionConfigEntityData> allData = transactionConfigEntityDataRepository.getAllData();
         return allData.stream()
                 .filter(TransactionConfigEntityData::isEnabled)
                 .filter(TransactionConfigEntityData::isEnabledForSingleIdp)
-                .map(t -> new TransactionDetailedDisplayData(t.getSimpleId().orElse(null),
-                        t.getServiceHomepage(),
+                .map(t -> new TransactionSingleIdpData(t.getSimpleId().orElse(null),
+                        t.getSingleIdpStartPage().orElse(t.getServiceHomepage()),
                         t.getLevelsOfAssurance(),
                         t.getEntityId())
                 )

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/TransactionConfigEntityDataBuilder.java
@@ -33,6 +33,8 @@ public class TransactionConfigEntityDataBuilder {
     private boolean eidasEnabled = false;
     private boolean shouldSignWithSHA1 = true;
     private URI headlessStartPage = URI.create("/headless-start-uri");
+    private URI singleIdpStartPage;
+
 
     public static TransactionConfigEntityDataBuilder aTransactionConfigData() {
         return new TransactionConfigEntityDataBuilder();
@@ -63,7 +65,8 @@ public class TransactionConfigEntityDataBuilder {
                 shouldHubSignResponseMessages,
                 levelsOfAssurance,
                 shouldSignWithSHA1,
-                headlessStartPage
+                headlessStartPage,
+                singleIdpStartPage
         );
     }
 
@@ -152,6 +155,11 @@ public class TransactionConfigEntityDataBuilder {
         return this;
     }
 
+    public TransactionConfigEntityDataBuilder withSingleIdpStartPage(final URI singleIdpStartPage) {
+        this.singleIdpStartPage = singleIdpStartPage;
+        return this;
+    }
+
     @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
     private static class TestTransactionConfigEntityData extends TransactionConfigEntityData {
 
@@ -171,7 +179,8 @@ public class TransactionConfigEntityDataBuilder {
                 boolean shouldHubSignResponseMessages,
                 List<LevelOfAssurance> levelsOfAssurance,
                 boolean shouldSignWithSHA1,
-                URI headlessStartPage) {
+                URI headlessStartPage,
+                URI singleIdpStartPage) {
             this.serviceHomepage = serviceHomepage;
             this.entityId = entityId;
             this.simpleId = simpleId;
@@ -190,6 +199,7 @@ public class TransactionConfigEntityDataBuilder {
             this.levelsOfAssurance = levelsOfAssurance;
             this.shouldSignWithSHA1 = shouldSignWithSHA1;
             this.headlessStartpage = headlessStartPage;
+            this.singleIdpStartpage = singleIdpStartPage;
         }
     }
 }


### PR DESCRIPTION
Amend TransactionDisplayData and TransactionConfigEntityData to include new singleIdpStartpage attribute
Amend TransactionResource to populate this new field in calls.

Co-authored-by: Callum Knights <callum.knights@digital.cabinet-office.gov.uk>