### PR TITLE
Make Policy send lists of assertions

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/PolicyState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/PolicyState.java
@@ -2,22 +2,23 @@ package uk.gov.ida.hub.policy.domain;
 
 import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
 import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataState;
-import uk.gov.ida.hub.policy.domain.state.EidasAuthnFailedErrorState;
-import uk.gov.ida.hub.policy.domain.state.EidasCountrySelectedState;
-import uk.gov.ida.hub.policy.domain.state.EidasCountrySelectingState;
-import uk.gov.ida.hub.policy.domain.state.EidasUserAccountCreationFailedState;
 import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.Cycle3DataInputCancelledState;
 import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.EidasAuthnFailedErrorState;
 import uk.gov.ida.hub.policy.domain.state.EidasAwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.EidasCountrySelectedState;
+import uk.gov.ida.hub.policy.domain.state.EidasCountrySelectingState;
 import uk.gov.ida.hub.policy.domain.state.EidasCycle0And1MatchRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.EidasCycle3MatchRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.EidasSuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.EidasUserAccountCreationFailedState;
 import uk.gov.ida.hub.policy.domain.state.EidasUserAccountCreationRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedState;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
 import uk.gov.ida.hub.policy.domain.state.MatchingServiceRequestErrorState;
 import uk.gov.ida.hub.policy.domain.state.NoMatchState;
+import uk.gov.ida.hub.policy.domain.state.NonMatchingJourneySuccessState;
 import uk.gov.ida.hub.policy.domain.state.RequesterErrorState;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
 import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchState;
@@ -39,6 +40,7 @@ public enum PolicyState {
     EIDAS_CYCLE_3_MATCH_REQUEST_SENT(EidasCycle3MatchRequestSentState.class),
     SUCCESSFUL_MATCH(SuccessfulMatchState.class),
     EIDAS_SUCCESSFUL_MATCH(EidasSuccessfulMatchState.class),
+    NON_MATCHING_JOURNEY_SUCCESS(NonMatchingJourneySuccessState.class),
     NO_MATCH(NoMatchState.class),
     USER_ACCOUNT_CREATED(UserAccountCreatedState.class),
     AWAITING_CYCLE3_DATA(AwaitingCycle3DataState.class),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseFromHub.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseFromHub.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.builder.StandardToStringStyle;
 
 import javax.annotation.concurrent.Immutable;
 import java.net.URI;
+import java.util.List;
 import java.util.Objects;
 
 @Immutable
@@ -14,7 +15,7 @@ public final class ResponseFromHub {
     private String responseId;
     private String inResponseTo;
     private TransactionIdaStatus status;
-    private Optional<String> encryptedMatchingServiceAssertion;
+    private List<String> encryptedAssertions;
     private Optional<String> relayState;
     private URI assertionConsumerServiceUri;
 
@@ -26,7 +27,7 @@ public final class ResponseFromHub {
             String responseId,
             String inResponseTo,
             String authnRequestIssuerEntityId,
-            Optional<String> encryptedMatchingServiceAssertion,
+            List<String> encryptedAssertions,
             Optional<String> relayState,
             URI assertionConsumerServiceUri,
             TransactionIdaStatus status) {
@@ -34,7 +35,7 @@ public final class ResponseFromHub {
         this.authnRequestIssuerEntityId = authnRequestIssuerEntityId;
         this.responseId = responseId;
         this.inResponseTo = inResponseTo;
-        this.encryptedMatchingServiceAssertion = encryptedMatchingServiceAssertion;
+        this.encryptedAssertions = encryptedAssertions;
         this.relayState = relayState;
         this.assertionConsumerServiceUri = assertionConsumerServiceUri;
         this.status = status;
@@ -52,8 +53,8 @@ public final class ResponseFromHub {
         return inResponseTo;
     }
 
-    public Optional<String> getEncryptedMatchingServiceAssertion() {
-        return encryptedMatchingServiceAssertion;
+    public List<String> getEncryptedAssertions() {
+        return encryptedAssertions;
     }
 
     public Optional<String> getRelayState() {
@@ -91,13 +92,13 @@ public final class ResponseFromHub {
             Objects.equals(responseId, that.responseId) &&
             Objects.equals(inResponseTo, that.inResponseTo) &&
             status == that.status &&
-            Objects.equals(encryptedMatchingServiceAssertion, that.encryptedMatchingServiceAssertion) &&
+            Objects.equals(encryptedAssertions, that.encryptedAssertions) &&
             Objects.equals(relayState, that.relayState) &&
             Objects.equals(assertionConsumerServiceUri, that.assertionConsumerServiceUri);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authnRequestIssuerEntityId, responseId, inResponseTo, status, encryptedMatchingServiceAssertion, relayState, assertionConsumerServiceUri);
+        return Objects.hash(authnRequestIssuerEntityId, responseId, inResponseTo, status, encryptedAssertions, relayState, assertionConsumerServiceUri);
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseFromHubFactory.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseFromHubFactory.java
@@ -5,8 +5,10 @@ import uk.gov.ida.common.shared.security.IdGenerator;
 
 import javax.inject.Inject;
 import java.net.URI;
+import java.util.List;
 
-import static com.google.common.base.Optional.fromNullable;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 public class ResponseFromHubFactory {
 
@@ -28,7 +30,7 @@ public class ResponseFromHubFactory {
                 idGenerator.getId(),
                 inResponseTo,
                 authnRequestIssuerEntityId,
-                fromNullable(matchingServiceAssertion),
+                singletonList(matchingServiceAssertion),
                 relayState,
                 assertionConsumerServiceUri,
                 TransactionIdaStatus.Success
@@ -45,7 +47,7 @@ public class ResponseFromHubFactory {
                 idGenerator.getId(),
                 inResponseTo,
                 authnRequestIssuerEntityId,
-                Optional.<String>absent(),
+                emptyList(),
                 relayState,
                 assertionConsumerServiceUri,
                 TransactionIdaStatus.NoAuthenticationContext
@@ -62,7 +64,7 @@ public class ResponseFromHubFactory {
                 idGenerator.getId(),
                 inResponseTo,
                 authnRequestIssuerEntityId,
-                Optional.<String>absent(),
+                emptyList(),
                 relayState,
                 assertionConsumerServiceUri,
                 TransactionIdaStatus.NoMatchingServiceMatchFromHub
@@ -79,7 +81,7 @@ public class ResponseFromHubFactory {
                 idGenerator.getId(),
                 inResponseTo,
                 authnRequestIssuerEntityId,
-                Optional.<String>absent(),
+                emptyList(),
                 relayState,
                 assertionConsumerServiceUri,
                 TransactionIdaStatus.AuthenticationFailed
@@ -96,7 +98,7 @@ public class ResponseFromHubFactory {
             idGenerator.getId(),
             requestId,
             requestIssuerId,
-            Optional.<String>absent(),
+            emptyList(),
             relayState,
             assertionConsumerServiceUri,
             TransactionIdaStatus.RequesterError

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseFromHubFactory.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/ResponseFromHubFactory.java
@@ -104,4 +104,22 @@ public class ResponseFromHubFactory {
             TransactionIdaStatus.RequesterError
         );
     }
+
+    public ResponseFromHub createNonMatchingSuccessResponseFromHub(
+            String requestId,
+            Optional<String> relayState,
+            String requestIssuerEntityId,
+            List<String> encryptedAssertions,
+            URI assertionConsumerServiceUri) {
+
+        return new ResponseFromHub(
+            idGenerator.getId(),
+            requestId,
+            requestIssuerEntityId,
+            encryptedAssertions,
+            relayState,
+            assertionConsumerServiceUri,
+            TransactionIdaStatus.Success
+        );
+    }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/NonMatchingJourneySuccessStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/NonMatchingJourneySuccessStateController.java
@@ -5,7 +5,9 @@ import uk.gov.ida.hub.policy.domain.ResponseFromHubFactory;
 import uk.gov.ida.hub.policy.domain.StateController;
 import uk.gov.ida.hub.policy.domain.state.NonMatchingJourneySuccessState;
 
-public class NonMatchingJourneySuccessStateController implements StateController {
+import java.util.ArrayList;
+
+public class NonMatchingJourneySuccessStateController implements StateController, ResponsePreparedStateController {
 
     private final NonMatchingJourneySuccessState state;
     private final ResponseFromHubFactory responseFromHubFactory;
@@ -16,5 +18,16 @@ public class NonMatchingJourneySuccessStateController implements StateController
 
         this.state = state;
         this.responseFromHubFactory = responseFromHubFactory;
+    }
+
+    @Override
+    public ResponseFromHub getPreparedResponse() {
+        return responseFromHubFactory.createNonMatchingSuccessResponseFromHub(
+                state.getRequestId(),
+                state.getRelayState(),
+                state.getRequestIssuerEntityId(),
+                new ArrayList<>(state.getEncryptedAssertions()),
+                state.getAssertionConsumerServiceUri()
+        );
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/StateControllerFactory.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/StateControllerFactory.java
@@ -10,21 +10,22 @@ import uk.gov.ida.hub.policy.domain.StateController;
 import uk.gov.ida.hub.policy.domain.StateTransitionAction;
 import uk.gov.ida.hub.policy.domain.state.AuthnFailedErrorState;
 import uk.gov.ida.hub.policy.domain.state.AwaitingCycle3DataState;
-import uk.gov.ida.hub.policy.domain.state.EidasAuthnFailedErrorState;
-import uk.gov.ida.hub.policy.domain.state.EidasCountrySelectedState;
-import uk.gov.ida.hub.policy.domain.state.EidasUserAccountCreationFailedState;
 import uk.gov.ida.hub.policy.domain.state.Cycle0And1MatchRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.Cycle3DataInputCancelledState;
 import uk.gov.ida.hub.policy.domain.state.Cycle3MatchRequestSentState;
+import uk.gov.ida.hub.policy.domain.state.EidasAuthnFailedErrorState;
 import uk.gov.ida.hub.policy.domain.state.EidasAwaitingCycle3DataState;
+import uk.gov.ida.hub.policy.domain.state.EidasCountrySelectedState;
 import uk.gov.ida.hub.policy.domain.state.EidasCycle0And1MatchRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.EidasCycle3MatchRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.EidasSuccessfulMatchState;
+import uk.gov.ida.hub.policy.domain.state.EidasUserAccountCreationFailedState;
 import uk.gov.ida.hub.policy.domain.state.EidasUserAccountCreationRequestSentState;
 import uk.gov.ida.hub.policy.domain.state.FraudEventDetectedState;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
 import uk.gov.ida.hub.policy.domain.state.MatchingServiceRequestErrorState;
 import uk.gov.ida.hub.policy.domain.state.NoMatchState;
+import uk.gov.ida.hub.policy.domain.state.NonMatchingJourneySuccessState;
 import uk.gov.ida.hub.policy.domain.state.RequesterErrorState;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
 import uk.gov.ida.hub.policy.domain.state.SuccessfulMatchState;
@@ -125,6 +126,11 @@ public class StateControllerFactory {
                         (EidasSuccessfulMatchState) state,
                         injector.getInstance(ResponseFromHubFactory.class),
                         injector.getInstance(CountriesService.class));
+
+            case NON_MATCHING_JOURNEY_SUCCESS:
+                return new NonMatchingJourneySuccessStateController(
+                        (NonMatchingJourneySuccessState) state,
+                        injector.getInstance(ResponseFromHubFactory.class));
 
             case NO_MATCH:
                 return new NoMatchStateController(

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/domain/ResponseFromHubBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/domain/ResponseFromHubBuilder.java
@@ -7,7 +7,7 @@ import uk.gov.ida.hub.policy.domain.TransactionIdaStatus;
 import java.net.URI;
 import java.util.UUID;
 
-import static com.google.common.base.Optional.absent;
+import static java.util.Collections.emptyList;
 
 public class ResponseFromHubBuilder {
 
@@ -15,7 +15,6 @@ public class ResponseFromHubBuilder {
     private String responseId = UUID.randomUUID().toString();
     private String inResponseTo = UUID.randomUUID().toString();
     private uk.gov.ida.hub.policy.domain.TransactionIdaStatus status = TransactionIdaStatus.Success;
-    private Optional<String> matchingDatasetAssertion = absent();
     private Optional<String> relayState = Optional.absent();
     private URI assertionConsumerServiceUri = URI.create("/default-index");
 
@@ -33,7 +32,7 @@ public class ResponseFromHubBuilder {
                 responseId,
                 inResponseTo,
                 authnRequestIssuerEntityId,
-                matchingDatasetAssertion,
+                emptyList(),
                 relayState,
                 assertionConsumerServiceUri,
                 status

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/ResponseFromHubTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/ResponseFromHubTest.java
@@ -7,13 +7,14 @@ import org.junit.Test;
 
 import java.net.URI;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResponseFromHubTest {
     private static final String RESPONSE_ID = "responseId";
     private static final String IN_RESPONSE_TO = "inResponseTo";
     private static final String AUTHN_REQUEST_ISSUER_ENTITY_ID = "authnRequestIssuerEntityId";
-    private static final Optional<String> MATCHING_SERVICE_ASSERTION = Optional.of("matchingServiceAssertion");
+    private static final String MATCHING_SERVICE_ASSERTION = "matchingServiceAssertion";
     private static final Optional<String> RELAY_STATE = Optional.of("relayState");
     private static final URI ASSERTION_CONSUMER_SERVICE_URI = URI.create("assertionConsumerServiceUri");
     private ResponseFromHub responseFromHub;
@@ -24,7 +25,7 @@ public class ResponseFromHubTest {
             RESPONSE_ID,
             IN_RESPONSE_TO,
             AUTHN_REQUEST_ISSUER_ENTITY_ID,
-            MATCHING_SERVICE_ASSERTION,
+            singletonList(MATCHING_SERVICE_ASSERTION),
             RELAY_STATE,
             ASSERTION_CONSUMER_SERVICE_URI,
             TransactionIdaStatus.Success
@@ -47,8 +48,8 @@ public class ResponseFromHubTest {
     }
 
     @Test
-    public void getMatchingServiceAssertion() {
-        assertThat(responseFromHub.getEncryptedMatchingServiceAssertion()).isEqualTo(MATCHING_SERVICE_ASSERTION);
+    public void getEncryptedAssertions() {
+        assertThat(responseFromHub.getEncryptedAssertions()).containsOnly(MATCHING_SERVICE_ASSERTION);
     }
 
     @Test
@@ -73,7 +74,7 @@ public class ResponseFromHubTest {
         sb.append(",responseId=").append(responseFromHub.getResponseId());
         sb.append(",inResponseTo=").append(responseFromHub.getInResponseTo());
         sb.append(",status=").append(responseFromHub.getStatus());
-        sb.append(",encryptedMatchingServiceAssertion=").append(responseFromHub.getEncryptedMatchingServiceAssertion());
+        sb.append(",encryptedAssertions=").append(responseFromHub.getEncryptedAssertions());
         sb.append(",relayState=").append(responseFromHub.getRelayState());
         sb.append(",assertionConsumerServiceUri=").append(responseFromHub.getAssertionConsumerServiceUri());
         sb.append(']');

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateControllerTest.java
@@ -34,6 +34,7 @@ import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 
 import java.net.URI;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -112,7 +113,7 @@ public class EidasAwaitingCycle3DataStateControllerTest {
             RESPONSE_ID,
             state.getRequestId(),
             state.getRequestIssuerEntityId(),
-            Optional.absent(),
+            emptyList(),
             Optional.of("relayState"),
             URI.create("assertionConsumerServiceUri"),
             TransactionIdaStatus.NoAuthenticationContext


### PR DESCRIPTION
- This PR makes policy use the new "encryptedAssertions" field
in ResponseFromHub
- Since we can now do this, also enable it for the non matching journey