### PR TITLE
EID-1117 - Turn DuplicateAssertionValidator into interface

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidator.java
@@ -1,41 +1,9 @@
 package uk.gov.ida.saml.core.validators.assertion;
 
-import com.google.inject.Inject;
-import org.joda.time.DateTime;
 import org.opensaml.saml.saml2.core.Assertion;
-import uk.gov.ida.saml.hub.exception.SamlValidationException;
 
-import java.util.concurrent.ConcurrentMap;
+public interface DuplicateAssertionValidator {
+    void validateAuthnStatementAssertion(Assertion assertion);
 
-import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnStatementAlreadyReceived;
-import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.duplicateMatchingDataset;
-
-public class DuplicateAssertionValidator {
-
-    private final ConcurrentMap<String, DateTime> duplicateIds;
-
-    @Inject
-    public DuplicateAssertionValidator(ConcurrentMap<String, DateTime> duplicateIds) {
-        this.duplicateIds = duplicateIds;
-    }
-
-    public void validateAuthnStatementAssertion(Assertion assertion) {
-        if (!valid(assertion)) throw new SamlValidationException(authnStatementAlreadyReceived(assertion.getID()));
-    }
-
-    public void validateMatchingDataSetAssertion(Assertion assertion, String responseIssuerId) {
-        if (!valid(assertion)) throw new SamlValidationException(duplicateMatchingDataset(assertion.getID(), responseIssuerId));
-    }
-
-    private boolean valid(Assertion assertion) {
-        if (isDuplicateNonExpired(assertion)) return false;
-
-        DateTime expire = assertion.getSubject().getSubjectConfirmations().get(0).getSubjectConfirmationData().getNotOnOrAfter();
-        duplicateIds.put(assertion.getID(), expire);
-        return true;
-    }
-
-    private boolean isDuplicateNonExpired(Assertion assertion) {
-        return duplicateIds.containsKey(assertion.getID()) && duplicateIds.get(assertion.getID()).isAfter(DateTime.now());
-    }
+    void validateMatchingDataSetAssertion(Assertion assertion, String responseIssuerId);
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidatorImpl.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidatorImpl.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.saml.core.validators.assertion;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.Assertion;
+import uk.gov.ida.saml.hub.exception.SamlValidationException;
+
+import java.util.concurrent.ConcurrentMap;
+
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.authnStatementAlreadyReceived;
+import static uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory.duplicateMatchingDataset;
+
+public class DuplicateAssertionValidatorImpl implements DuplicateAssertionValidator {
+
+    private final ConcurrentMap<String, DateTime> duplicateIds;
+
+    @Inject
+    public DuplicateAssertionValidatorImpl(ConcurrentMap<String, DateTime> duplicateIds) {
+        this.duplicateIds = duplicateIds;
+    }
+
+    @Override
+    public void validateAuthnStatementAssertion(Assertion assertion) {
+        if (!valid(assertion))
+            throw new SamlValidationException(authnStatementAlreadyReceived(assertion.getID()));
+    }
+
+    @Override
+    public void validateMatchingDataSetAssertion(Assertion assertion, String responseIssuerId) {
+        if (!valid(assertion))
+            throw new SamlValidationException(duplicateMatchingDataset(assertion.getID(), responseIssuerId));
+    }
+
+    private boolean valid(Assertion assertion) {
+        if (isDuplicateNonExpired(assertion))
+            return false;
+
+        DateTime expire = assertion.getSubject().getSubjectConfirmations().get(0).getSubjectConfirmationData().getNotOnOrAfter();
+        duplicateIds.put(assertion.getID(), expire);
+        return true;
+    }
+
+    private boolean isDuplicateNonExpired(Assertion assertion) {
+        return duplicateIds.containsKey(assertion.getID()) && duplicateIds.get(assertion.getID()).isAfter(DateTime.now());
+    }
+}

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
@@ -27,7 +27,7 @@ import uk.gov.ida.saml.core.validators.DestinationValidator;
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.core.validators.assertion.AssertionValidator;
 import uk.gov.ida.saml.core.validators.assertion.AuthnStatementAssertionValidator;
-import uk.gov.ida.saml.core.validators.assertion.DuplicateAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.DuplicateAssertionValidatorImpl;
 import uk.gov.ida.saml.core.validators.assertion.IPAddressValidator;
 import uk.gov.ida.saml.core.validators.assertion.IdentityProviderAssertionValidator;
 import uk.gov.ida.saml.core.validators.assertion.MatchingDatasetAssertionValidator;
@@ -549,9 +549,9 @@ public class HubTransformersFactory {
                         new AssertionAttributeStatementValidator(),
                         new AssertionSubjectConfirmationValidator()
                 ),
-                new MatchingDatasetAssertionValidator(new DuplicateAssertionValidator(assertionIdCache)),
+                new MatchingDatasetAssertionValidator(new DuplicateAssertionValidatorImpl(assertionIdCache)),
                 new AuthnStatementAssertionValidator(
-                        new DuplicateAssertionValidator(assertionIdCache)
+                        new DuplicateAssertionValidatorImpl(assertionIdCache)
                 ),
                 new IPAddressValidator(),
                 hubEntityId

--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/validators/assertion/DuplicateAssertionValidatorTest.java
@@ -38,7 +38,7 @@ public class DuplicateAssertionValidatorTest {
         duplicateIds.put("duplicate", DateTime.now().plusMinutes(5));
         duplicateIds.put("expired-duplicate", DateTime.now().minusMinutes(2));
 
-        duplicateAssertionValidator = new DuplicateAssertionValidator(duplicateIds);
+        duplicateAssertionValidator = new DuplicateAssertionValidatorImpl(duplicateIds);
     }
 
     @Test

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -76,7 +76,7 @@ import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSi
 import uk.gov.ida.saml.core.validators.DestinationValidator;
 import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
 import uk.gov.ida.saml.core.validators.assertion.AuthnStatementAssertionValidator;
-import uk.gov.ida.saml.core.validators.assertion.DuplicateAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.DuplicateAssertionValidatorImpl;
 import uk.gov.ida.saml.core.validators.assertion.IdentityProviderAssertionValidator;
 import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
 import uk.gov.ida.saml.core.validators.subjectconfirmation.AssertionSubjectConfirmationValidator;
@@ -695,7 +695,7 @@ public class SamlEngineModule extends AbstractModule {
                 ),
                 new EidasAttributeStatementAssertionValidator(),
                 new AuthnStatementAssertionValidator(
-                        new DuplicateAssertionValidator(assertionIdCache)
+                        new DuplicateAssertionValidatorImpl(assertionIdCache)
                 ),
                 new EidasAuthnResponseIssuerValidator(),
                 destination.toString())


### PR DESCRIPTION
- So it can be used with a different implementation in proxy node

Co-authored-by: Simon Worthington <simon.worthington@digital.cabinet-office.gov.uk>