### PR TITLE
AUTO110: Add Prometheus bundles to all applications

### DIFF
--- a/debian/config/config.yml
+++ b/debian/config/config.yml
@@ -72,3 +72,5 @@ clientTrustStoreConfiguration:
 rpTrustStoreConfiguration:
   path: /ida/truststore/ida_rp_truststore.ts
   password: ${RP_TRUSTSTORE_PASSWORD}
+
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/debian/saml-engine/saml-engine.yml
+++ b/debian/saml-engine/saml-engine.yml
@@ -180,3 +180,5 @@ country:
         protocol: TLSv1.2
         verifyHostname: false
         trustSelfSignedCertificates: true
+
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/debian/saml-proxy/saml-proxy.yml
+++ b/debian/saml-proxy/saml-proxy.yml
@@ -166,3 +166,4 @@ eventEmitterConfiguration:
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
 
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/debian/saml-soap-proxy/saml-soap-proxy.yml
+++ b/debian/saml-soap-proxy/saml-soap-proxy.yml
@@ -179,3 +179,4 @@ eventEmitterConfiguration:
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
 
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/config/build.gradle
+++ b/hub/config/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     compile configurations.ida_utils,
             configurations.config,
             configurations.dropwizard,
-            configurations.common
+            configurations.common,
+            configurations.prometheus
 }
 
 apply plugin: 'application'

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.config;
 
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
+import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -49,6 +50,7 @@ public class ConfigApplication extends Application<ConfigConfiguration> {
         bootstrap.addBundle(new ServiceStatusBundle());
         bootstrap.addBundle(new MonitoringBundle());
         bootstrap.addBundle(new LoggingBundle());
+        bootstrap.addBundle(new PrometheusBundle());
         bootstrap.addCommand(new ConfigValidCommand());
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
 import io.dropwizard.Configuration;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
@@ -13,7 +14,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ConfigConfiguration extends Configuration implements TrustStoreConfiguration, ServiceNameConfiguration {
+public class ConfigConfiguration extends Configuration implements TrustStoreConfiguration, ServiceNameConfiguration, PrometheusConfiguration {
 
     @Valid
     @NotNull
@@ -49,6 +50,10 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @NotNull
     @JsonProperty
     protected Duration certificateWarningPeriod = Duration.days(30);
+
+    @Valid
+    @JsonProperty
+    protected Boolean prometheusEnabled = false;
 
     protected ConfigConfiguration() {}
 
@@ -87,4 +92,8 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
 
     public boolean getEnableRetryTimeOutConnections() { return enableRetryTimeOutConnections; }
 
+    @Override
+    public boolean isPrometheusEnabled() {
+        return prometheusEnabled;
+    }
 }

--- a/hub/config/src/test/resources/config.yml
+++ b/hub/config/src/test/resources/config.yml
@@ -43,3 +43,5 @@ clientTrustStoreConfiguration:
 rpTrustStoreConfiguration:
   path: ${RP_TRUSTSTORE_PATH}
   password: ${RP_TRUSTSTORE_PASSWORD}
+
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/saml-engine/build.gradle
+++ b/hub/saml-engine/build.gradle
@@ -11,8 +11,8 @@ dependencies {
             configurations.soap,
             configurations.common,
             configurations.ida_utils,
-            configurations.trust_anchor
-
+            configurations.trust_anchor,
+            configurations.prometheus
 }
 
 apply plugin: 'application'

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
@@ -6,6 +6,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
+import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -81,6 +82,7 @@ public class SamlEngineApplication extends Application<SamlEngineConfiguration> 
                         bindMetadata())
                 .build();
         bootstrap.addBundle(guiceBundle);
+        bootstrap.addBundle(new PrometheusBundle());
     }
 
     private Module bindMetadata() {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.samlengine;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
@@ -25,7 +26,7 @@ import java.net.URI;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SamlEngineConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, InfinispanServiceConfiguration, SamlDuplicateRequestValidationConfiguration, SamlAuthnRequestValidityDurationConfiguration {
+public class SamlEngineConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, InfinispanServiceConfiguration, SamlDuplicateRequestValidationConfiguration, SamlAuthnRequestValidityDurationConfiguration, PrometheusConfiguration {
 
     protected SamlEngineConfiguration() {}
 
@@ -100,6 +101,10 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
+    @Valid
+    @JsonProperty
+    protected Boolean prometheusEnabled = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -171,4 +176,8 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @Override
     public boolean getEnableRetryTimeOutConnections() { return enableRetryTimeOutConnections; }
 
+    @Override
+    public boolean isPrometheusEnabled() {
+        return prometheusEnabled;
+    }
 }

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -146,3 +146,5 @@ country:
         protocol: TLSv1.2
         verifyHostname: false
         trustSelfSignedCertificates: true
+
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/saml-proxy/build.gradle
+++ b/hub/saml-proxy/build.gradle
@@ -7,7 +7,8 @@ dependencies {
             configurations.dropwizard,
             configurations.saml,
             configurations.common,
-            configurations.verify_event_emitter
+            configurations.verify_event_emitter,
+            configurations.prometheus
 }
 
 apply plugin: 'application'

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.samlproxy;
 
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
+import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -58,6 +59,7 @@ public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
         bootstrap.addBundle(new ServiceStatusBundle());
         bootstrap.addBundle(new MonitoringBundle());
         bootstrap.addBundle(new LoggingBundle());
+        bootstrap.addBundle(new PrometheusBundle());
     }
 
     @Override

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.ida.hub.samlproxy;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.util.Duration;
@@ -22,7 +23,7 @@ import java.net.URI;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SamlProxyConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration {
+public class SamlProxyConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, PrometheusConfiguration {
 
     protected SamlProxyConfiguration(){}
 
@@ -93,6 +94,10 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
 
+    @Valid
+    @JsonProperty
+    protected Boolean prometheusEnabled = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -153,5 +158,10 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
 
     public boolean isEidasEnabled(){
         return getCountryConfiguration().isPresent() && getCountryConfiguration().get().isEnabled();
+    }
+
+    @Override
+    public boolean isPrometheusEnabled() {
+        return prometheusEnabled;
     }
 }

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -127,3 +127,5 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}
+
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/saml-soap-proxy/build.gradle
+++ b/hub/saml-soap-proxy/build.gradle
@@ -9,7 +9,8 @@ dependencies {
             configurations.saml,
             configurations.common,
             configurations.soap,
-            configurations.verify_event_emitter
+            configurations.verify_event_emitter,
+            configurations.prometheus
 }
 
 apply plugin: 'application'

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplication.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyApplication.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
+import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -62,6 +63,7 @@ public class SamlSoapProxyApplication extends Application<SamlSoapProxyConfigura
         bootstrap.addBundle(new ServiceStatusBundle());
         bootstrap.addBundle(new MonitoringBundle());
         bootstrap.addBundle(new LoggingBundle());
+        bootstrap.addBundle(new PrometheusBundle());
     }
 
     private AbstractModule bindVerifyMetadata() {

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.samlsoapproxy;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
@@ -19,7 +20,7 @@ import javax.validation.constraints.NotNull;
 import java.net.URI;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SamlSoapProxyConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration {
+public class SamlSoapProxyConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, PrometheusConfiguration {
 
     protected SamlSoapProxyConfiguration() {
     }
@@ -92,6 +93,10 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
 
+    @Valid
+    @JsonProperty
+    protected Boolean prometheusEnabled = false;
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -152,5 +157,10 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
 
     public EventEmitterConfiguration getEventEmitterConfiguration() {
         return eventEmitterConfiguration;
+    }
+
+    @Override
+    public boolean isPrometheusEnabled() {
+        return prometheusEnabled;
     }
 }

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -107,3 +107,5 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}
+
+prometheusEnabled: ${PROMETHEUS_ENABLED:-false}


### PR DESCRIPTION
This pull requests adds Prometheus Bundle to Config, SAML Engine, SAML Proxy and SAML SOAP Proxy applications. This change introduces a new configuration item (prometheusEnabled). If `prometheusEnabled` is true then Prometheus metrics endpoint (/prometheus/metrics) will be enabled on the admin port and this will allow Prometheus server to scrape metrics from the application's endpoint.  Policy already has Prometheus Bundle and no change is required.

Author: @adityapahuja