### PR TITLE
Prepare to rotate microservice tls cert

### DIFF
--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -90,6 +90,7 @@ httpClient:
     protocol: TLSv1.2
     trustStorePath: /ida/policy/policy.ks
     trustStorePassword: ${HTTP_TLS_TRUSTSTORE_PASSWORD}
+    trustSelfSignedCertificates: true
     verifyHostname: false
 
 samlSoapProxyClient:

--- a/debian/saml-engine/saml-engine.yml
+++ b/debian/saml-engine/saml-engine.yml
@@ -53,6 +53,7 @@ httpClient:
   tls:
     protocol: TLSv1.2
     verifyHostname: false
+    trustSelfSignedCertificates: true
     trustStorePath: /ida/saml-engine/saml-engine.ks
     trustStorePassword: ${HTTP_TLS_TRUSTSTORE_PASSWORD}
 

--- a/debian/saml-proxy/saml-proxy.yml
+++ b/debian/saml-proxy/saml-proxy.yml
@@ -51,6 +51,7 @@ httpClient:
   tls:
     protocol: TLSv1.2
     verifyHostname: false
+    trustSelfSignedCertificates: true
     trustStorePath: /ida/saml-proxy/saml-proxy.ks
     trustStorePassword: ${KEYSTORE_PASSWORD}
 

--- a/debian/saml-soap-proxy/saml-soap-proxy.yml
+++ b/debian/saml-soap-proxy/saml-soap-proxy.yml
@@ -53,6 +53,7 @@ httpClient:
   tls:
     protocol: TLSv1.2
     verifyHostname: false
+    trustSelfSignedCertificates: true
     trustStorePath: /ida/saml-soap-proxy/saml-soap-proxy.ks
     trustStorePassword: ${KEYSTORE_PASSWORD}
 


### PR DESCRIPTION
We need to rotate the microservice tls cert

The puppet module we are using that builds the keystore only supports
one key and cert

While we rotate the key and cert we need the httpClient to not care
whether the cert is in the truststore or not

This only affects internal TLS as the external truststores are separate

We will do the rotation in puppet after this goes out