### PR TITLE
BAU: Do not run the MSA healthchecks against non-matching RPs

### DIFF
--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/MatchingServiceResourceIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/MatchingServiceResourceIntegrationTest.java
@@ -36,6 +36,10 @@ public class MatchingServiceResourceIntegrationTest {
                     .withEntityId("rp-entity-id")
                     .withMatchingServiceEntityId(ENTITY_ID)
                     .build())
+            .addTransaction(aTransactionConfigData()
+                    .withEntityId("rp-entity-id-no-matching")
+                    .withUsingMatching(false)
+                    .build())
             .addMatchingService(aMatchingServiceConfigEntityData()
                     .withEntityId(ENTITY_ID)
                     .withUri(URI.create(MATCHING_URI))
@@ -57,7 +61,7 @@ public class MatchingServiceResourceIntegrationTest {
     public void getMatchingServices_returnsOkAndListOfMatchingServices(){
         Response response = client.target(configAppRule.getUri(Urls.ConfigUrls.MATCHING_SERVICE_ROOT).build()).request().get();
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        assertThat(response.readEntity(Collection.class)).isNotEmpty();
+        assertThat(response.readEntity(Collection.class).size()).isEqualTo(1);
     }
 
     @Test

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/MatchingServiceAdapterService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/MatchingServiceAdapterService.java
@@ -35,6 +35,7 @@ public class MatchingServiceAdapterService {
 
     public List<MatchingServicePerTransaction> getMatchingServices() {
         return transactionConfigEntityDataRepository.getAllData().stream()
+                .filter(transaction -> transaction.isUsingMatching())
                 .map(transaction -> new MatchingServicePerTransaction(transaction.getEntityId(),
                         matchingServiceConfigEntityDataRepository.getData(transaction.getMatchingServiceEntityId()).get()))
                 .collect(toList());


### PR DESCRIPTION
This change filters out the non-matching services on the getMatchingServices method.