### PR TITLE
BAU: Fix pre-commit failing to start Hub components

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -31,7 +31,7 @@ function funky_fail_banner {
 echo "Running tests"
 ./shutdown.sh
 
-if ./gradlew --parallel --daemon clean build intTest 2>/dev/null; then
+if ./gradlew --parallel --daemon clean build intTest installDist 2>/dev/null; then
   echo "Checking for dependency updates:"
   tput setaf 3
   ./gradlew -q dependencyUpdates -Drevision=release \


### PR DESCRIPTION
The startup.sh script needs gradle to complete installDist task before starting Hub components (e.g. Config, SAML Engine, SAML Proxy, SAML SOAP Proxy and Policy).

I have tested pre-commit.sh script and it is working properly.

Author: @adityapahuja