### PR TITLE
AUTO-146: Add OCSP Revocation Status to Certificate Metrics

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
@@ -94,8 +94,8 @@ public class ConfigModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private PrometheusClientService getPrometheusClientService(CertificateService certificateService) {
-        return new PrometheusClientService(certificateService);
+    private PrometheusClientService getPrometheusClientService(CertificateService certificateService, OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker) {
+        return new PrometheusClientService(certificateService, ocspCertificateChainValidityChecker);
     }
 
     @Provides

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigValidCommand.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigValidCommand.java
@@ -28,6 +28,7 @@ import uk.gov.ida.hub.config.domain.CertificateValidityChecker;
 import uk.gov.ida.hub.config.domain.CountriesConfigEntityData;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
 import uk.gov.ida.hub.config.domain.MatchingServiceConfigEntityData;
+import uk.gov.ida.hub.config.domain.OCSPCertificateChainValidityChecker;
 import uk.gov.ida.hub.config.domain.ThrowingCertificateChainConfigValidator;
 import uk.gov.ida.hub.config.domain.TransactionConfigEntityData;
 import uk.gov.ida.hub.config.domain.TranslationData;
@@ -75,12 +76,13 @@ public class ConfigValidCommand extends ConfiguredCommand<ConfigConfiguration> {
                         bind(CertificateChainConfigValidator.class)
                                 .annotatedWith(CertificateConfigValidator.class)
                                 .to(ThrowingCertificateChainConfigValidator.class);
+                        bind(OCSPCertificateChainValidityChecker.class);
                     }
 
                     @Provides
                     @Singleton
-                    private PrometheusClientService getPrometheusClientService(CertificateService certificateService) {
-                        return new PrometheusClientService(certificateService);
+                    private PrometheusClientService getPrometheusClientService(CertificateService certificateService, OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker) {
+                        return new PrometheusClientService(certificateService, ocspCertificateChainValidityChecker);
                     }
 
                     @Provides

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
@@ -1,0 +1,48 @@
+package uk.gov.ida.hub.config.application;
+
+import io.prometheus.client.Gauge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.hub.config.domain.CertificateDetails;
+import uk.gov.ida.hub.config.domain.OCSPCertificateChainValidityChecker;
+
+import java.security.cert.CertificateException;
+import java.util.Set;
+import java.util.TimerTask;
+
+public class OcspCertificateChainValidationService extends TimerTask {
+    private static final Logger LOG = LoggerFactory.getLogger(OcspCertificateChainValidationService.class);
+    private final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker;
+    private final CertificateService certificateService;
+    private final Gauge gauge;
+
+    public OcspCertificateChainValidationService(final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker,
+                                                 final CertificateService certificateService,
+                                                 final Gauge gauge) {
+        this.ocspCertificateChainValidityChecker = ocspCertificateChainValidityChecker;
+        this.certificateService = certificateService;
+        this.gauge = gauge;
+    }
+
+
+    @Override
+    public void run() {
+        final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+
+        certificateDetailsSet.forEach(
+            certificateDetails -> {
+                try {
+                    gauge.labels(
+                        certificateDetails.getIssuerId(),
+                        certificateDetails.getCertificate().getCertificateType().toString(),
+                        certificateDetails.getCertificate().getSubject(),
+                        certificateDetails.getCertificate().getFingerprint())
+                         .set(ocspCertificateChainValidityChecker.isValid(
+                             certificateDetails.getCertificate(),
+                             certificateDetails.getFederationEntityType()) ? 1.0 : 0.0);
+                } catch (CertificateException e) {
+                    LOG.warn(String.format("Invalid X.509 certificate [issuer id: %s]", certificateDetails.getIssuerId()));
+                }
+            });
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
@@ -4,18 +4,23 @@ import io.prometheus.client.Gauge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.config.domain.CertificateDetails;
+import uk.gov.ida.hub.config.domain.OCSPCertificateChainValidityChecker;
 
 import javax.inject.Inject;
 import java.security.cert.CertificateException;
 import java.util.Set;
+import java.util.Timer;
 
 public class PrometheusClientService {
     private static final Logger LOG = LoggerFactory.getLogger(PrometheusClientService.class);
     private final CertificateService certificateService;
+    private final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker;
 
     @Inject
-    public PrometheusClientService(final CertificateService certificateService) {
+    public PrometheusClientService(final CertificateService certificateService,
+                                   final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker) {
         this.certificateService = certificateService;
+        this.ocspCertificateChainValidityChecker = ocspCertificateChainValidityChecker;
     }
 
     public void createCertificateExpiryMetrics() {
@@ -37,5 +42,21 @@ public class PrometheusClientService {
                     LOG.warn(String.format("Invalid X.509 certificate [issuer id: %s]", certificateDetails.getIssuerId()));
                 }
             });
+    }
+
+    public void createCertificateOcspSuccessMetrics() {
+        Gauge gauge = Gauge.build("verify_config_certificate_ocsp_success", "Valid X.509 certificate")
+                           .labelNames("entity_id", "use", "subject", "fingerprint")
+                           .register();
+
+        OcspCertificateChainValidationService ocspCertificateChainValidationService =
+            new OcspCertificateChainValidationService(
+                ocspCertificateChainValidityChecker,
+                certificateService,
+                gauge);
+
+        Timer timer = new Timer(true);
+        timer.scheduleAtFixedRate(ocspCertificateChainValidationService, 0, 60*60*1000);
+        LOG.info("OCSP Certificate Chain Validation Service has started.");
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigDataBootstrap.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigDataBootstrap.java
@@ -92,6 +92,7 @@ public class ConfigDataBootstrap implements Managed {
             .accept(allConfig);
 
         prometheusClientService.createCertificateExpiryMetrics();
+        prometheusClientService.createCertificateOcspSuccessMetrics();
     }
 
     @Override

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateValidityChecker.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateValidityChecker.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.CertificateValidity;
 import uk.gov.ida.common.shared.security.verification.OCSPCertificateChainValidator;
+import uk.gov.ida.hub.config.dto.FederationEntityType;
 import uk.gov.ida.hub.config.dto.InvalidCertificateDto;
 import uk.gov.ida.hub.config.truststore.TrustStoreForCertificateProvider;
 
@@ -49,6 +50,15 @@ public class CertificateValidityChecker {
         CertificateValidity certificateValidity = certificateChainValidator.validate(
                 certificate.getX509(),
                 trustStoreForCertificateProvider.getTrustStoreFor(certificate.getFederationEntityType()));
+
+        return certificateValidity.isValid();
+    }
+
+    public boolean isValid(final Certificate certificate,
+                           final FederationEntityType federationEntityType) {
+        CertificateValidity certificateValidity = certificateChainValidator.validate(
+            certificate.getX509(),
+            trustStoreForCertificateProvider.getTrustStoreFor(federationEntityType));
 
         return certificateValidity.isValid();
     }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/OCSPCertificateChainValidityChecker.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/OCSPCertificateChainValidityChecker.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.config.domain;
 
 import com.google.common.collect.ImmutableList;
 import uk.gov.ida.common.shared.security.verification.OCSPCertificateChainValidator;
+import uk.gov.ida.hub.config.dto.FederationEntityType;
 import uk.gov.ida.hub.config.dto.InvalidCertificateDto;
 import uk.gov.ida.hub.config.truststore.TrustStoreForCertificateProvider;
 
@@ -22,4 +23,8 @@ public class OCSPCertificateChainValidityChecker {
         return certificateValidityChecker.getInvalidCertificates(certificateDetails);
     }
 
+    public boolean isValid(final Certificate certificate,
+                           final FederationEntityType federationEntityType) {
+        return certificateValidityChecker.isValid(certificate, federationEntityType);
+    }
 }


### PR DESCRIPTION
Currently, Sensu hits Config application's /config/certificates/invalid endpoint  which causes it to perform OCSP checking of RP and MSA certificates and returns a list of invalid certificates. Sensu alerts if there are invalid certificates.

This commit adds a new metrics to prometheus metrics which returns all RP and MSA certificates' OCSP revocation statuses updated every 1 hour so that we can add alerts in the new infrastructure for any invalid certificates and also update a dashboard to display a list of certificates' OCSP revocation statuses. This will enable support team to rectify any invalid certificates quickly.

Author: @adityapahuja