### PR TITLE
EID-1072 Bump saml-libs to version 169

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-34',
-            saml_libs:"$opensaml_version-163",
+            saml_libs:"$opensaml_version-169",
         ]
 
 subprojects {
@@ -89,7 +89,6 @@ subprojects {
         ida_utils
         ida_test_utils
         dev_pki
-        trust_anchor
         saml_libs
         prometheus
         redis
@@ -132,8 +131,6 @@ subprojects {
         saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
              "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_libs",
              project(":hub-saml")
-
-        trust_anchor "uk.gov.ida.eidas:trust-anchor:1.0-31"
 
         saml_test project(":hub-saml-test-utils")
 

--- a/hub/saml-engine/build.gradle
+++ b/hub/saml-engine/build.gradle
@@ -11,7 +11,6 @@ dependencies {
             configurations.soap,
             configurations.common,
             configurations.ida_utils,
-            configurations.trust_anchor,
             configurations.prometheus
 }
 

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/HealthCheckTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/HealthCheckTest.java
@@ -8,7 +8,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.ConfigStubRule;
-import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.MetadataRule;
 import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule;
 
 import javax.ws.rs.client.Client;
@@ -16,7 +15,7 @@ import javax.ws.rs.client.Client;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.samlengine.SamlEngineModule.COUNTRY_METADATA_HEALTH_CHECK;
-import static uk.gov.ida.hub.samlengine.SamlEngineModule.VERIFY_METADATA_HEALTH_CHECK;
+import static uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule.VERIFY_METADATA_PATH;
 
 public class HealthCheckTest {
 
@@ -39,7 +38,7 @@ public class HealthCheckTest {
 
     @Test
     public void shouldContainBothVerifyAndCountryMetadataHealthChecks() {
-        assertThat(samlEngineAppRule.getEnvironment().healthChecks().getNames().contains(VERIFY_METADATA_HEALTH_CHECK)).isTrue();
+        assertThat(samlEngineAppRule.getEnvironment().healthChecks().getNames().stream().anyMatch(name -> name.contains(VERIFY_METADATA_PATH))).isTrue();
         assertThat(samlEngineAppRule.getEnvironment().healthChecks().getNames().contains(COUNTRY_METADATA_HEALTH_CHECK)).isTrue();
     }
 }

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/HealthCheckWithoutCountryTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/HealthCheckWithoutCountryTest.java
@@ -8,7 +8,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.ConfigStubRule;
-import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.MetadataRule;
 import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule;
 
 import javax.ws.rs.client.Client;
@@ -16,7 +15,7 @@ import javax.ws.rs.client.Client;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.samlengine.SamlEngineModule.COUNTRY_METADATA_HEALTH_CHECK;
-import static uk.gov.ida.hub.samlengine.SamlEngineModule.VERIFY_METADATA_HEALTH_CHECK;
+import static uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule.VERIFY_METADATA_PATH;
 
 public class HealthCheckWithoutCountryTest {
 
@@ -40,7 +39,7 @@ public class HealthCheckWithoutCountryTest {
 
     @Test
     public void shouldContainBothVerifyAndCountryMetadataHealthChecks() {
-        assertThat(samlEngineAppRule.getEnvironment().healthChecks().getNames().contains(VERIFY_METADATA_HEALTH_CHECK)).isTrue();
+        assertThat(samlEngineAppRule.getEnvironment().healthChecks().getNames().stream().anyMatch(name -> name.contains(VERIFY_METADATA_PATH))).isTrue();
         assertThat(samlEngineAppRule.getEnvironment().healthChecks().getNames().contains(COUNTRY_METADATA_HEALTH_CHECK)).isFalse();
     }
 }

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -59,7 +59,7 @@ import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
 import static uk.gov.ida.saml.metadata.ResourceEncoder.entityIdAsResource;
 
 public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration> {
-    private static final String VERIFY_METADATA_PATH = "/uk/gov/ida/saml/metadata/federation";
+    public static final String VERIFY_METADATA_PATH = "/uk/gov/ida/saml/metadata/federation";
     private static final String COUNTRY_METADATA_PATH = "/uk/gov/ida/saml/metadata/country";
     public static final String EIDAS_ENTITY_ID = "http://localhost/eidasMetadata";
     private static final String TRUST_ANCHOR_PATH = "/trust-anchor";

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -146,8 +146,8 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
         return readKeysFromFileDescriptors;
     }
 
-    public MetadataResolverConfiguration getMetadataConfiguration() {
-        return metadata;
+    public Optional<MetadataResolverConfiguration> getMetadataConfiguration() {
+        return Optional.of(metadata);
     }
 
     @Override

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -156,7 +156,6 @@ import static java.util.Arrays.asList;
 
 public class SamlEngineModule extends AbstractModule {
 
-    public static final String VERIFY_METADATA_HEALTH_CHECK = "VerifyMetadataHealthCheck";
     public static final String COUNTRY_METADATA_HEALTH_CHECK = "CountryMetadataHealthCheck";
     public static final String EIDAS_HUB_ENTITY_ID_NOT_CONFIGURED_ERROR_MESSAGE = "eIDAS hub entity id is not configured";
     public static final String VERIFY_METADATA_RESOLVER = "VerifyMetadataResolver";
@@ -291,17 +290,6 @@ public class SamlEngineModule extends AbstractModule {
         return expectedDestination.map(d -> new DestinationValidator(d, Urls.FrontendUrls.SAML2_SSO_EIDAS_RESPONSE_ENDPOINT));
     }
 
-    @Provides
-    @Singleton
-    @Named(VERIFY_METADATA_HEALTH_CHECK)
-    private MetadataHealthCheck getVerifyMetadataHealthCheck(
-        @Named("VerifyMetadataResolver") MetadataResolver metadataResolver,
-        Environment environment,
-        SamlEngineConfiguration configuration) {
-        MetadataHealthCheck metadataHealthCheck = new MetadataHealthCheck(metadataResolver, configuration.getMetadataConfiguration().getExpectedEntityId());
-        environment.healthChecks().register(VERIFY_METADATA_HEALTH_CHECK, metadataHealthCheck);
-        return metadataHealthCheck;
-    }
 
     @Provides
     @Named("VERIFY_METADATA_REFRESH_TASK")

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -18,6 +18,7 @@ import uk.gov.ida.truststore.TrustStoreConfiguration;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SamlSoapProxyConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, PrometheusConfiguration {
@@ -117,8 +118,8 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
         return policyUri;
     }
 
-    public MetadataResolverConfiguration getMetadataConfiguration() {
-        return metadata;
+    public Optional<MetadataResolverConfiguration> getMetadataConfiguration() {
+        return Optional.of(metadata);
     }
 
     @Override

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -37,6 +37,7 @@ import uk.gov.ida.hub.samlsoapproxy.config.ConfigServiceKeyStore;
 import uk.gov.ida.hub.samlsoapproxy.config.SamlConfiguration;
 import uk.gov.ida.hub.samlsoapproxy.config.TrustStoreForCertificateProvider;
 import uk.gov.ida.hub.samlsoapproxy.domain.TimeoutEvaluator;
+import uk.gov.ida.hub.samlsoapproxy.exceptions.MissingMetadataException;
 import uk.gov.ida.hub.samlsoapproxy.health.MetadataHealthCheckRegistry;
 import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthCheckHandler;
 import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthChecker;
@@ -80,6 +81,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.cert.CertificateException;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
@@ -149,7 +151,10 @@ public class SamlSoapProxyModule extends AbstractModule {
     @Provides
     @Singleton
     public MetadataHealthCheck getMetadataHealthCheck(MetadataResolver metadataResolver, SamlSoapProxyConfiguration configuration) {
-        return new MetadataHealthCheck(metadataResolver, configuration.getMetadataConfiguration().getExpectedEntityId());
+        return new MetadataHealthCheck(
+            metadataResolver,
+            configuration.getMetadataConfiguration().orElseThrow(() -> new MissingMetadataException()).getExpectedEntityId()
+        );
     }
 
     @Provides
@@ -297,7 +302,7 @@ public class SamlSoapProxyModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public MetadataResolverConfiguration metadataConfiguration(SamlSoapProxyConfiguration samlSoapProxyConfiguration) {
+    public Optional<MetadataResolverConfiguration> metadataConfiguration(SamlSoapProxyConfiguration samlSoapProxyConfiguration) {
         return samlSoapProxyConfiguration.getMetadataConfiguration();
     }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/exceptions/MissingMetadataException.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/exceptions/MissingMetadataException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.hub.samlsoapproxy.exceptions;
+
+public class MissingMetadataException extends RuntimeException {
+    public MissingMetadataException() {
+        super();
+    }
+}


### PR DESCRIPTION
It pulls in a few new things.

An update to EidasMetadataResolverRepository to throw an exception
instead of an error if it encounters certificate that's expired. This is
useful in saml-engine and saml-proxy.

MetadataResolverBundle has been updated to generate a dropwizard
healthcheck for the metadata, rather than the app itself having to do
it. This meant the healtcheck being created in saml-engine could be
removed.

It allows optional metadata bundling, which required an update to the
config class for saml-engine as well as saml-soap-proxy to support
Optionals being returned by `getMetadataConfiguration`. The metadata is
always not null in these cases to impact is minimal.