### PR TITLE
HUB-399: Create a SIDP customised start page for SA in the hub

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TranslationData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TranslationData.java
@@ -103,6 +103,14 @@ public class TranslationData implements ConfigEntityData {
         @JsonProperty
         protected String customFailContactDetailsIntro;
 
+        @Valid
+        @JsonProperty
+        protected String singleIdpStartPageTitle;
+
+        @Valid
+        @JsonProperty
+        protected String singleIdpStartPageContent;
+
         public Translation setLocale(String locale) {
             this.locale = locale;
             return this;


### PR DESCRIPTION
Added singleIdpStartPageContent attribute to translation data.

Co-authored-by: Kerr Rainey <kerr.rainey@digital.cabinet-office.gov.uk>