### PR TITLE
EID-1088 Allow usage of DuplicateAuthnRequestValidator outside of Hub

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidator.java
@@ -2,18 +2,24 @@ package uk.gov.ida.saml.hub.validators.authnrequest;
 
 import com.google.inject.Inject;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
 import uk.gov.ida.saml.hub.configuration.SamlDuplicateRequestValidationConfiguration;
 
 import java.util.concurrent.ConcurrentMap;
 
 public class DuplicateAuthnRequestValidator {
     private final ConcurrentMap<AuthnRequestIdKey, DateTime> previousRequestKeys;
-    private final SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration;
+    private final Duration expirationDuration;
 
     @Inject
     public DuplicateAuthnRequestValidator(ConcurrentMap<AuthnRequestIdKey, DateTime> duplicateIds, SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration) {
+        this(duplicateIds, Duration.millis(samlDuplicateRequestValidationConfiguration.getAuthnRequestIdExpirationDuration().toMilliseconds()));
+    }
+
+    public DuplicateAuthnRequestValidator(ConcurrentMap<AuthnRequestIdKey, DateTime> duplicateIds, Duration authnRequestIdExpirationDuration) {
         this.previousRequestKeys = duplicateIds;
-        this.samlDuplicateRequestValidationConfiguration = samlDuplicateRequestValidationConfiguration;
+        this.expirationDuration = authnRequestIdExpirationDuration;
     }
 
     public boolean valid(String requestId) {
@@ -22,7 +28,7 @@ public class DuplicateAuthnRequestValidator {
         if (previousRequestKeys.containsKey(key) && previousRequestKeys.get(key).isAfter(DateTime.now())) {
             return false;
         }
-        DateTime expire = DateTime.now().plus(samlDuplicateRequestValidationConfiguration.getAuthnRequestIdExpirationDuration().toMilliseconds());
+        DateTime expire = DateTime.now().plus(expirationDuration);
         previousRequestKeys.put(key, expire);
         return true;
     }


### PR DESCRIPTION
- Also support instantiating a validator with just
  a simple `Duration` object.