### PR TITLE
EID-1183 - Allow Hub to run on Java11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ jdk:
   - openjdk10
   - openjdk11
 matrix:
-  allow_failures:
-  - jdk: openjdk10
-  - jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,10 @@ subprojects {
     dependencies {
 
         common 'joda-time:joda-time:2.3',
-                'com.google.inject:guice:4.0'
+                'com.google.inject:guice:4.0',
+                "javax.xml.bind:jaxb-api:2.3.1",
+                "com.sun.xml.bind:jaxb-core:2.3.0.1",
+                "com.sun.xml.bind:jaxb-impl:2.3.0.1"
 
         dropwizard 'io.dropwizard:dropwizard-core:' + dependencyVersions.dropwizard,
                 'io.dropwizard:dropwizard-client:' + dependencyVersions.dropwizard,


### PR DESCRIPTION
- The JAXB APIs have been completely removed from the JDK in Java 11.
- Add JAX-B API as a dependency.
- Don't allow failures with openjdk10 or openjdk11 with travis.