### PR TITLE
ZD-3567692: Add error metrics to SSP endpoint

### DIFF
--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/resources/AttributeQueryRequestSenderResource.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/resources/AttributeQueryRequestSenderResource.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.samlsoapproxy.resources;
 
+import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +37,7 @@ public class AttributeQueryRequestSenderResource {
 
     @POST
     @Timed
+    @ResponseMetered
     public Response sendAttributeQueryRequest(final AttributeQueryContainerDto attributeQueryContainerDto, @QueryParam(Urls.SharedUrls.SESSION_ID_PARAM) SessionId sessionId) {
         LOG.info("Received request to send attribute query {} to {}", attributeQueryContainerDto.getId(), attributeQueryContainerDto.getMatchingServiceUri());
 


### PR DESCRIPTION
- In commit 22cca62 we added `@ResponseMetered` annotations to the
  SAML-Proxy endpoints and have used them to monitor the "success %age"
of our SAML requests in Hub
- As requests to SAML SOAP Proxy do not go through SAML Proxy, errors
  occurring when sending AQRs aren't currently tracked
- Adding this metric will mean that we can track the number of errors
  being thrown in the endpoint
- By monitoring the endpoint itself, we only report on when a request
  completely fails (so if an attempt fails but passes in a future retry
this metric reports it as OK)