### PR TITLE
EID-1015: Unhandled exception when user fails MW auth and goes back to re-submit form

### DIFF
--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyApplicationExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyApplicationExceptionMapper.java
@@ -33,7 +33,7 @@ public class SamlProxyApplicationExceptionMapper extends AbstractContextExceptio
         levelLogger.log(exception.getExceptionType().getLevel(), exception, errorId);
 
         return Response.serverError()
-                .entity(ErrorStatusDto.createAuditedErrorStatus(errorId, exception.getExceptionType()))
+                .entity(ErrorStatusDto.createAuditedErrorStatus(errorId, exception.getExceptionType(), exception.getMessage()))
                 .build();
     }
 }

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/AbstractContextExceptionMapperTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/AbstractContextExceptionMapperTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.common.ErrorStatusDto;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.hub.samlproxy.Urls;
 
@@ -67,6 +68,7 @@ public class AbstractContextExceptionMapperTest {
         Response response = mapper.toResponse(new RuntimeException("We don't expect to see this message"));
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertThat(response.getEntity()).isInstanceOf(ErrorStatusDto.class);
     }
 
     @Test

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyApplicationExceptionMapperTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyApplicationExceptionMapperTest.java
@@ -48,7 +48,7 @@ public class SamlProxyApplicationExceptionMapperTest {
     public HttpServletRequest servletRequest;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         servletRequest = mock(HttpServletRequest.class);
         when(servletRequest.getParameter(SESSION_ID_PARAM)).thenReturn(sessionId.toString());
         when(servletRequestProvider.get()).thenReturn(servletRequest);
@@ -60,7 +60,7 @@ public class SamlProxyApplicationExceptionMapperTest {
     }
 
     @Test
-    public void toResponse_shouldAuditException() throws Exception {
+    public void toResponse_shouldAuditException() {
         URI exceptionUri = URI.create("/exception-uri");
         ApplicationException exception = createUnauditedException(exceptionType, errorId, exceptionUri);
 
@@ -70,7 +70,7 @@ public class SamlProxyApplicationExceptionMapperTest {
     }
 
     @Test
-    public void toResponse_shouldReturnAuditedErrorResponse() throws Exception {
+    public void toResponse_shouldReturnAuditedErrorResponse() {
         ApplicationException exception = createAuditedException(exceptionType, errorId);
 
         final Response response = mapper.toResponse(exception);
@@ -81,18 +81,10 @@ public class SamlProxyApplicationExceptionMapperTest {
     }
 
     @Test
-    public void shouldLogExceptionAtCorrectLevel() throws Exception {
+    public void shouldLogExceptionAtCorrectLevel() {
         ApplicationException exception = createAuditedException(exceptionType, errorId);
         mapper.toResponse(exception);
 
         verify(levelLogger).log(eq(exception.getExceptionType().getLevel()), eq(exception), any(UUID.class));
-    }
-
-    private ApplicationException createUnauditedExceptionThatShouldNotBeAudited() {
-        return createUnauditedException(
-                ExceptionType.NETWORK_ERROR,
-                UUID.randomUUID(),
-                URI.create("/some-uri")
-        );
     }
 }


### PR DESCRIPTION
Currently, if a user fails authentication with the Middleware and and goes back and retries, Policy will throw an `INVALID_STATE` exception. SAML Proxy will pick that up and in turn return an HTTP response. Frontend expects a JSON body, however, and cannot parse the response. The JSON library code throws an exception that may be handled at the top level. In prod users get correctly redirected to the "Something went wrong page" but we see an entry in Sentry every time with the message ```Couldn't parse JSON``` instead of the actual exception message. In non-prod environments, devs see the Ruby error page.


Summary of changes:
  - **FIX 1: Send JSON in the response body from SAML Proxy so frontend can handle it**
    - Add a line to `AbstractContextExceptionMapper` in SAML Proxy to make sure that it returns a JSON body that Frontend can handle.
    - Add `/EidasResponse/POST` path to the list of paths which we don't expect to have context. The regular IDP response path was in that list but the eIDAS path wasn't and that caused `INVALID_STATE` exceptions for eIDAS journeys to not be handled properly.
    - Add exception message to the JSON body when handling `SamlProxyApplicationException`
  - **FIX 2: Business logic to handle multiple authn responses from a country in EidasAuthnFailed state**
    - When handling a country response, if the session is in `EidasAuthnFailedErrorState` return non-success response action