### PR TITLE
Hub 348 expose notonorafter

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/InboundResponseFromIdpData.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/InboundResponseFromIdpData.java
@@ -1,8 +1,9 @@
 package uk.gov.ida.saml.core.domain;
 
-import java.util.Optional;
-
+import org.joda.time.DateTime;
 import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
+
+import java.util.Optional;
 
 public class InboundResponseFromIdpData {
     private IdpIdaStatus.Status status;
@@ -15,6 +16,7 @@ public class InboundResponseFromIdpData {
     private String levelOfAssurance;
     private Optional<String> idpFraudEventId;
     private Optional<String> fraudIndicator;
+    private Optional<DateTime> notOnOrAfter;
 
     public InboundResponseFromIdpData(
             IdpIdaStatus.Status status,
@@ -26,7 +28,8 @@ public class InboundResponseFromIdpData {
             Optional<String> principalIpAddressAsSeenByIdp,
             String levelOfAssurance,
             Optional<String> idpFraudEventId,
-            Optional<String> fraudIndicator) {
+            Optional<String> fraudIndicator,
+            Optional<DateTime> notOnOrAfter) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.issuer = issuer;
@@ -37,6 +40,8 @@ public class InboundResponseFromIdpData {
         this.levelOfAssurance = levelOfAssurance;
         this.idpFraudEventId = idpFraudEventId;
         this.fraudIndicator = fraudIndicator;
+        this.notOnOrAfter = notOnOrAfter;
+
     }
 
     protected InboundResponseFromIdpData() {}
@@ -80,4 +85,9 @@ public class InboundResponseFromIdpData {
     public Optional<String> getEncryptedMatchingDatasetAssertion() {
         return encryptedMatchingDatasetAssertion;
     }
+
+    public Optional<DateTime> getNotOnOrAfter() {
+        return notOnOrAfter;
+    }
+
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromIdp.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromIdp.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 public class InboundResponseFromIdp extends IdaSamlResponse {
     private Optional<PassthroughAssertion> matchingDatasetAssertion;
     private Optional<PassthroughAssertion> authnStatementAssertion;
+    private Optional<DateTime> notOnOrAfter;
     private Optional<Signature> signature;
     private IdpIdaStatus status;
 
@@ -26,6 +27,7 @@ public class InboundResponseFromIdp extends IdaSamlResponse {
             URI destination,
             Optional<PassthroughAssertion> authnStatementAssertion) {
         super(id, issueInstant, inResponseTo, issuer, destination);
+        this.notOnOrAfter = notOnOrAfter;
         this.signature = signature;
         this.matchingDatasetAssertion = matchingDatasetAssertion;
         this.authnStatementAssertion = authnStatementAssertion;
@@ -48,4 +50,7 @@ public class InboundResponseFromIdp extends IdaSamlResponse {
         return status;
     }
 
+    public Optional<DateTime> getNotOnOrAfter() {
+        return notOnOrAfter;
+    }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromIdp.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/InboundResponseFromIdp.java
@@ -19,6 +19,7 @@ public class InboundResponseFromIdp extends IdaSamlResponse {
             String inResponseTo,
             String issuer,
             DateTime issueInstant,
+            Optional<DateTime> notOnOrAfter,
             IdpIdaStatus status,
             Optional<Signature> signature,
             Optional<PassthroughAssertion> matchingDatasetAssertion,

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
@@ -36,6 +36,7 @@ public class IdaResponseFromIdpUnmarshaller {
                 validatedResponse.getInResponseTo(),
                 validatedResponse.getIssuer().getValue(),
                 validatedResponse.getIssueInstant(),
+                validatedAssertions.getMatchingDatasetAssertion().flatMap(a -> Optional.ofNullable(a.getConditions().getNotOnOrAfter())),
                 transformedStatus,
                 Optional.ofNullable(validatedResponse.getSignature()),
                 matchingDatasetAssertion,

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
@@ -30,7 +30,6 @@ public class IdaResponseFromIdpUnmarshaller {
         IdpIdaStatus transformedStatus = statusUnmarshaller.fromSaml(validatedResponse.getStatus());
         URI destination = URI.create(validatedResponse.getDestination());
 
-
         return new InboundResponseFromIdp(
                 validatedResponse.getID(),
                 validatedResponse.getInResponseTo(),

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshaller.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.saml.hub.transformers.inbound;
 
+import org.joda.time.DateTime;
 import uk.gov.ida.saml.core.domain.PassthroughAssertion;
 import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
 import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
@@ -29,13 +30,17 @@ public class IdaResponseFromIdpUnmarshaller {
 
         IdpIdaStatus transformedStatus = statusUnmarshaller.fromSaml(validatedResponse.getStatus());
         URI destination = URI.create(validatedResponse.getDestination());
+        Optional<DateTime> notOnOrAfter = validatedAssertions.getMatchingDatasetAssertion()
+                .flatMap(a -> Optional.ofNullable(a.getConditions()))
+                .flatMap(c -> Optional.ofNullable(c.getNotOnOrAfter()));
+
 
         return new InboundResponseFromIdp(
                 validatedResponse.getID(),
                 validatedResponse.getInResponseTo(),
                 validatedResponse.getIssuer().getValue(),
                 validatedResponse.getIssueInstant(),
-                validatedAssertions.getMatchingDatasetAssertion().flatMap(a -> Optional.ofNullable(a.getConditions().getNotOnOrAfter())),
+                notOnOrAfter,
                 transformedStatus,
                 Optional.ofNullable(validatedResponse.getSignature()),
                 matchingDatasetAssertion,

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromIdpDataGenerator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromIdpDataGenerator.java
@@ -58,6 +58,6 @@ public class InboundResponseFromIdpDataGenerator {
                 levelOfAssurance,
                 idpFraudEventId,
                 fraudIndicator,
-                Optional.empty());
+                idaResponseFromIdp.getNotOnOrAfter());
     }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromIdpDataGenerator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/InboundResponseFromIdpDataGenerator.java
@@ -57,6 +57,7 @@ public class InboundResponseFromIdpDataGenerator {
                 principalIpAddressFromIdp,
                 levelOfAssurance,
                 idpFraudEventId,
-                fraudIndicator);
+                fraudIndicator,
+                Optional.empty());
     }
 }

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
@@ -391,7 +391,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
 
     private void stubSamlEngineTranslationLOAForCountry(final LevelOfAssurance loa, final EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        InboundResponseFromCountry translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa));
+        InboundResponseFromCountry translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa), Optional.absent());
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
@@ -102,7 +102,7 @@ public class EidasSessionResourceIntegrationTest {
         Response response = postAuthnResponseToPolicy(sessionId);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        ResponseAction expectedResult = ResponseAction.success(sessionId, false, LevelOfAssurance.LEVEL_2);
+        ResponseAction expectedResult = ResponseAction.success(sessionId, false, LevelOfAssurance.LEVEL_2, null);
         assertThat(response.readEntity(ResponseAction.class)).isEqualToComparingFieldByField(expectedResult);
 
         assertThatCurrentStateForSesssionIs(sessionId, EidasCycle0And1MatchRequestSentState.class);
@@ -199,13 +199,13 @@ public class EidasSessionResourceIntegrationTest {
 
     private void stubSamlEngineTranslationLOAForCountry(LevelOfAssurance loa, EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa));
+        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.absent(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa), Optional.absent());
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 
     private void stubSamlEngineTranslationToFailForCountry(EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Failure, Optional.absent(), country.getEntityId(), Optional.absent(), Optional.absent(), Optional.absent());
+        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Failure, Optional.absent(), country.getEntityId(), Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent());
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionResourceAuthnResponseFromIdpIntegrationTests.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionResourceAuthnResponseFromIdpIntegrationTests.java
@@ -177,7 +177,7 @@ public class SessionResourceAuthnResponseFromIdpIntegrationTests {
         samlEngineStub.setupStubForAttributeQueryRequest(AttributeQueryContainerDtoBuilder.anAttributeQueryContainerDto().build());
         samlSoapProxyStub.setUpStubForSendHubMatchingServiceRequest(sessionId);
         Response response = postIdpResponse(sessionId, samlResponseDto);
-        ResponseAction expected = ResponseAction.success(sessionId, true, loaAchieved);
+        ResponseAction expected = ResponseAction.success(sessionId, true, loaAchieved, null);
         ResponseAction actualResponseAction = response.readEntity(ResponseAction.class);
         assertThat(actualResponseAction).isEqualToComparingFieldByField(expected);
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionResourceIntegrationTest.java
@@ -303,7 +303,7 @@ public class SessionResourceIntegrationTest {
                 .post(Entity.json(aSamlAuthnResponseContainerDto().withSessionId(sessionId).build()));
 
         //Then
-        ResponseAction expectedResult = ResponseAction.success(sessionId, true, loaAchieved);
+        ResponseAction expectedResult = ResponseAction.success(sessionId, true, loaAchieved, null);
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
         ResponseAction actualResult = response.readEntity(ResponseAction.class);
         assertThat(actualResult).isEqualToComparingFieldByField(expectedResult);

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/InboundResponseFromIdpDtoBuilder.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/builders/InboundResponseFromIdpDtoBuilder.java
@@ -10,33 +10,52 @@ public class InboundResponseFromIdpDtoBuilder {
         return buildDTO(IdpIdaStatus.Status.Success,
                 idpEntityId,
                 Optional.of(levelOfAssurance),
-                Optional.<String>absent());
+                Optional.<String>absent(),
+                Optional.absent());
+    }
+
+    public static InboundResponseFromIdpDto successResponse(String idpEntityId, LevelOfAssurance levelOfAssurance, String notOnOrAfter) {
+        return buildDTO(IdpIdaStatus.Status.Success,
+                idpEntityId,
+                Optional.of(levelOfAssurance),
+                Optional.<String>absent(),
+                Optional.of(notOnOrAfter));
     }
 
     public static InboundResponseFromIdpDto errorResponse(String idpEntityId, IdpIdaStatus.Status status) {
         return buildDTO(status, idpEntityId,
                 Optional.of(LevelOfAssurance.LEVEL_2),
+                Optional.<String>absent(),
                 Optional.<String>absent());
     }
 
     public static InboundResponseFromIdpDto fraudResponse(String idpEntityId) {
-        return buildDTO(IdpIdaStatus.Status.RequesterError, idpEntityId,
+        return buildDTO(IdpIdaStatus.Status.RequesterError,
+                idpEntityId,
                 Optional.of(LevelOfAssurance.LEVEL_X),
-                Optional.of("fraudIndicator"));
+                Optional.of("fraudIndicator"),
+                Optional.<String>absent());
     }
 
     public static InboundResponseFromIdpDto failedResponse(String idpEntityId) {
-        return buildDTO(IdpIdaStatus.Status.AuthenticationFailed, idpEntityId, Optional.of(LevelOfAssurance.LEVEL_2), Optional.<String>absent());
+        return buildDTO(IdpIdaStatus.Status.AuthenticationFailed,
+                idpEntityId, Optional.of(LevelOfAssurance.LEVEL_2),
+                Optional.<String>absent(),
+                Optional.<String>absent());
     }
 
     public static InboundResponseFromIdpDto noAuthnContextResponse(String idpEntityId) {
-        return buildDTO(IdpIdaStatus.Status.NoAuthenticationContext, idpEntityId, Optional.<LevelOfAssurance>absent(),
+        return buildDTO(IdpIdaStatus.Status.NoAuthenticationContext,
+                idpEntityId,
+                Optional.<LevelOfAssurance>absent(),
+                Optional.<String>absent(),
                 Optional.<String>absent());
     }
 
     private static InboundResponseFromIdpDto buildDTO(IdpIdaStatus.Status status, String idpEntityId,
                                                       Optional<LevelOfAssurance> levelOfAssurance,
-                                                      Optional<String> fraudText) {
+                                                      Optional<String> fraudText,
+                                                      Optional<String> notOnOrAfter) {
         return new InboundResponseFromIdpDto(
                 status,
                 Optional.fromNullable("message"),
@@ -47,6 +66,7 @@ public class InboundResponseFromIdpDtoBuilder {
                 Optional.fromNullable("pid"),
                 levelOfAssurance,
                 fraudText,
-                fraudText);
+                fraudText,
+                notOnOrAfter);
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromCountry.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromCountry.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.policy.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Optional;
+import org.joda.time.DateTime;
 
 // This annotation is required for ZDD where we may add fields to newer versions of this DTO
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -12,14 +13,16 @@ public class InboundResponseFromCountry {
     private Optional<String> statusMessage;
     private Optional<String> encryptedIdentityAssertionBlob;
     private Optional<LevelOfAssurance> levelOfAssurance;
+    private Optional<DateTime> notOnOrAfter;
 
-    public InboundResponseFromCountry(CountryAuthenticationStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedIdentityAssertionBlob, Optional<String> persistentId, Optional<LevelOfAssurance> levelOfAssurance) {
+    public InboundResponseFromCountry(CountryAuthenticationStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedIdentityAssertionBlob, Optional<String> persistentId, Optional<LevelOfAssurance> levelOfAssurance, Optional<DateTime> notOnOrAfter) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.issuer = issuer;
         this.encryptedIdentityAssertionBlob = encryptedIdentityAssertionBlob;
         this.persistentId = persistentId;
         this.levelOfAssurance = levelOfAssurance;
+        this.notOnOrAfter = notOnOrAfter;
     }
 
     protected InboundResponseFromCountry() {
@@ -47,5 +50,9 @@ public class InboundResponseFromCountry {
 
     public Optional<String> getEncryptedIdentityAssertionBlob() {
         return encryptedIdentityAssertionBlob;
+    }
+
+    public Optional<DateTime> getNotOnOrAfter() {
+        return notOnOrAfter;
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromIdpDto.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromIdpDto.java
@@ -16,18 +16,20 @@ public class InboundResponseFromIdpDto {
     private Optional<LevelOfAssurance> levelOfAssurance;
     private Optional<String> idpFraudEventId;
     private Optional<String> fraudIndicator;
+    private Optional<String> notOnOrAfter;
 
-    public InboundResponseFromIdpDto(IdpIdaStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedAuthnAssertion, Optional<String> encryptedMatchingDatasetAssertion, Optional<String> persistentId, Optional<String> principalIpAddressAsSeenByIdp, Optional<LevelOfAssurance> levelOfAssurance, Optional<String> idpFraudEventId, Optional<String> fraudIndicator) {
+    public InboundResponseFromIdpDto(IdpIdaStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedAuthnAssertion, Optional<String> encryptedMatchingDatasetAssertion, Optional<String> persistentId, Optional<String> principalIpAddressAsSeenByIdp, Optional<LevelOfAssurance> levelOfAssurance, Optional<String> idpFraudEventId, Optional<String> fraudIndicator, Optional<String> notOnOrAfter) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.issuer = issuer;
         this.encryptedAuthnAssertion = encryptedAuthnAssertion;
         this.encryptedMatchingDatasetAssertion = encryptedMatchingDatasetAssertion;
-        this.principalIpAddressAsSeenByIdp = principalIpAddressAsSeenByIdp;
         this.persistentId = persistentId;
+        this.principalIpAddressAsSeenByIdp = principalIpAddressAsSeenByIdp;
         this.levelOfAssurance = levelOfAssurance;
         this.idpFraudEventId = idpFraudEventId;
         this.fraudIndicator = fraudIndicator;
+        this.notOnOrAfter = notOnOrAfter;
     }
 
     protected InboundResponseFromIdpDto() {
@@ -72,5 +74,9 @@ public class InboundResponseFromIdpDto {
 
     public Optional<String> getEncryptedMatchingDatasetAssertion() {
         return encryptedMatchingDatasetAssertion;
+    }
+
+    public Optional<String> getNotOnOrAfter(){
+        return notOnOrAfter;
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseAction.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseAction.java
@@ -22,37 +22,39 @@ public final class ResponseAction {
     private IdpResult result;
     private boolean isRegistration;
     private LevelOfAssurance loaAchieved;
+    private String notOnOrAfter;
 
     @JsonIgnore
-    public static ResponseAction cancel(SessionId sessionId, boolean isRegistration) { return new ResponseAction(sessionId, CANCEL, isRegistration, null); }
+    public static ResponseAction cancel(SessionId sessionId, boolean isRegistration) { return new ResponseAction(sessionId, CANCEL, isRegistration, null, null); }
 
     @JsonIgnore
-    public static ResponseAction other(SessionId sessionId, boolean isRegistration) { return new ResponseAction(sessionId, OTHER, isRegistration, null); }
+    public static ResponseAction other(SessionId sessionId, boolean isRegistration) { return new ResponseAction(sessionId, OTHER, isRegistration, null, null); }
 
     @JsonIgnore
-    public static ResponseAction failedUplift(SessionId sessionId, boolean isRegistration) { return new ResponseAction(sessionId, FAILED_UPLIFT, isRegistration, null); }
+    public static ResponseAction failedUplift(SessionId sessionId, boolean isRegistration) { return new ResponseAction(sessionId, FAILED_UPLIFT, isRegistration, null, null); }
 
     @JsonIgnore
-    public static ResponseAction success(SessionId sessionId, boolean isRegistration, LevelOfAssurance loaAchieved) { return new ResponseAction(sessionId, SUCCESS, isRegistration, loaAchieved); }
+    public static ResponseAction success(SessionId sessionId, boolean isRegistration, LevelOfAssurance loaAchieved, String notOnOrAfter) { return new ResponseAction(sessionId, SUCCESS, isRegistration, loaAchieved, notOnOrAfter); }
 
     @JsonIgnore
-    public static ResponseAction matchingJourneySuccess(SessionId sessionId, boolean isRegistration, LevelOfAssurance loaAchieved) { return new ResponseAction(sessionId, MATCHING_JOURNEY_SUCCESS, isRegistration, loaAchieved); }
+    public static ResponseAction matchingJourneySuccess(SessionId sessionId, boolean isRegistration, LevelOfAssurance loaAchieved, String notOnOrAfter) { return new ResponseAction(sessionId, MATCHING_JOURNEY_SUCCESS, isRegistration, loaAchieved, notOnOrAfter); }
 
     @JsonIgnore
-    public static ResponseAction nonMatchingJourneySuccess(SessionId sessionId, boolean isRegistration, LevelOfAssurance loaAchieved) { return new ResponseAction(sessionId, NON_MATCHING_JOURNEY_SUCCESS, isRegistration, loaAchieved); }
+    public static ResponseAction nonMatchingJourneySuccess(SessionId sessionId, boolean isRegistration, LevelOfAssurance loaAchieved, String notOnOrAfter) { return new ResponseAction(sessionId, NON_MATCHING_JOURNEY_SUCCESS, isRegistration, loaAchieved, notOnOrAfter); }
 
     @JsonIgnore
-    public static ResponseAction pending(SessionId sessionId) { return new ResponseAction(sessionId, PENDING, true, null); }
+    public static ResponseAction pending(SessionId sessionId) { return new ResponseAction(sessionId, PENDING, true, null, null); }
 
     @SuppressWarnings("unused")//Needed by JAXB
     private ResponseAction() {
     }
 
-    private ResponseAction(SessionId sessionId, IdpResult result, boolean isRegistration, LevelOfAssurance loaAchieved) {
+    private ResponseAction(SessionId sessionId, IdpResult result, boolean isRegistration, LevelOfAssurance loaAchieved, String notOnOrAfter) {
         this.sessionId = sessionId;
         this.result = result;
         this.isRegistration = isRegistration;
         this.loaAchieved = loaAchieved;
+        this.notOnOrAfter = notOnOrAfter;
     }
 
     public SessionId getSessionId() {
@@ -71,5 +73,9 @@ public final class ResponseAction {
 
     public LevelOfAssurance getLoaAchieved() {
         return loaAchieved;
+    }
+
+    public String getNotOnOrAfter() {
+        return notOnOrAfter;
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
@@ -79,7 +79,7 @@ public class AuthnResponseFromCountryService {
         AttributeQueryContainerDto aqr = samlEngineProxy.generateEidasAttributeQuery(stateController.getEidasAttributeQueryRequestDto(translatedResponse));
         samlSoapProxyProxy.sendHubMatchingServiceRequest(sessionId, getAttributeQueryRequest(aqr));
 
-        return ResponseAction.success(sessionId, false, LevelOfAssurance.LEVEL_2);
+        return ResponseAction.success(sessionId, false, LevelOfAssurance.LEVEL_2, null);
     }
 
     private ResponseAction handleAuthenticationFailedResponse(SamlAuthnResponseContainerDto responseFromCountry, SessionId sessionId, EidasCountrySelectedStateController stateController) {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
@@ -117,10 +117,10 @@ public class AuthnResponseFromIdpService {
             idpSelectedStateController.handleMatchingJourneySuccessResponseFromIdp(successFromIdp);
             AttributeQueryRequestDto attributeQuery = idpSelectedStateController.createAttributeQuery(successFromIdp);
             attributeQueryService.sendAttributeQueryRequest(sessionId, attributeQuery);
-            return success(sessionId, idpSelectedStateController.isRegistrationContext(), loaAchieved);
+            return success(sessionId, idpSelectedStateController.isRegistrationContext(), loaAchieved, inboundResponseFromIdpDto.getNotOnOrAfter().orNull());
         } else {
             idpSelectedStateController.handleNonMatchingJourneySuccessResponseFromIdp(successFromIdp);
-            return nonMatchingJourneySuccess(sessionId, idpSelectedStateController.isRegistrationContext(), loaAchieved);
+            return nonMatchingJourneySuccess(sessionId, idpSelectedStateController.isRegistrationContext(), loaAchieved, inboundResponseFromIdpDto.getNotOnOrAfter().orNull());
         }
     }
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/domain/InboundResponseFromIdpDtoBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/domain/InboundResponseFromIdpDtoBuilder.java
@@ -7,48 +7,61 @@ import uk.gov.ida.hub.policy.domain.InboundResponseFromIdpDto;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 
 public class InboundResponseFromIdpDtoBuilder {
-    public static InboundResponseFromIdpDto successResponse(String idpEntityId, LevelOfAssurance levelOfAssurance) {
+    public static InboundResponseFromIdpDto successResponse(String idpEntityId, LevelOfAssurance levelOfAssurance, String notOnOrAfter) {
         return buildDTO(IdpIdaStatus.Status.Success,
                 idpEntityId,
                 Optional.of(levelOfAssurance),
-                null);
+                Optional.<String>absent(),
+                Optional.fromNullable(notOnOrAfter));
     }
 
     public static InboundResponseFromIdpDto errorResponse(String idpEntityId, IdpIdaStatus.Status status) {
         return buildDTO(status, idpEntityId,
                 Optional.of(LevelOfAssurance.LEVEL_2),
+                Optional.<String>absent(),
                 Optional.<String>absent());
     }
 
     public static InboundResponseFromIdpDto fraudResponse(String idpEntityId) {
-        return buildDTO(IdpIdaStatus.Status.RequesterError, idpEntityId,
+        return buildDTO(IdpIdaStatus.Status.RequesterError,
+                idpEntityId,
                 Optional.of(LevelOfAssurance.LEVEL_X),
-                Optional.of("fraudIndicator"));
+                Optional.of("fraudIndicator"),
+                Optional.<String>absent());
     }
 
     public static InboundResponseFromIdpDto unsupportedResponse(String idpEntityId) {
         return buildDTO(IdpIdaStatus.Status.valueOf("unsupported"), idpEntityId,
                 Optional.of(LevelOfAssurance.LEVEL_X),
-                Optional.of("unsupported"));
+                Optional.of("unsupported"),
+                Optional.absent());
     }
 
     public static InboundResponseFromIdpDto failedResponse(String idpEntityId) {
-        return buildDTO(IdpIdaStatus.Status.AuthenticationFailed, idpEntityId, Optional.of(LevelOfAssurance.LEVEL_2), Optional.<String>absent());
+        return buildDTO(IdpIdaStatus.Status.AuthenticationFailed,
+                idpEntityId, Optional.of(LevelOfAssurance.LEVEL_2),
+                Optional.<String>absent(),
+                Optional.<String>absent());
     }
 
     public static InboundResponseFromIdpDto noAuthnContextResponse(String idpEntityId) {
-        return buildDTO(IdpIdaStatus.Status.NoAuthenticationContext, idpEntityId, Optional.<LevelOfAssurance>absent(),
+        return buildDTO(IdpIdaStatus.Status.NoAuthenticationContext,
+                idpEntityId,
+                Optional.<LevelOfAssurance>absent(),
+                Optional.<String>absent(),
                 Optional.<String>absent());
     }
 
     public static InboundResponseFromIdpDto authnPendingResponse(String idpEntityId) {
         return buildDTO(IdpIdaStatus.Status.AuthenticationPending, idpEntityId, Optional.<LevelOfAssurance>absent(),
-                Optional.<String>absent());
+                Optional.<String>absent(),
+                Optional.absent());
     }
 
     private static InboundResponseFromIdpDto buildDTO(IdpIdaStatus.Status status, String idpEntityId,
                                                       Optional<LevelOfAssurance> levelOfAssurance,
-                                                      Optional<String> fraudText) {
+                                                      Optional<String> fraudText,
+                                                      Optional<String> notOnOrAfter) {
         return new InboundResponseFromIdpDto(
                 status,
                 Optional.fromNullable("message"),
@@ -59,6 +72,7 @@ public class InboundResponseFromIdpDtoBuilder {
                 Optional.fromNullable("principalipseenbyidp"),
                 levelOfAssurance,
                 fraudText,
-                fraudText);
+                fraudText,
+                notOnOrAfter);
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -63,7 +63,8 @@ public class EidasCountrySelectedStateControllerTest {
             STUB_COUNTRY_ONE,
             Optional.of(BLOB),
             Optional.of(PID),
-            Optional.of(LEVEL_2));
+            Optional.of(LEVEL_2),
+            Optional.absent());
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -133,7 +134,8 @@ public class EidasCountrySelectedStateControllerTest {
                 STUB_COUNTRY_ONE,
                 Optional.of(BLOB),
                 Optional.absent(),
-                Optional.of(LEVEL_2));
+                Optional.of(LEVEL_2),
+                Optional.absent());
 
         controller.handleSuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS);
     }
@@ -149,7 +151,8 @@ public class EidasCountrySelectedStateControllerTest {
                 STUB_COUNTRY_ONE,
                 Optional.absent(),
                 Optional.of(PID),
-                Optional.of(LEVEL_2));
+                Optional.of(LEVEL_2),
+                Optional.absent());
 
         controller.handleSuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS);
     }
@@ -165,6 +168,7 @@ public class EidasCountrySelectedStateControllerTest {
                 STUB_COUNTRY_ONE,
                 Optional.of(BLOB),
                 Optional.of(PID),
+                Optional.absent(),
                 Optional.absent());
 
         controller.handleSuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS);
@@ -183,7 +187,8 @@ public class EidasCountrySelectedStateControllerTest {
                 STUB_IDP_ONE,
                 Optional.of(BLOB),
                 Optional.of(PID),
-                Optional.of(LEVEL_1));
+                Optional.of(LEVEL_1),
+                Optional.absent());
 
         controller.handleSuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS);
     }
@@ -220,7 +225,8 @@ public class EidasCountrySelectedStateControllerTest {
                 STUB_COUNTRY_ONE,
                 Optional.of(eidasAttributeQueryRequestDto.getEncryptedIdentityAssertion()),
                 Optional.of(eidasAttributeQueryRequestDto.getPersistentId().getNameId()),
-                Optional.of(LEVEL_2));
+                Optional.of(LEVEL_2),
+                Optional.absent());
 
         controller.handleSuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS);
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryServiceTest.java
@@ -74,7 +74,8 @@ public class AuthnResponseFromCountryServiceTest {
         STUB_IDP_ONE,
         Optional.of(BLOB),
         Optional.of(PID),
-        Optional.of(LEVEL_2));
+        Optional.of(LEVEL_2),
+        Optional.absent());
 
     private static final EidasAttributeQueryRequestDto EIDAS_ATTRIBUTE_QUERY_REQUEST_DTO = new EidasAttributeQueryRequestDto(
         REQUEST_ID,
@@ -164,7 +165,7 @@ public class AuthnResponseFromCountryServiceTest {
         verify(samlEngineProxy).generateEidasAttributeQuery(EIDAS_ATTRIBUTE_QUERY_REQUEST_DTO);
         verify(stateController).handleSuccessResponseFromCountry(INBOUND_RESPONSE_FROM_COUNTRY, SAML_AUTHN_RESPONSE_CONTAINER_DTO.getPrincipalIPAddressAsSeenByHub());
         verify(samlSoapProxyProxy).sendHubMatchingServiceRequest(SESSION_ID, ATTRIBUTE_QUERY_REQUEST);
-        ResponseAction expectedResponseAction = ResponseAction.success(SESSION_ID, false, LEVEL_2);
+        ResponseAction expectedResponseAction = ResponseAction.success(SESSION_ID, false, LEVEL_2, null);
         assertThat(responseAction).isEqualToComparingFieldByField(expectedResponseAction);
     }
 
@@ -184,7 +185,7 @@ public class AuthnResponseFromCountryServiceTest {
     @Test
     public void shouldReturnSuccessResponseIfTranslationResponseFromSamlEngineIsSuccessful() {
         final InboundResponseFromCountry inboundResponseFromCountry =
-                new InboundResponseFromCountry(Status.Success, Optional.of("status"), "issuer", Optional.of("blob"), Optional.of("pid"), Optional.of(LEVEL_2));
+                new InboundResponseFromCountry(Status.Success, Optional.of("status"), "issuer", Optional.of("blob"), Optional.of("pid"), Optional.of(LEVEL_2), Optional.absent());
 
         when(samlEngineProxy.translateAuthnResponseFromCountry(SAML_AUTHN_RESPONSE_TRANSLATOR_DTO))
                 .thenReturn(inboundResponseFromCountry);
@@ -198,7 +199,7 @@ public class AuthnResponseFromCountryServiceTest {
     @Test
     public void shouldReturnOtherResponseIfTranslationResponseFromSamlEngineIsFailure() {
         when(samlEngineProxy.translateAuthnResponseFromCountry(SAML_AUTHN_RESPONSE_TRANSLATOR_DTO))
-            .thenReturn(new InboundResponseFromCountry(Status.Failure, Optional.of("status"), "issuer", Optional.of("blob"), Optional.of("pid"), Optional.of(LEVEL_2)));
+            .thenReturn(new InboundResponseFromCountry(Status.Failure, Optional.of("status"), "issuer", Optional.of("blob"), Optional.of("pid"), Optional.of(LEVEL_2), Optional.absent()));
 
         ResponseAction responseAction = service.receiveAuthnResponseFromCountry(SESSION_ID, SAML_AUTHN_RESPONSE_CONTAINER_DTO);
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpServiceTest.java
@@ -82,7 +82,7 @@ public class AuthnResponseFromIdpServiceTest {
         stub(idpSelectedStateController.isRegistrationContext()).toReturn(REGISTERING);
         when(idpSelectedStateController.getMatchingServiceEntityId()).thenReturn(msaEntityId);
         when(idpSelectedStateController.isMatchingJourney()).thenReturn(true);
-        InboundResponseFromIdpDto successResponseFromIdp = InboundResponseFromIdpDtoBuilder.successResponse(UUID.randomUUID().toString(), loaAchieved);
+        InboundResponseFromIdpDto successResponseFromIdp = InboundResponseFromIdpDtoBuilder.successResponse(UUID.randomUUID().toString(), loaAchieved, null);
         SamlAuthnResponseTranslatorDto samlAuthnResponseTranslatorDto = SamlAuthnResponseTranslatorDtoBuilder.aSamlAuthnResponseTranslatorDto().build();
         when(samlAuthnResponseTranslatorDtoFactory.fromSamlAuthnResponseContainerDto(samlAuthnResponseContainerDto, msaEntityId)).thenReturn(samlAuthnResponseTranslatorDto);
         stub(samlEngineProxy.translateAuthnResponseFromIdp(any(SamlAuthnResponseTranslatorDto.class))).toReturn(successResponseFromIdp);
@@ -98,7 +98,7 @@ public class AuthnResponseFromIdpServiceTest {
         verify(samlAuthnResponseTranslatorDtoFactory).fromSamlAuthnResponseContainerDto(samlAuthnResponseContainerDto, msaEntityId);
         verify(attributeQueryService).sendAttributeQueryRequest(sessionId, attributeQueryRequestDto);
         verifyIdpStateControllerIsCalledWithRightDataOnSuccess(successResponseFromIdp, true);
-        ResponseAction expectedResponseAction = ResponseAction.success(sessionId, REGISTERING, loaAchieved);
+        ResponseAction expectedResponseAction = ResponseAction.success(sessionId, REGISTERING, loaAchieved, null);
         assertThat(responseAction).isEqualToComparingFieldByField(expectedResponseAction);
     }
 
@@ -108,7 +108,7 @@ public class AuthnResponseFromIdpServiceTest {
         LevelOfAssurance loaAchieved = LevelOfAssurance.LEVEL_2;
         stub(idpSelectedStateController.isRegistrationContext()).toReturn(REGISTERING);
         when(idpSelectedStateController.isMatchingJourney()).thenReturn(false);
-        InboundResponseFromIdpDto successResponseFromIdp = InboundResponseFromIdpDtoBuilder.successResponse(UUID.randomUUID().toString(), loaAchieved);
+        InboundResponseFromIdpDto successResponseFromIdp = InboundResponseFromIdpDtoBuilder.successResponse(UUID.randomUUID().toString(), loaAchieved, null);
         stub(samlEngineProxy.translateAuthnResponseFromIdp(any(SamlAuthnResponseTranslatorDto.class))).toReturn(successResponseFromIdp);
 
         // When
@@ -116,7 +116,7 @@ public class AuthnResponseFromIdpServiceTest {
 
         // Then
         verifyIdpStateControllerIsCalledWithRightDataOnSuccess(successResponseFromIdp, false);
-        ResponseAction expectedResponseAction = ResponseAction.nonMatchingJourneySuccess(sessionId, REGISTERING, loaAchieved);
+        ResponseAction expectedResponseAction = ResponseAction.nonMatchingJourneySuccess(sessionId, REGISTERING, loaAchieved, null);
         assertThat(responseAction).isEqualToComparingFieldByField(expectedResponseAction);
     }
 

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/IdpAuthnResponseTranslatorResourceTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/IdpAuthnResponseTranslatorResourceTest.java
@@ -149,6 +149,7 @@ public class IdpAuthnResponseTranslatorResourceTest {
         assertThat(inboundResponseFromIdpDto.getEncryptedMatchingDatasetAssertion().isPresent()).isTrue();
         assertThat(inboundResponseFromIdpDto.getPersistentId().isPresent()).isTrue();
         assertThat(inboundResponseFromIdpDto.getLevelOfAssurance().isPresent()).isTrue();
+        assertThat(inboundResponseFromIdpDto.getNotOnOrAfter().isPresent()).isTrue();
     }
 
     @Test

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/AuthnResponseFactory.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/AuthnResponseFactory.java
@@ -3,7 +3,9 @@ package uk.gov.ida.integrationtest.hub.samlengine.builders;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.core.Response;
@@ -19,6 +21,7 @@ import uk.gov.ida.saml.core.test.builders.AssertionBuilder;
 import uk.gov.ida.saml.core.test.builders.AuthnContextBuilder;
 import uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder;
 import uk.gov.ida.saml.core.test.builders.AuthnStatementBuilder;
+import uk.gov.ida.saml.core.test.builders.ConditionsBuilder;
 import uk.gov.ida.saml.core.test.builders.Gpg45StatusAttributeBuilder;
 import uk.gov.ida.saml.core.test.builders.IdpFraudEventIdAttributeBuilder;
 import uk.gov.ida.saml.core.test.builders.IssuerBuilder;
@@ -156,6 +159,7 @@ public class AuthnResponseFactory {
                                 .build())
                         .build())
                 .build();
+        final Conditions mdsAssertionConditions = ConditionsBuilder.aConditions().validFor(new Duration(1000*60*60)).build();
         final AttributeStatement matchingDatasetAttributeStatement = MatchingDatasetAttributeStatementBuilder_1_1.aMatchingDatasetAttributeStatement_1_1().build();
         final Credential encryptingCredential;
         if(basicCredential.isPresent()) {
@@ -167,6 +171,7 @@ public class AuthnResponseFactory {
         final AssertionBuilder mdsAssertion = AssertionBuilder.anAssertion().withId(generateId())
                 .withIssuer(IssuerBuilder.anIssuer().withIssuerId(mdsAssertionIssuer).build())
                 .withSubject(mdsAssertionSubject)
+                .withConditions(mdsAssertionConditions)
                 .withId(mdsStatementAssertionId)
                 .addAttributeStatement(matchingDatasetAttributeStatement);
         final AssertionBuilder authnAssertion = AssertionBuilder.anAssertion().withId(generateId())

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/domain/InboundResponseFromIdpDto.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/domain/InboundResponseFromIdpDto.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.hub.samlengine.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.joda.time.DateTime;
 import uk.gov.ida.saml.hub.domain.IdpIdaStatus;
 
 import java.util.Optional;
@@ -20,8 +21,9 @@ public class InboundResponseFromIdpDto {
     private Optional<LevelOfAssurance> levelOfAssurance;
     private Optional<String> idpFraudEventId;
     private Optional<String> fraudIndicator;
+    private Optional<DateTime> notOnOrAfter;
 
-    public InboundResponseFromIdpDto(IdpIdaStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedAuthnAssertion, Optional<String> encryptedMatchingDatasetAssertion, Optional<String> persistentId, Optional<String> principalIpAddressAsSeenByIdp, Optional<LevelOfAssurance> levelOfAssurance, Optional<String> idpFraudEventId, Optional<String> fraudIndicator) {
+    public InboundResponseFromIdpDto(IdpIdaStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedAuthnAssertion, Optional<String> encryptedMatchingDatasetAssertion, Optional<String> persistentId, Optional<String> principalIpAddressAsSeenByIdp, Optional<LevelOfAssurance> levelOfAssurance, Optional<String> idpFraudEventId, Optional<String> fraudIndicator, Optional<DateTime> notOnOrAfter) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.issuer = issuer;
@@ -32,6 +34,7 @@ public class InboundResponseFromIdpDto {
         this.levelOfAssurance = levelOfAssurance;
         this.idpFraudEventId = idpFraudEventId;
         this.fraudIndicator = fraudIndicator;
+        this.notOnOrAfter = notOnOrAfter;
     }
 
     protected InboundResponseFromIdpDto() {
@@ -77,4 +80,9 @@ public class InboundResponseFromIdpDto {
     public Optional<String> getEncryptedMatchingDatasetAssertion() {
         return encryptedMatchingDatasetAssertion;
     }
+
+    public Optional<DateTime> getNotOnOrAfter() {
+        return notOnOrAfter;
+    }
+
 }

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/IdpAuthnResponseTranslatorService.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/IdpAuthnResponseTranslatorService.java
@@ -88,7 +88,8 @@ public class IdpAuthnResponseTranslatorService {
                     inboundResponseFromIdpData.getPrincipalIpAddressAsSeenByIdp(),
                     levelOfAssurance,
                     inboundResponseFromIdpData.getIdpFraudEventId(),
-                    inboundResponseFromIdpData.getFraudIndicator());
+                    inboundResponseFromIdpData.getFraudIndicator(),
+                    inboundResponseFromIdpData.getNotOnOrAfter());
         } catch (SamlTransformationErrorException e) {
             throw new SamlContextException(response.getID(), response.getIssuer().getValue(), e);
         }

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/UnknownMethodAlgorithmLoggerTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/UnknownMethodAlgorithmLoggerTest.java
@@ -71,6 +71,7 @@ public class UnknownMethodAlgorithmLoggerTest {
     private static final String ISSUER_IDP = TestEntityIds.STUB_IDP_ONE;
     private static final String ISSUER_SP = TestEntityIds.TEST_RP;
     private static final DateTime ISSUE_INSTANT = new DateTime();
+    private static final Optional<DateTime> NOT_ON_OR_AFTER = Optional.empty();
     private static final IdpIdaStatus STATUS = IdpIdaStatus.success();
     private static final Optional<PassthroughAssertion> AUTHN_STATEMENT_ASSERTION = Optional.empty();
     private static final Optional<PassthroughAssertion> MATCHING_DATASET_ASSERTION = Optional.empty();
@@ -135,6 +136,7 @@ public class UnknownMethodAlgorithmLoggerTest {
                 IN_RESPONSE_TO,
                 ISSUER_IDP,
                 ISSUE_INSTANT,
+                NOT_ON_OR_AFTER,
                 STATUS,
                 signature,
                 MATCHING_DATASET_ASSERTION,
@@ -152,6 +154,7 @@ public class UnknownMethodAlgorithmLoggerTest {
                 IN_RESPONSE_TO,
                 ISSUER_IDP,
                 ISSUE_INSTANT,
+                NOT_ON_OR_AFTER,
                 STATUS,
                 signatureWithUnknownSignatureAlgorithm,
                 MATCHING_DATASET_ASSERTION,
@@ -172,6 +175,7 @@ public class UnknownMethodAlgorithmLoggerTest {
                 IN_RESPONSE_TO,
                 ISSUER_IDP,
                 ISSUE_INSTANT,
+                NOT_ON_OR_AFTER,
                 STATUS,
                 signatureWithUnknownDigestAlgorithm,
                 MATCHING_DATASET_ASSERTION,
@@ -192,6 +196,7 @@ public class UnknownMethodAlgorithmLoggerTest {
                 IN_RESPONSE_TO,
                 ISSUER_IDP,
                 ISSUE_INSTANT,
+                NOT_ON_OR_AFTER,
                 STATUS,
                 signatureWithUnknownSignatureAndDigestAlgorithms,
                 MATCHING_DATASET_ASSERTION,

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/MetadataConsumerTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/MetadataConsumerTests.java
@@ -62,7 +62,7 @@ public class MetadataConsumerTests {
     @Test
     public void shouldAllowRequestsWhenMetadataIsAvailableAndValid() throws Exception {
         SessionId sessionId = SessionId.createNewSessionId();
-        policyStubRule.register(UriBuilder.fromPath(Urls.PolicyUrls.IDP_AUTHN_RESPONSE_RESOURCE).build(sessionId).getPath(), 200, ResponseActionDto.success(sessionId, true, LEVEL_2));
+        policyStubRule.register(UriBuilder.fromPath(Urls.PolicyUrls.IDP_AUTHN_RESPONSE_RESOURCE).build(sessionId).getPath(), 200, ResponseActionDto.success(sessionId, true, LEVEL_2, null));
         org.opensaml.saml.saml2.core.Response samlResponse = authnResponseFactory.aResponseFromIdp(
                 TestEntityIds.STUB_IDP_ONE,
                 STUB_IDP_PUBLIC_PRIMARY_CERT,
@@ -83,7 +83,7 @@ public class MetadataConsumerTests {
     public void shouldReturnBadRequestWhenEntityIdCannotBeFoundInMetadata() throws Exception {
         SessionId sessionId = SessionId.createNewSessionId();
 
-        policyStubRule.register(UriBuilder.fromPath(Urls.PolicyUrls.IDP_AUTHN_RESPONSE_RESOURCE).build(sessionId).getPath(), 200, ResponseActionDto.success(sessionId, true, LEVEL_2));
+        policyStubRule.register(UriBuilder.fromPath(Urls.PolicyUrls.IDP_AUTHN_RESPONSE_RESOURCE).build(sessionId).getPath(), 200, ResponseActionDto.success(sessionId, true, LEVEL_2, null));
         org.opensaml.saml.saml2.core.Response samlResponse = authnResponseFactory.aResponseFromIdp(
                 "non-existent-entity-id",
                 STUB_IDP_PUBLIC_PRIMARY_CERT,

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/PolicyStubRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/PolicyStubRule.java
@@ -43,7 +43,7 @@ public class PolicyStubRule extends HttpStubRule {
 
     public void receiveAuthnResponseFromIdp(String sessionId, LevelOfAssurance loaAchieved) throws JsonProcessingException {
         String locationUri = getAuthnResponseFromIdpLocation(sessionId);
-        ResponseActionDto responseActionDto = ResponseActionDto.success(new SessionId(sessionId), false, loaAchieved);
+        ResponseActionDto responseActionDto = ResponseActionDto.success(new SessionId(sessionId), false, loaAchieved, null);
         register(locationUri, Status.OK.getStatusCode(), responseActionDto);
     }
 
@@ -88,7 +88,7 @@ public class PolicyStubRule extends HttpStubRule {
 
     public void receiveAuthnResponseFromCountry(String sessionId, LevelOfAssurance loaAchieved) throws JsonProcessingException {
         String locationUri = getAuthnResponseFromCountryLocation(sessionId);
-        ResponseActionDto responseActionDto = ResponseActionDto.success(new SessionId(sessionId), false, loaAchieved);
+        ResponseActionDto responseActionDto = ResponseActionDto.success(new SessionId(sessionId), false, loaAchieved, null);
         register(locationUri, Status.OK.getStatusCode(), responseActionDto);
     }
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/domain/ResponseActionDto.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/domain/ResponseActionDto.java
@@ -13,21 +13,23 @@ public final class ResponseActionDto {
     private IdpResult result;
     private boolean isRegistration;
     private LevelOfAssurance loaAchieved;
+    private String notOnOrAfter;
 
     @SuppressWarnings("unused") // needed by jaxb
     private ResponseActionDto() {
     }
 
-    private ResponseActionDto(SessionId sessionId, IdpResult result, final boolean isRegistration, LevelOfAssurance loaAchieved) {
+    private ResponseActionDto(SessionId sessionId, IdpResult result, final boolean isRegistration, LevelOfAssurance loaAchieved, String notOnOrAfter) {
         this.sessionId = sessionId;
         this.result = result;
         this.isRegistration = isRegistration;
         this.loaAchieved = loaAchieved;
+        this.notOnOrAfter = notOnOrAfter;
     }
 
     @JsonIgnore
-    public static ResponseActionDto success(SessionId sessionId, boolean registrationContext, LevelOfAssurance loaAchieved) {
-        return new ResponseActionDto(sessionId, SUCCESS, registrationContext, loaAchieved);
+    public static ResponseActionDto success(SessionId sessionId, boolean registrationContext, LevelOfAssurance loaAchieved, String notOnOrAfter) {
+        return new ResponseActionDto(sessionId, SUCCESS, registrationContext, loaAchieved, notOnOrAfter);
     }
 
     public SessionId getSessionId() {
@@ -45,6 +47,10 @@ public final class ResponseActionDto {
 
     public LevelOfAssurance getLoaAchieved() {
         return loaAchieved;
+    }
+
+    public String getNotOnOrAfter(){
+        return notOnOrAfter;
     }
 }
 

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
@@ -120,7 +120,7 @@ public class SamlMessageReceiverApiTest {
 
     @Test
     public void handleResponsePost_shouldReturnActionDtoOnSuccessfulRegistration() throws MarshallingException, SignatureException {
-        ResponseActionDto responseActionDto = ResponseActionDto.success(SESSION_ID, true, LevelOfAssurance.LEVEL_2);
+        ResponseActionDto responseActionDto = ResponseActionDto.success(SESSION_ID, true, LevelOfAssurance.LEVEL_2, null);
         when(stringSamlResponseTransformer.apply(SAML_REQUEST)).thenReturn(validSamlResponse);
         when(samlMessageSignatureValidator.validate(any(org.opensaml.saml.saml2.core.Response.class), any(QName.class))).thenReturn(SamlValidationResponse.aValidResponse());
         when(sessionProxy.receiveAuthnResponseFromIdp(any(SamlAuthnResponseContainerDto.class), eq(SESSION_ID))).thenReturn(responseActionDto);


### PR DESCRIPTION
Front end needs to know when the SAML Response from an IDP stops being valid according to the NotOnOrAfter attribute of the Conditions element for the user's assertion.

We have exposed this as a value in the ResponseAction from policy, which in turn gets it from saml engine via saml proxy.

At this stage all relevant tests have been modified so that the NotOnOrAfter is null, a valid condition.