### PR TITLE
lKH7U7yW: Allow lists of assertions in response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-44",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-34',
-            saml_libs:"$opensaml_version-160",
+            saml_libs:"$opensaml_version-161",
         ]
 
 subprojects {

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformer.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.saml.hub.transformers.outbound;
 
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
@@ -7,6 +8,9 @@ import uk.gov.ida.saml.core.domain.OutboundResponseFromHub;
 import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 import uk.gov.ida.saml.core.transformers.outbound.IdaResponseToSamlResponseTransformer;
 import uk.gov.ida.saml.core.transformers.outbound.IdaStatusMarshaller;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class OutboundResponseFromHubToSamlResponseTransformer extends IdaResponseToSamlResponseTransformer<OutboundResponseFromHub> {
 
@@ -27,9 +31,9 @@ public class OutboundResponseFromHubToSamlResponseTransformer extends IdaRespons
     @Override
     protected void transformAssertions(OutboundResponseFromHub originalResponse, Response transformedResponse) {
         originalResponse
-                .getMatchingServiceAssertion()
+                .getEncryptedAssertions().stream()
                 .map(encryptedAssertionUnmarshaller::transform)
-                .map(transformedResponse.getEncryptedAssertions()::add);
+                .forEach(transformedResponse.getEncryptedAssertions()::add);
     }
 
     @Override

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileOutboundResponseFromHubToSamlResponseTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/SimpleProfileOutboundResponseFromHubToSamlResponseTransformer.java
@@ -28,9 +28,9 @@ public class SimpleProfileOutboundResponseFromHubToSamlResponseTransformer exten
     @Override
     protected void transformAssertions(OutboundResponseFromHub originalResponse, Response transformedResponse) {
         originalResponse
-                .getMatchingServiceAssertion()
+                .getEncryptedAssertions().stream()
                 .map(encryptedAssertionUnmarshaller::transform)
-                .map(transformedResponse.getEncryptedAssertions()::add);
+                .forEach(transformedResponse.getEncryptedAssertions()::add);
     }
 
     @Override

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/outbound/OutboundResponseFromHubToSamlResponseTransformerTest.java
@@ -10,6 +10,9 @@ import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.domain.PassthroughAssertion;
 import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
@@ -38,7 +41,8 @@ public class OutboundResponseFromHubToSamlResponseTransformerTest {
         EncryptedAssertion transformedMatchingDatasetAssertion = anAssertion().build();
         when(encryptedAssertionUnmarshaller.transform(matchingServiceAssertion.getUnderlyingAssertionBlob())).thenReturn(transformedMatchingDatasetAssertion);
 
-        transformer.transformAssertions(anAuthnResponse().withMatchingServiceAssertion(matchingServiceAssertion.getUnderlyingAssertionBlob()).buildOutboundResponseFromHub(), transformedResponse);
+        String encryptedMatchingServiceAssertion = matchingServiceAssertion.getUnderlyingAssertionBlob();
+        transformer.transformAssertions(anAuthnResponse().withEncryptedAssertions(Arrays.asList(encryptedMatchingServiceAssertion)).buildOutboundResponseFromHub(), transformedResponse);
 
         assertThat(transformedResponse.getEncryptedAssertions().size()).isEqualTo(1);
         assertThat(transformedResponse.getEncryptedAssertions().get(0)).isEqualTo(transformedMatchingDatasetAssertion);

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/ResponseFromHubDtoBuilder.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/ResponseFromHubDtoBuilder.java
@@ -4,6 +4,8 @@ import uk.gov.ida.hub.samlengine.contracts.ResponseFromHubDto;
 import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,6 +16,7 @@ public class ResponseFromHubDtoBuilder {
     private String inResponseTo = UUID.randomUUID().toString();
     private TransactionIdaStatus status = TransactionIdaStatus.Success;
     private Optional<String> assertion = Optional.empty();
+    private List<String> encryptedAssertions = Collections.emptyList();
     private Optional<String> relayState = Optional.empty();
     private URI assertionConsumerServiceUri = URI.create("/default-index");
 
@@ -27,6 +30,7 @@ public class ResponseFromHubDtoBuilder {
                 inResponseTo,
                 authnRequestIssuerEntityId,
                 assertion,
+                encryptedAssertions,
                 relayState,
                 assertionConsumerServiceUri,
                 status
@@ -40,6 +44,11 @@ public class ResponseFromHubDtoBuilder {
 
     public ResponseFromHubDtoBuilder withAssertion(String assertion) {
         this.assertion = Optional.of(assertion);
+        return this;
+    }
+
+    public ResponseFromHubDtoBuilder withAssertions(List<String> encryptedAssertions) {
+        this.encryptedAssertions = encryptedAssertions;
         return this;
     }
 

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/contracts/ResponseFromHubDto.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/contracts/ResponseFromHubDto.java
@@ -3,6 +3,7 @@ package uk.gov.ida.hub.samlengine.contracts;
 import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 public class ResponseFromHubDto {
@@ -12,6 +13,7 @@ public class ResponseFromHubDto {
     private String inResponseTo;
     private TransactionIdaStatus status;
     private Optional<String> encryptedMatchingServiceAssertion;
+    private List<String> encryptedAssertions;
     private Optional<String> relayState;
     private URI assertionConsumerServiceUri;
 
@@ -24,6 +26,7 @@ public class ResponseFromHubDto {
             String inResponseTo,
             String authnRequestIssuerEntityId,
             Optional<String> encryptedMatchingServiceAssertion,
+            List<String> encryptedAssertions,
             Optional<String> relayState,
             URI assertionConsumerServiceUri,
             TransactionIdaStatus status) {
@@ -32,6 +35,7 @@ public class ResponseFromHubDto {
         this.responseId = responseId;
         this.inResponseTo = inResponseTo;
         this.encryptedMatchingServiceAssertion = encryptedMatchingServiceAssertion;
+        this.encryptedAssertions = encryptedAssertions;
         this.relayState = relayState;
         this.assertionConsumerServiceUri = assertionConsumerServiceUri;
         this.status = status;
@@ -51,6 +55,10 @@ public class ResponseFromHubDto {
 
     public Optional<String> getEncryptedMatchingServiceAssertion() {
         return encryptedMatchingServiceAssertion;
+    }
+
+    public List<String> getEncryptedAssertions() {
+        return encryptedAssertions;
     }
 
     public Optional<String> getRelayState() {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpAuthnResponseGeneratorService.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpAuthnResponseGeneratorService.java
@@ -12,6 +12,10 @@ import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class RpAuthnResponseGeneratorService {
 
@@ -36,13 +40,20 @@ public class RpAuthnResponseGeneratorService {
     private AuthnResponseFromHubContainerDto createSuccessResponse(final ResponseFromHubDto responseFromHub) {
         String authnRequestIssuerEntityId = responseFromHub.getAuthnRequestIssuerEntityId();
 
+        List<String> encryptedAssertions = responseFromHub.getEncryptedAssertions();
+        if (encryptedAssertions.isEmpty()) {
+            encryptedAssertions = responseFromHub.getEncryptedMatchingServiceAssertion()
+                .map(Collections::singletonList)
+                .orElse(Collections.emptyList());
+        }
+
         final OutboundResponseFromHub response = new OutboundResponseFromHub(
                 responseFromHub.getResponseId(),
                 responseFromHub.getInResponseTo(),
                 hubEntityId,
                 DateTime.now(),
                 TransactionIdaStatus.valueOf(responseFromHub.getStatus().name()),
-                responseFromHub.getEncryptedMatchingServiceAssertion(),
+                encryptedAssertions,
                 responseFromHub.getAssertionConsumerServiceUri());
 
         String samlMessage = outboundResponseFromHubToResponseTransformerFactory.get(authnRequestIssuerEntityId).apply(response);

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpErrorResponseGeneratorService.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpErrorResponseGeneratorService.java
@@ -12,6 +12,8 @@ import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import java.util.Collections;
+
 import static java.util.Optional.empty;
 
 public class RpErrorResponseGeneratorService {
@@ -36,7 +38,7 @@ public class RpErrorResponseGeneratorService {
                     hubEntityId,
                     DateTime.now(),
                     TransactionIdaStatus.valueOf(requestForErrorResponseFromHubDto.getStatus().name()),
-                    empty(),
+                    Collections.emptyList(),
                     requestForErrorResponseFromHubDto.getAssertionConsumerServiceUri());
 
             final String errorResponse = outboundResponseFromHubToResponseTransformerFactory.get(requestForErrorResponseFromHubDto.getAuthnRequestIssuerEntityId()).apply(response);


### PR DESCRIPTION
- For the non-matching journey, we need to support sending a List of assertions in ResponseFromHubDto, rather than just one.
- The new List of assertions is used everywhere internally, but to achieve ZDD, we currently retain the encryptedMatchingServiceAssertion field.  Both the list and the original field get populated.

https://trello.com/c/lKH7U7yW/185-wrap-assertions-in-hub-response-to-handle-idp-assertions

Solo: @alan-gds