### PR TITLE
Allow policy to trust self signed certs internally

### DIFF
--- a/debian/policy/policy.yml
+++ b/debian/policy/policy.yml
@@ -104,6 +104,7 @@ samlSoapProxyClient:
     protocol: TLSv1.2
     trustStorePath: /ida/truststore/saml_soap_proxy_tls_truststore.ts
     trustStorePassword: ${SAML_SOAP_PROXY_TLS_TRUSTSTORE_PASSWORD}
+    trustSelfSignedCertificates: true
     verifyHostname: ${SAML_SOAP_PROXY_TLS_CLIENT_VERIFYHOSTNAME}
 
 configUri: https://config:50243


### PR DESCRIPTION
Policy has a separate client specifically for saml soap proxy which
needs to allow self signed certs while we rotate the ms tls cert

See 48d992893c for more context