### PR TITLE
make eventSinkUri an optional configuration parameter

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyConfiguration.java
@@ -56,7 +56,6 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     public Boolean enableRetryTimeOutConnections = false;
 
     @Valid
-    @NotNull
     @JsonProperty
     public URI eventSinkUri;
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -8,7 +8,6 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.common.shared.security.IdGenerator;
 import uk.gov.ida.eventemitter.Configuration;
-import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkProxy;
 import uk.gov.ida.hub.policy.annotations.Config;
@@ -65,7 +64,6 @@ public class PolicyModule extends AbstractModule {
         bind(KeyStoreLoader.class).toInstance(new KeyStoreLoader());
         bind(InfinispanStartupTasks.class).asEagerSingleton();
         bind(JsonResponseProcessor.class);
-        bind(EventSinkProxy.class).to(EventSinkHttpProxy.class);
         bind(HubEventLogger.class);
         bind(SessionService.class);
         bind(CountriesService.class);
@@ -152,10 +150,13 @@ public class PolicyModule extends AbstractModule {
     }
 
     @Provides
-    @EventSink
     @Singleton
-    public URI eventSinkUri(PolicyConfiguration policyConfiguration) {
-        return policyConfiguration.getEventSinkUri();
+    public EventSinkProxy eventSinkProxy(JsonClient jsonClient, PolicyConfiguration policyConfiguration, Environment environment) {
+        URI eventSinkUri = policyConfiguration.getEventSinkUri();
+        if (eventSinkUri != null) {
+            return new EventSinkHttpProxy(jsonClient, eventSinkUri, environment);
+        }
+        return event -> {};
     }
 
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -57,7 +57,6 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     protected Boolean enableRetryTimeOutConnections = false;
 
     @Valid
-    @NotNull
     @JsonProperty
     protected URI eventSinkUri;
 

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -60,7 +60,6 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     protected Boolean enableRetryTimeOutConnections = false;
 
     @Valid
-    @NotNull
     @JsonProperty
     protected URI eventSinkUri;
 

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -22,7 +22,6 @@ import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.PKIXParametersProvider;
 import uk.gov.ida.eventemitter.Configuration;
-import uk.gov.ida.eventsink.EventSink;
 import uk.gov.ida.eventsink.EventSinkHttpProxy;
 import uk.gov.ida.eventsink.EventSinkProxy;
 import uk.gov.ida.hub.samlsoapproxy.annotations.Config;
@@ -95,7 +94,6 @@ public class SamlSoapProxyModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(TrustStoreConfiguration.class).to(SamlSoapProxyConfiguration.class);
-        bind(EventSinkProxy.class).to(EventSinkHttpProxy.class);
         bind(PublicKeyInputStreamFactory.class).toInstance(new PublicKeyFileInputStreamFactory());
         bind(RestfulClientConfiguration.class).to(SamlSoapProxyConfiguration.class);
         bind(Client.class).toProvider(DefaultClientProvider.class).asEagerSingleton();
@@ -258,10 +256,13 @@ public class SamlSoapProxyModule extends AbstractModule {
     }
 
     @Provides
-    @EventSink
     @Singleton
-    public URI eventSinkUri(SamlSoapProxyConfiguration policyConfiguration) {
-        return policyConfiguration.getEventSinkUri();
+    public EventSinkProxy eventSinkProxy(JsonClient jsonClient, SamlSoapProxyConfiguration samlSoapProxyConfiguration, Environment environment) {
+        URI eventSinkUri = samlSoapProxyConfiguration.getEventSinkUri();
+        if (eventSinkUri != null) {
+            return new EventSinkHttpProxy(jsonClient, eventSinkUri, environment);
+        }
+        return event -> {};
     }
 
     @Provides


### PR DESCRIPTION
This removes @NotNull from eventSinkUri in policy, saml proxy and saml
soap proxy.  It also changes their respective modules to register a
no-op EventSinkProxy implementation if eventSinkUri is not provided.

All environments now support the new eventEmitterConfiguration option
instead so eventSinkUri is no longer required.