### PR TITLE
lKH7U7yW: Remove old encryptedMatchingDataset assertion

### DIFF
--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/RpAuthnResponseGeneratorResourceTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/RpAuthnResponseGeneratorResourceTest.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.integrationtest.hub.samlengine.builders.ResponseFromHubDtoBuilder.aResponseFromHubDto;
 
@@ -79,7 +80,7 @@ public class RpAuthnResponseGeneratorResourceTest {
         ResponseFromHubDto responseFromHubDto = aResponseFromHubDto()
                 .withStatus(TransactionIdaStatus.NoMatchingServiceMatchFromHub)
                 .withAuthnRequestIssuerEntityId(TestEntityIds.TEST_RP)
-                .withAssertion(createAssertionString())
+                .withAssertions(singletonList(createAssertionString()))
                 .build();
         configStub.setupCertificatesForEntity(responseFromHubDto.getAuthnRequestIssuerEntityId());
         configStub.signResponsesAndUseLegacyStandard(responseFromHubDto.getAuthnRequestIssuerEntityId());
@@ -108,7 +109,7 @@ public class RpAuthnResponseGeneratorResourceTest {
 
         ResponseFromHubDto responseFromHubDto = aResponseFromHubDto()
                 .withAuthnRequestIssuerEntityId(TestEntityIds.TEST_RP)
-                .withAssertion(assertion)
+                .withAssertions(singletonList(createAssertionString()))
                 .withStatus(TransactionIdaStatus.Success)
                 .build();
 
@@ -141,7 +142,7 @@ public class RpAuthnResponseGeneratorResourceTest {
 
         ResponseFromHubDto responseFromHubDto = aResponseFromHubDto()
                 .withAuthnRequestIssuerEntityId(TestEntityIds.TEST_RP)
-                .withAssertion(assertion)
+                .withAssertions(singletonList(createAssertionString()))
                 .withStatus(TransactionIdaStatus.Success)
                 .build();
 
@@ -186,80 +187,6 @@ public class RpAuthnResponseGeneratorResourceTest {
         assertThat(rpAuthnResponse.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         ErrorStatusDto errorStatusDto = rpAuthnResponse.readEntity(ErrorStatusDto.class);
         assertThat(errorStatusDto.getExceptionType()).isEqualTo(ExceptionType.INVALID_INPUT);
-    }
-
-    @Test
-    public void shouldUseEncryptedAssertionsFromListIfNonEmpty() throws Exception {
-        // Given
-        ResponseFromHubDto responseFromHubDto = aResponseFromHubDto()
-            .withAuthnRequestIssuerEntityId(TestEntityIds.TEST_RP)
-            .withAssertions(Arrays.asList(createAssertionString(), createAssertionString()))
-            .build();
-        configStub.setupCertificatesForEntity(responseFromHubDto.getAuthnRequestIssuerEntityId());
-        configStub.signResponsesAndUseSamlStandard(responseFromHubDto.getAuthnRequestIssuerEntityId());
-
-        // When
-        URI generateAuthnResponseEndpoint = samlEngineAppRule.getUri(Urls.SamlEngineUrls.GENERATE_RP_AUTHN_RESPONSE_RESOURCE);
-        Response rpAuthnResponse = client.target(generateAuthnResponseEndpoint).request().post(Entity.entity(responseFromHubDto, MediaType.APPLICATION_JSON_TYPE));
-
-        // Then
-        assertThat(rpAuthnResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        AuthnResponseFromHubContainerDto result = rpAuthnResponse.readEntity(AuthnResponseFromHubContainerDto
-            .class);
-
-        org.opensaml.saml.saml2.core.Response response = extractResponse(result);
-        assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
-        assertThat(response.getEncryptedAssertions().size()).isEqualTo(2);
-    }
-
-    @Test
-    public void shouldIgnoreMatchingServiceAssertionIfEncryptedAssertionsListNonEmpty() throws Exception {
-        // Given
-        ResponseFromHubDto responseFromHubDto = aResponseFromHubDto()
-            .withAuthnRequestIssuerEntityId(TestEntityIds.TEST_RP)
-            .withAssertions(Arrays.asList(createAssertionString(), createAssertionString()))
-            .withAssertion(createAssertionString())
-            .build();
-        configStub.setupCertificatesForEntity(responseFromHubDto.getAuthnRequestIssuerEntityId());
-        configStub.signResponsesAndUseSamlStandard(responseFromHubDto.getAuthnRequestIssuerEntityId());
-
-        // When
-        URI generateAuthnResponseEndpoint = samlEngineAppRule.getUri(Urls.SamlEngineUrls.GENERATE_RP_AUTHN_RESPONSE_RESOURCE);
-        Response rpAuthnResponse = client.target(generateAuthnResponseEndpoint).request().post(Entity.entity(responseFromHubDto, MediaType.APPLICATION_JSON_TYPE));
-
-        // Then
-        assertThat(rpAuthnResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        AuthnResponseFromHubContainerDto result = rpAuthnResponse.readEntity(AuthnResponseFromHubContainerDto
-            .class);
-
-        org.opensaml.saml.saml2.core.Response response = extractResponse(result);
-        assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
-        assertThat(response.getEncryptedAssertions().size()).isEqualTo(2);
-    }
-
-    @Test
-    public void shouldFallBackToMatchingServiceAssertionIfEncryptedAssertionsListIsEmpty() throws Exception {
-        // Given
-        ResponseFromHubDto responseFromHubDto = aResponseFromHubDto()
-            .withAuthnRequestIssuerEntityId(TestEntityIds.TEST_RP)
-            .withAssertions(Collections.emptyList())
-            .withAssertion(createAssertionString())
-            .build();
-        configStub.setupCertificatesForEntity(responseFromHubDto.getAuthnRequestIssuerEntityId());
-        configStub.signResponsesAndUseSamlStandard(responseFromHubDto.getAuthnRequestIssuerEntityId());
-
-        // When
-        URI generateAuthnResponseEndpoint = samlEngineAppRule.getUri(Urls.SamlEngineUrls.GENERATE_RP_AUTHN_RESPONSE_RESOURCE);
-        Response rpAuthnResponse = client.target(generateAuthnResponseEndpoint).request().post(Entity.entity(responseFromHubDto, MediaType.APPLICATION_JSON_TYPE));
-
-        // Then
-        assertThat(rpAuthnResponse.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        AuthnResponseFromHubContainerDto result = rpAuthnResponse.readEntity(AuthnResponseFromHubContainerDto
-            .class);
-
-        org.opensaml.saml.saml2.core.Response response = extractResponse(result);
-        assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo(StatusCode.SUCCESS);
-        assertThat(response.getEncryptedAssertions().size()).isEqualTo(1);
     }
 
     @Test

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/ResponseFromHubDtoBuilder.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/ResponseFromHubDtoBuilder.java
@@ -15,7 +15,6 @@ public class ResponseFromHubDtoBuilder {
     private String responseId = UUID.randomUUID().toString();
     private String inResponseTo = UUID.randomUUID().toString();
     private TransactionIdaStatus status = TransactionIdaStatus.Success;
-    private Optional<String> assertion = Optional.empty();
     private List<String> encryptedAssertions = Collections.emptyList();
     private Optional<String> relayState = Optional.empty();
     private URI assertionConsumerServiceUri = URI.create("/default-index");
@@ -29,7 +28,6 @@ public class ResponseFromHubDtoBuilder {
                 responseId,
                 inResponseTo,
                 authnRequestIssuerEntityId,
-                assertion,
                 encryptedAssertions,
                 relayState,
                 assertionConsumerServiceUri,
@@ -39,11 +37,6 @@ public class ResponseFromHubDtoBuilder {
 
     public ResponseFromHubDtoBuilder withRelayState(String relayState) {
         this.relayState = Optional.ofNullable(relayState);
-        return this;
-    }
-
-    public ResponseFromHubDtoBuilder withAssertion(String assertion) {
-        this.assertion = Optional.of(assertion);
         return this;
     }
 

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/contracts/ResponseFromHubDto.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/contracts/ResponseFromHubDto.java
@@ -12,7 +12,6 @@ public class ResponseFromHubDto {
     private String responseId;
     private String inResponseTo;
     private TransactionIdaStatus status;
-    private Optional<String> encryptedMatchingServiceAssertion;
     private List<String> encryptedAssertions;
     private Optional<String> relayState;
     private URI assertionConsumerServiceUri;
@@ -25,7 +24,6 @@ public class ResponseFromHubDto {
             String responseId,
             String inResponseTo,
             String authnRequestIssuerEntityId,
-            Optional<String> encryptedMatchingServiceAssertion,
             List<String> encryptedAssertions,
             Optional<String> relayState,
             URI assertionConsumerServiceUri,
@@ -34,7 +32,6 @@ public class ResponseFromHubDto {
         this.authnRequestIssuerEntityId = authnRequestIssuerEntityId;
         this.responseId = responseId;
         this.inResponseTo = inResponseTo;
-        this.encryptedMatchingServiceAssertion = encryptedMatchingServiceAssertion;
         this.encryptedAssertions = encryptedAssertions;
         this.relayState = relayState;
         this.assertionConsumerServiceUri = assertionConsumerServiceUri;
@@ -51,10 +48,6 @@ public class ResponseFromHubDto {
 
     public String getInResponseTo() {
         return inResponseTo;
-    }
-
-    public Optional<String> getEncryptedMatchingServiceAssertion() {
-        return encryptedMatchingServiceAssertion;
     }
 
     public List<String> getEncryptedAssertions() {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpAuthnResponseGeneratorService.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpAuthnResponseGeneratorService.java
@@ -40,20 +40,13 @@ public class RpAuthnResponseGeneratorService {
     private AuthnResponseFromHubContainerDto createSuccessResponse(final ResponseFromHubDto responseFromHub) {
         String authnRequestIssuerEntityId = responseFromHub.getAuthnRequestIssuerEntityId();
 
-        List<String> encryptedAssertions = responseFromHub.getEncryptedAssertions();
-        if (encryptedAssertions.isEmpty()) {
-            encryptedAssertions = responseFromHub.getEncryptedMatchingServiceAssertion()
-                .map(Collections::singletonList)
-                .orElse(Collections.emptyList());
-        }
-
         final OutboundResponseFromHub response = new OutboundResponseFromHub(
                 responseFromHub.getResponseId(),
                 responseFromHub.getInResponseTo(),
                 hubEntityId,
                 DateTime.now(),
                 TransactionIdaStatus.valueOf(responseFromHub.getStatus().name()),
-                encryptedAssertions,
+                responseFromHub.getEncryptedAssertions(),
                 responseFromHub.getAssertionConsumerServiceUri());
 
         String samlMessage = outboundResponseFromHubToResponseTransformerFactory.get(authnRequestIssuerEntityId).apply(response);


### PR DESCRIPTION
- Policy now only uses the list of assertions so we never expect to get
  this value anymore so can safely delete
- Deleted previously added tests that demonstrated the fallback
  behaviour whilst dual running