### PR TITLE
BAU: Add @ResponseMetered to saml proxy endpoints

### DIFF
--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.samlproxy.resources;
 
+import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
 import org.jboss.logging.MDC;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -22,7 +23,6 @@ import uk.gov.ida.saml.core.validation.SamlValidationResponse;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
 import uk.gov.ida.saml.deserializers.StringToOpenSamlObjectTransformer;
 import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
-import uk.gov.ida.saml.security.validators.ValidatedResponse;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -69,6 +69,7 @@ public class SamlMessageReceiverApi {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Timed
+    @ResponseMetered
     public Response handleRequestPost(SamlRequestDto samlRequestDto) {
 
         relayStateValidator.validate(samlRequestDto.getRelayState());
@@ -95,6 +96,7 @@ public class SamlMessageReceiverApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Path(Urls.SamlProxyUrls.RESPONSE_POST_PATH)
     @Timed
+    @ResponseMetered
     public Response handleResponsePost(SamlRequestDto samlRequestDto) {
 
         final SessionId sessionId = new SessionId(samlRequestDto.getRelayState());
@@ -129,6 +131,7 @@ public class SamlMessageReceiverApi {
     @Produces(MediaType.APPLICATION_JSON)
     @Path(Urls.SamlProxyUrls.EIDAS_RESPONSE_POST_PATH)
     @Timed
+    @ResponseMetered
     public Response handleEidasResponsePost(SamlRequestDto samlRequestDto) {
 
         if (eidasValidatorFactory.isPresent()) {

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageSenderApi.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageSenderApi.java
@@ -1,12 +1,12 @@
 package uk.gov.ida.hub.samlproxy.resources;
 
+import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
-import javax.inject.Inject;
-
+import uk.gov.ida.common.SessionId;
 import uk.gov.ida.hub.samlproxy.Urls;
 import uk.gov.ida.hub.samlproxy.controllogic.SamlMessageSenderHandler;
-import uk.gov.ida.common.SessionId;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -32,6 +32,7 @@ public class SamlMessageSenderApi {
     @GET
     @Path(Urls.SamlProxyUrls.SEND_AUTHN_REQUEST_PATH)
     @Timed
+    @ResponseMetered
     public Response sendJsonAuthnRequestFromHub(
             @QueryParam(SESSION_ID_PARAM) final SessionId sessionId,
             @HeaderParam(X_FORWARDED_FOR) String xForwardedFor) {
@@ -41,6 +42,7 @@ public class SamlMessageSenderApi {
     @GET
     @Path(Urls.SamlProxyUrls.SEND_RESPONSE_FROM_HUB_PATH)
     @Timed
+    @ResponseMetered
     public Response sendJsonAuthnResponseFromHub(
             @QueryParam(SESSION_ID_PARAM) final SessionId sessionId,
             @HeaderParam(X_FORWARDED_FOR) String xForwardedFor) {
@@ -50,6 +52,7 @@ public class SamlMessageSenderApi {
     @GET
     @Path(Urls.SamlProxyUrls.SEND_ERROR_RESPONSE_FROM_HUB_PATH)
     @Timed
+    @ResponseMetered
     public Response sendJsonErrorResponseFromHub(
             @QueryParam(SESSION_ID_PARAM) final SessionId sessionId,
             @HeaderParam(X_FORWARDED_FOR) String xForwardedFor) {


### PR DESCRIPTION
- This will give us the number of successful and unsuccessful responses
  from these touchpoints in hub
- This isn't complete coverage but if any of these endpoints fail then
  user journeys will start to fail so worth monitoring