### PR TITLE
bau - upgrade bintray version to 1.8.4

### DIFF
--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -1,4 +1,4 @@
-plugins { id "com.jfrog.bintray" version "1.8.0" }
+plugins { id "com.jfrog.bintray" version "1.8.4" }
 
 apply plugin: 'maven-publish'
 apply plugin: 'java'

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -1,4 +1,4 @@
-plugins { id "com.jfrog.bintray" version "1.8.0" }
+plugins { id "com.jfrog.bintray" version "1.8.4" }
 
 apply plugin: 'maven-publish'
 apply plugin: 'java'


### PR DESCRIPTION
- There appears to be an issue with bintray version 1.8.0 and gradle version 4.8 or later.
- The issue is that the upload uri is constructed incorrectly and causes the bintrayUpload task to fail. 
- More information can be found on this issue here - https://github.com/bintray/gradle-bintray-plugin/issues/234