### PR TITLE
AUTO-146: Changes to Prometheus Metrics

### DIFF
--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
@@ -155,7 +155,7 @@ public class PrometheusMetricsIntegrationTest {
                 certificate.getCertificateType(),
                 certificate.getSubject(),
                 certificate.getFingerprint(),
-                Long.toString(DateTime.now(DateTimeZone.UTC).getMillis()),
+                DateTime.now(DateTimeZone.UTC).toString(),
                 new Double(new DateTime(certificate.getNotAfter().getTime(), DateTimeZone.UTC).getMillis())));
         } catch (CertificateException e) {
             System.err.println(String.format(CERTIFICATE_EXCEPTION_MESSAGE, entityId, certificate.getCertificateType()));
@@ -172,7 +172,7 @@ public class PrometheusMetricsIntegrationTest {
                 certificate.getCertificateType(),
                 certificate.getSubject(),
                 certificate.getFingerprint(),
-                Long.toString(DateTime.now(DateTimeZone.UTC).getMillis()),
+                DateTime.now(DateTimeZone.UTC).toString(),
                 new Double(INVALID)));
         } catch (CertificateException e) {
             System.err.println(String.format(CERTIFICATE_EXCEPTION_MESSAGE, entityId, certificate.getCertificateType()));

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
@@ -12,10 +12,13 @@ import org.junit.Test;
 import uk.gov.ida.hub.config.CertificateEntity;
 import uk.gov.ida.hub.config.ConfigEntityData;
 import uk.gov.ida.hub.config.domain.Certificate;
+import uk.gov.ida.hub.config.domain.EncryptionCertificate;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
 import uk.gov.ida.hub.config.domain.MatchingServiceConfigEntityData;
+import uk.gov.ida.hub.config.domain.SignatureVerificationCertificate;
 import uk.gov.ida.hub.config.domain.TransactionConfigEntityData;
 import uk.gov.ida.integrationtest.hub.config.apprule.support.ConfigAppRule;
+import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -28,44 +31,88 @@ import java.util.Optional;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.hub.config.application.PrometheusClientService.VERIFY_CONFIG_CERTIFICATE_EXPIRY;
+import static uk.gov.ida.hub.config.domain.builders.EncryptionCertificateBuilder.anEncryptionCertificate;
 import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
 import static uk.gov.ida.hub.config.domain.builders.MatchingServiceConfigEntityDataBuilder.aMatchingServiceConfigEntityData;
+import static uk.gov.ida.hub.config.domain.builders.SignatureVerificationCertificateBuilder.aSignatureVerificationCertificate;
 import static uk.gov.ida.hub.config.domain.builders.TransactionConfigEntityDataBuilder.aTransactionConfigData;
 
 public class PrometheusMetricsIntegrationTest {
     private static Client client;
+    private static final int WAIT_FOR_CERTIFICATE_METRICS_TO_BE_UPDATED = 2_500;
     private static final String RP_ENTITY_ID = "rp-entity-id";
     private static final String RP_MS_ENTITY_ID = "rp-ms-entity-id";
-    private static final String CERTIFICATE_METRICS_TEMPLATE = "verify_config_certificate_expiry{entity_id=\"%s\",use=\"%s\",subject=\"%s\",fingerprint=\"%s\",} %s\n";
-    private static final TransactionConfigEntityData TRANSACTION_CONFIG_ENTITY_DATA = aTransactionConfigData().withEntityId(RP_ENTITY_ID).withMatchingServiceEntityId(RP_MS_ENTITY_ID).build();
-    private static final MatchingServiceConfigEntityData MATCHING_SERVICE_CONFIG_ENTITY_DATA = aMatchingServiceConfigEntityData().withEntityId(RP_MS_ENTITY_ID).build();
-    private static final IdentityProviderConfigEntityData IDENTITY_PROVIDER_CONFIG_ENTITY_DATA = anIdentityProviderConfigData().withEntityId("idp-entity-id").withOnboarding(asList(RP_ENTITY_ID)).build();
+    private static final String CERTIFICATE_METRICS_TEMPLATE = "verify_config_certificate_expiry{entity_id=\"%s\",use=\"%s\",subject=\"%s\",fingerprint=\"%s\",timestamp=\"%s\",} %s\n";
+    private static final TransactionConfigEntityData TRANSACTION_CONFIG_ENTITY_DATA = aTransactionConfigData().withEntityId(RP_ENTITY_ID)
+                                                                                                              .withMatchingServiceEntityId(RP_MS_ENTITY_ID)
+                                                                                                              .build();
+    private static final MatchingServiceConfigEntityData MATCHING_SERVICE_CONFIG_ENTITY_DATA = aMatchingServiceConfigEntityData().withEntityId(RP_MS_ENTITY_ID)
+                                                                                                                                 .build();
+    private static final IdentityProviderConfigEntityData IDENTITY_PROVIDER_CONFIG_ENTITY_DATA = anIdentityProviderConfigData().withEntityId("idp-entity-id")
+                                                                                                                               .withOnboarding(asList(RP_ENTITY_ID))
+                                                                                                                               .build();
+    private static final String RP_ENTITY_ID_BAD_SIGNATURE_CERT = "rp-entity-id-bad-cert";
+    private static final String RP_ENTITY_ID_BAD_ENCRYPTION_CERT = "rp-entity-id-bad-encryption-cert";
+    private static final String BAD_CERTIFICATE_VALUE = "MIIEZzCCA0+gAwIBAgIQX/UeEoUFa9978uQ8FbLFyDANBgkqhkiG9w0BAQsFADBZMQswCQYDVQQGEwJHQjEXMBUGA1UEChMOQ2FiaW5ldCBPZmZpY2UxDDAKBgNVBAsTA0dEUzEjMCEGA1UEAxMaSURBUCBSZWx5aW5nIFBhcnR5IFRlc3QgQ0EwHhcNMTUwODI3MDAwMDAwWhcNMTcwODI2MjM1OTU5WjCBgzELMAkGA1UEBhMCR0IxDzANBgNVBAgTBkxvbmRvbjEPMA0GA1UEBxMGTG9uZG9uMRcwFQYDVQQKFA5DYWJpbmV0IE9mZmljZTEMMAoGA1UECxQDR0RTMSswKQYDVQQDEyJTYW1wbGUgUlAgU2lnbmluZyAoMjAxNTA4MjYxNjMzMDcpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuIdy6fiwdlLpMOsOiZC8DXcAU1eKDKz0w04TRAdUMR4rdv36IcyTfUortDHQ60pmX4I/s5iksey4UHCqTNZKpw6coCboyFGtGy1M6tTFhrxKc/pZmjEqV0kqgfjUnVWqiOnjpuWOJsCRfScjGfJ4Gio0omnrfX6KOTrnieaSM7aZJ7WkWUe4KRGOyxBywRIyFFbUeNgIbD/IfV7GFZCLUa9XwKjnaidTTmEhihC0TiBcnl3NCeqSwNK0TsIYSh/k5i7U/QeIvc6w34lacHOsqL5woRMPBnmS91brY/hy/vdePx7Nk8Hiwx7VpLsn5b0BVJnEZcLs5gwDid0Vra+6kQIDAQABo4H/MIH8MAwGA1UdEwEB/wQCMAAwYQYDVR0fBFowWDBWoFSgUoZQaHR0cDovL29uc2l0ZWNybC50cnVzdHdpc2UuY29tL0NhYmluZXRPZmZpY2VJREFQUmVseWluZ1BhcnR5VGVzdENBL0xhdGVzdENSTC5jcmwwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBSsYjo5j/oZAQ/h35orm1VR+n5hVTAfBgNVHSMEGDAWgBTd5PVdGgoPOtFIIh5OwPhuNvbFJTA5BggrBgEFBQcBAQQtMCswKQYIKwYBBQUHMAGGHWh0dHA6Ly9zdGQtb2NzcC50cnVzdHdpc2UuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBHYp/kWufCENWW8xI/rwVRJrOjvYxbhyEM61QoMZzTqfSQVuaBCv1qwXTMU8D+iPVtSVStFdU+vxWrU0z8ZQcd9107wZtnIJWwoJJ4WJlrmXTzBNvlqc8Q57G4Y/x9SZZdyVn4JrQRK8Vm5NzZqYZeXqgMk5xeQEObY8EQFmdryZeh/B2j0WFm3ywXOYcz77a1e1WCxBgOULPh1sQD793KjbJlEUfyeq5w/cIPovI8u4xXa78ionzq+L9t3oRh/wuTNjG/qezgArncr53sV2RZzb45RtT9+PxdQ1YFbQM7lL526kxVij0+FS6+b+EBx2CBVLWalmOugi0vA9vYpZJL";
+    private static final SignatureVerificationCertificate BAD_SIGNATURE_CERTIFICATE = aSignatureVerificationCertificate().withX509(BAD_CERTIFICATE_VALUE)
+                                                                                                                         .build();
+    private static final EncryptionCertificate BAD_ENCRYPTION_CERTIFICATE = anEncryptionCertificate().withX509(BAD_CERTIFICATE_VALUE)
+                                                                                                     .build();
 
     @ClassRule
-    public static ConfigAppRule configAppRule = new ConfigAppRule(config("prometheusEnabled", "true"))
-                                                    .addTransaction(TRANSACTION_CONFIG_ENTITY_DATA)
-                                                    .addMatchingService(MATCHING_SERVICE_CONFIG_ENTITY_DATA)
-                                                    .addIdp(IDENTITY_PROVIDER_CONFIG_ENTITY_DATA);
+    public static ConfigAppRule configAppRule = new ConfigAppRule(
+        config("prometheusEnabled", "true"),
+        config("certificateExpiryDateCheckServiceConfiguration.enable", "true"),
+        config("certificateExpiryDateCheckServiceConfiguration.initialDelay", "1s"),
+        config("certificateExpiryDateCheckServiceConfiguration.delay", "2s"))
+                                                        .addTransaction(TRANSACTION_CONFIG_ENTITY_DATA)
+                                                        .addTransaction(aTransactionConfigData().withEntityId(RP_ENTITY_ID_BAD_ENCRYPTION_CERT)
+                                                                                                .withMatchingServiceEntityId(RP_MS_ENTITY_ID)
+                                                                                                .withEncryptionCertificate(BAD_ENCRYPTION_CERTIFICATE)
+                                                                                                .build())
+                                                        .addTransaction(aTransactionConfigData().withEntityId(RP_ENTITY_ID_BAD_SIGNATURE_CERT)
+                                                                                                .withMatchingServiceEntityId(RP_MS_ENTITY_ID)
+                                                                                                .addSignatureVerificationCertificate(BAD_SIGNATURE_CERTIFICATE)
+                                                                                                .build())
+                                                        .addMatchingService(MATCHING_SERVICE_CONFIG_ENTITY_DATA)
+                                                        .addIdp(IDENTITY_PROVIDER_CONFIG_ENTITY_DATA);
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUpBeforeClass() {
         final JerseyClientConfiguration jerseyClientConfiguration = JerseyClientConfigurationBuilder.aJerseyClientConfiguration().withTimeout(Duration.seconds(10)).build();
-        client = new JerseyClientBuilder(configAppRule.getEnvironment()).using(jerseyClientConfiguration).build(CertificatesResourceIntegrationTest.class.getSimpleName());
+        client = new JerseyClientBuilder(configAppRule.getEnvironment()).using(jerseyClientConfiguration).build(PrometheusMetricsIntegrationTest.class.getSimpleName());
     }
 
     @Test
-    public void shouldHaveCertificatesMetrics() {
-        final Response response = client.target(UriBuilder.fromUri("http://localhost")
-                                                          .path("/prometheus/metrics")
-                                                          .port(configAppRule.getAdminPort())
-                                                          .build())
-                                        .request()
-                                        .get();
+    public void shouldHaveUpdatedCertificatesMetrics() throws InterruptedException {
+        DateTimeFreezer.freezeTime();
+        Thread.sleep(WAIT_FOR_CERTIFICATE_METRICS_TO_BE_UPDATED);
+        final DateTime firstTimestamp = DateTime.now(DateTimeZone.UTC);
+        Response response = getPrometheusMetrics();
 
+        assertThatCertificatesMetricsAreCorrect(response);
+        DateTimeFreezer.unfreezeTime();
+
+        DateTimeFreezer.freezeTime();
+        Thread.sleep(WAIT_FOR_CERTIFICATE_METRICS_TO_BE_UPDATED);
+        final DateTime secondTimestamp = DateTime.now(DateTimeZone.UTC);
+        response = getPrometheusMetrics();
+
+        assertThat(firstTimestamp).isNotEqualTo(secondTimestamp);
+        assertThatCertificatesMetricsAreCorrect(response);
+        DateTimeFreezer.unfreezeTime();
+    }
+
+    private void assertThatCertificatesMetricsAreCorrect(final Response response) {
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
         final String entity = response.readEntity(String.class);
-        assertThat(entity).contains("# TYPE verify_config_certificate_expiry gauge\n");
+        assertThat(entity).contains(String.format("# TYPE %s gauge\n", VERIFY_CONFIG_CERTIFICATE_EXPIRY));
         getExpectedCertificatesMetrics().forEach(expectedCertificateMetric -> assertThat(entity).contains(expectedCertificateMetric));
+    }
+
+    private Response getPrometheusMetrics() {
+        return client.target(UriBuilder.fromUri("http://localhost").path("/prometheus/metrics").port(configAppRule.getAdminPort()).build()).request().get();
     }
 
     private List<String> getExpectedCertificatesMetrics() {
@@ -94,6 +141,7 @@ public class PrometheusMetricsIntegrationTest {
                 certificate.getCertificateType(),
                 certificate.getSubject(),
                 certificate.getFingerprint(),
+                Long.toString(DateTime.now(DateTimeZone.UTC).getMillis()),
                 new Double(new DateTime(certificate.getNotAfter().getTime(), DateTimeZone.UTC).getMillis())));
         } catch (CertificateException e) {
             System.err.println(String.format("Unable to get NotAfter from the certificate [issuer = %s, type = %s]", entityId, certificate.getCertificateType()));

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -7,6 +7,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.configuration.ServiceNameConfiguration;
+import uk.gov.ida.hub.config.configuration.PrometheusClientServiceConfiguration;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
@@ -55,6 +56,10 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @JsonProperty
     protected Boolean prometheusEnabled = false;
 
+    @Valid
+    @JsonProperty
+    private PrometheusClientServiceConfiguration certificateExpiryDateCheckServiceConfiguration = new PrometheusClientServiceConfiguration();
+
     protected ConfigConfiguration() {}
 
     public String getDataDirectory() {
@@ -95,5 +100,9 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @Override
     public boolean isPrometheusEnabled() {
         return prometheusEnabled;
+    }
+
+    public PrometheusClientServiceConfiguration getCertificateExpiryDateCheckServiceConfiguration() {
+        return certificateExpiryDateCheckServiceConfiguration;
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -60,6 +60,10 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @JsonProperty
     private PrometheusClientServiceConfiguration certificateExpiryDateCheckServiceConfiguration = new PrometheusClientServiceConfiguration();
 
+    @Valid
+    @JsonProperty
+    private PrometheusClientServiceConfiguration certificateOcspRevocationStatusCheckServiceConfiguration = new PrometheusClientServiceConfiguration();
+
     protected ConfigConfiguration() {}
 
     public String getDataDirectory() {
@@ -104,5 +108,9 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
 
     public PrometheusClientServiceConfiguration getCertificateExpiryDateCheckServiceConfiguration() {
         return certificateExpiryDateCheckServiceConfiguration;
+    }
+
+    public PrometheusClientServiceConfiguration getCertificateOcspRevocationStatusCheckServiceConfiguration() {
+        return certificateOcspRevocationStatusCheckServiceConfiguration;
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
@@ -97,13 +97,16 @@ public class ConfigModule extends AbstractModule {
     private PrometheusClientService getPrometheusClientService(
         Environment environment,
         ConfigConfiguration configConfiguration,
-        CertificateService certificateService) {
+        CertificateService certificateService,
+        OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker) {
 
         PrometheusClientService prometheusClientService = new PrometheusClientService(
             environment,
             configConfiguration,
-            certificateService);
+            certificateService,
+            ocspCertificateChainValidityChecker);
         prometheusClientService.createCertificateExpiryDateCheckMetrics();
+        prometheusClientService.createCertificateOcspRevocationStatusCheckMetrics();
         return prometheusClientService;
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
@@ -94,8 +94,17 @@ public class ConfigModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private PrometheusClientService getPrometheusClientService(CertificateService certificateService) {
-        return new PrometheusClientService(certificateService);
+    private PrometheusClientService getPrometheusClientService(
+        Environment environment,
+        ConfigConfiguration configConfiguration,
+        CertificateService certificateService) {
+
+        PrometheusClientService prometheusClientService = new PrometheusClientService(
+            environment,
+            configConfiguration,
+            certificateService);
+        prometheusClientService.createCertificateExpiryDateCheckMetrics();
+        return prometheusClientService;
     }
 
     @Provides

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigValidCommand.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigValidCommand.java
@@ -3,17 +3,15 @@ package uk.gov.ida.hub.config;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.configuration.ConfigurationFactoryFactory;
 import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
-import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.config.annotations.CertificateConfigValidator;
-import uk.gov.ida.hub.config.application.CertificateService;
-import uk.gov.ida.hub.config.application.PrometheusClientService;
 import uk.gov.ida.hub.config.data.ConfigDataBootstrap;
 import uk.gov.ida.hub.config.data.ConfigDataSource;
 import uk.gov.ida.hub.config.data.ConfigEntityDataRepository;
@@ -24,7 +22,6 @@ import uk.gov.ida.hub.config.data.FileBackedTransactionConfigDataSource;
 import uk.gov.ida.hub.config.data.FileBackedTranslationsDataSource;
 import uk.gov.ida.hub.config.data.LevelsOfAssuranceConfigValidator;
 import uk.gov.ida.hub.config.domain.CertificateChainConfigValidator;
-import uk.gov.ida.hub.config.domain.CertificateValidityChecker;
 import uk.gov.ida.hub.config.domain.CountriesConfigEntityData;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
 import uk.gov.ida.hub.config.domain.MatchingServiceConfigEntityData;
@@ -34,10 +31,6 @@ import uk.gov.ida.hub.config.domain.TranslationData;
 import uk.gov.ida.hub.config.exceptions.ConfigValidationException;
 import uk.gov.ida.hub.config.truststore.TrustStoreForCertificateProvider;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.inject.Singleton;
 
 public class ConfigValidCommand extends ConfiguredCommand<ConfigConfiguration> {
 
@@ -75,17 +68,6 @@ public class ConfigValidCommand extends ConfiguredCommand<ConfigConfiguration> {
                         bind(CertificateChainConfigValidator.class)
                                 .annotatedWith(CertificateConfigValidator.class)
                                 .to(ThrowingCertificateChainConfigValidator.class);
-                    }
-
-                    @Provides
-                    @Singleton
-                    private PrometheusClientService getPrometheusClientService(CertificateService certificateService) {
-                        return new PrometheusClientService(certificateService);
-                    }
-
-                    @Provides
-                    public CertificateValidityChecker validityChecker(TrustStoreForCertificateProvider trustStoreForCertificateProvider, CertificateChainValidator certificateChainValidator) {
-                        return CertificateValidityChecker.createNonOCSPCheckingCertificateValidityChecker(trustStoreForCertificateProvider, certificateChainValidator);
                     }
                 });
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateExpiryDateCheckService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateExpiryDateCheckService.java
@@ -24,6 +24,7 @@ public class CertificateExpiryDateCheckService implements Runnable {
     @Override
     public void run() {
         final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+        final String TIMESTAMP = DateTime.now(DateTimeZone.UTC).toString();
         gauge.clear();
         certificateDetailsSet.forEach(
             certificateDetails -> {
@@ -33,7 +34,7 @@ public class CertificateExpiryDateCheckService implements Runnable {
                         certificateDetails.getCertificate().getCertificateType().toString(),
                         certificateDetails.getCertificate().getSubject(),
                         certificateDetails.getCertificate().getFingerprint(),
-                        Long.toString(DateTime.now(DateTimeZone.UTC).getMillis()))
+                        TIMESTAMP)
                          .set(certificateDetails.getCertificate().getNotAfter().getTime());
                 } catch (CertificateException e) {
                     LOG.warn(String.format("Invalid X.509 certificate [issuer id: %s]", certificateDetails.getIssuerId()));

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateExpiryDateCheckService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateExpiryDateCheckService.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.hub.config.application;
+
+import io.prometheus.client.Gauge;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.hub.config.domain.CertificateDetails;
+
+import java.security.cert.CertificateException;
+import java.util.Set;
+
+public class CertificateExpiryDateCheckService implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(CertificateExpiryDateCheckService.class);
+    private final CertificateService certificateService;
+    private final Gauge gauge;
+
+    public CertificateExpiryDateCheckService(final CertificateService certificateService,
+                                             final Gauge gauge) {
+        this.certificateService = certificateService;
+        this.gauge = gauge;
+    }
+
+    @Override
+    public void run() {
+        final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+        gauge.clear();
+        certificateDetailsSet.forEach(
+            certificateDetails -> {
+                try {
+                    gauge.labels(
+                        certificateDetails.getIssuerId(),
+                        certificateDetails.getCertificate().getCertificateType().toString(),
+                        certificateDetails.getCertificate().getSubject(),
+                        certificateDetails.getCertificate().getFingerprint(),
+                        Long.toString(DateTime.now(DateTimeZone.UTC).getMillis()))
+                         .set(certificateDetails.getCertificate().getNotAfter().getTime());
+                } catch (CertificateException e) {
+                    LOG.warn(String.format("Invalid X.509 certificate [issuer id: %s]", certificateDetails.getIssuerId()));
+                }
+            });
+        LOG.info("Updated Certificates Expiry Dates Metrics.");
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
@@ -30,6 +30,7 @@ public class OcspCertificateChainValidationService implements Runnable {
     @Override
     public void run() {
         final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+        final String TIMESTAMP = DateTime.now(DateTimeZone.UTC).toString();
         gauge.clear();
         certificateDetailsSet.forEach(
             certificateDetails -> {
@@ -39,7 +40,7 @@ public class OcspCertificateChainValidationService implements Runnable {
                         certificateDetails.getCertificate().getCertificateType().toString(),
                         certificateDetails.getCertificate().getSubject(),
                         certificateDetails.getCertificate().getFingerprint(),
-                        Long.toString(DateTime.now(DateTimeZone.UTC).getMillis()))
+                        TIMESTAMP)
                          .set(ocspCertificateChainValidityChecker.isValid(
                              certificateDetails.getCertificate(),
                              certificateDetails.getFederationEntityType()) ? VALID : INVALID);

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
@@ -1,0 +1,52 @@
+package uk.gov.ida.hub.config.application;
+
+import io.prometheus.client.Gauge;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.hub.config.domain.CertificateDetails;
+import uk.gov.ida.hub.config.domain.OCSPCertificateChainValidityChecker;
+
+import java.security.cert.CertificateException;
+import java.util.Set;
+
+public class OcspCertificateChainValidationService implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(OcspCertificateChainValidationService.class);
+    public static final double VALID = 1.0;
+    public static final double INVALID = 0.0;
+    private final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker;
+    private final CertificateService certificateService;
+    private final Gauge gauge;
+
+    public OcspCertificateChainValidationService(final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker,
+                                                 final CertificateService certificateService,
+                                                 final Gauge gauge) {
+        this.ocspCertificateChainValidityChecker = ocspCertificateChainValidityChecker;
+        this.certificateService = certificateService;
+        this.gauge = gauge;
+    }
+
+    @Override
+    public void run() {
+        final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+        gauge.clear();
+        certificateDetailsSet.forEach(
+            certificateDetails -> {
+                try {
+                    gauge.labels(
+                        certificateDetails.getIssuerId(),
+                        certificateDetails.getCertificate().getCertificateType().toString(),
+                        certificateDetails.getCertificate().getSubject(),
+                        certificateDetails.getCertificate().getFingerprint(),
+                        Long.toString(DateTime.now(DateTimeZone.UTC).getMillis()))
+                         .set(ocspCertificateChainValidityChecker.isValid(
+                             certificateDetails.getCertificate(),
+                             certificateDetails.getFederationEntityType()) ? VALID : INVALID);
+                } catch (CertificateException e) {
+                    LOG.warn(String.format("Invalid X.509 certificate [issuer id: %s]", certificateDetails.getIssuerId()));
+                }
+            });
+        LOG.info("Updated Certificates OCSP Revocation Statuses Metrics.");
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
@@ -1,41 +1,48 @@
 package uk.gov.ida.hub.config.application;
 
+import io.dropwizard.setup.Environment;
 import io.prometheus.client.Gauge;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.ida.hub.config.domain.CertificateDetails;
+import uk.gov.ida.hub.config.ConfigConfiguration;
+import uk.gov.ida.hub.config.configuration.PrometheusClientServiceConfiguration;
 
 import javax.inject.Inject;
-import java.security.cert.CertificateException;
-import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class PrometheusClientService {
-    private static final Logger LOG = LoggerFactory.getLogger(PrometheusClientService.class);
+    public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY = "verify_config_certificate_expiry";
+    private static final boolean USE_DAEMON_THREADS = true;
+    private final Environment environment;
+    private final ConfigConfiguration configConfiguration;
     private final CertificateService certificateService;
 
     @Inject
-    public PrometheusClientService(final CertificateService certificateService) {
+    public PrometheusClientService(final Environment environment,
+                                   final ConfigConfiguration configConfiguration,
+                                   final CertificateService certificateService) {
+        this.environment = environment;
+        this.configConfiguration = configConfiguration;
         this.certificateService = certificateService;
     }
 
-    public void createCertificateExpiryMetrics() {
-        final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
-        Gauge gauge = Gauge.build("verify_config_certificate_expiry", "Timestamp of NotAfter value of X.509 certificate")
-                           .labelNames("entity_id", "use", "subject", "fingerprint")
-                           .register();
+    public void createCertificateExpiryDateCheckMetrics() {
+        final PrometheusClientServiceConfiguration configuration = configConfiguration.getCertificateExpiryDateCheckServiceConfiguration();
+        if (configuration.getEnable()) {
+            Gauge gauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_EXPIRY, "Timestamp of NotAfter value of X.509 certificate")
+                               .labelNames("entity_id", "use", "subject", "fingerprint", "timestamp")
+                               .register();
 
-        certificateDetailsSet.forEach(
-            certificateDetails -> {
-                try {
-                    gauge.labels(
-                        certificateDetails.getIssuerId(),
-                        certificateDetails.getCertificate().getCertificateType().toString(),
-                        certificateDetails.getCertificate().getSubject(),
-                        certificateDetails.getCertificate().getFingerprint())
-                         .set(certificateDetails.getCertificate().getNotAfter().getTime());
-                } catch (CertificateException e) {
-                    LOG.warn(String.format("Invalid X.509 certificate [issuer id: %s]", certificateDetails.getIssuerId()));
-                }
-            });
+            CertificateExpiryDateCheckService certificateExpiryDateCheckService = new CertificateExpiryDateCheckService(certificateService, gauge);
+
+            ScheduledExecutorService scheduledCertificateExpiryDateCheckService =
+                environment.lifecycle()
+                           .scheduledExecutorService(VERIFY_CONFIG_CERTIFICATE_EXPIRY, USE_DAEMON_THREADS)
+                           .build();
+            scheduledCertificateExpiryDateCheckService.scheduleWithFixedDelay(
+                certificateExpiryDateCheckService,
+                configuration.getInitialDelay().toSeconds(),
+                configuration.getDelay().toSeconds(),
+                TimeUnit.SECONDS);
+        }
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
@@ -4,6 +4,7 @@ import io.dropwizard.setup.Environment;
 import io.prometheus.client.Gauge;
 import uk.gov.ida.hub.config.ConfigConfiguration;
 import uk.gov.ida.hub.config.configuration.PrometheusClientServiceConfiguration;
+import uk.gov.ida.hub.config.domain.OCSPCertificateChainValidityChecker;
 
 import javax.inject.Inject;
 import java.util.concurrent.ScheduledExecutorService;
@@ -11,18 +12,22 @@ import java.util.concurrent.TimeUnit;
 
 public class PrometheusClientService {
     public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY = "verify_config_certificate_expiry";
+    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_SUCCESS = "verify_config_certificate_ocsp_success";
     private static final boolean USE_DAEMON_THREADS = true;
     private final Environment environment;
     private final ConfigConfiguration configConfiguration;
     private final CertificateService certificateService;
+    private final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker;
 
     @Inject
     public PrometheusClientService(final Environment environment,
                                    final ConfigConfiguration configConfiguration,
-                                   final CertificateService certificateService) {
+                                   final CertificateService certificateService,
+                                   final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker) {
         this.environment = environment;
         this.configConfiguration = configConfiguration;
         this.certificateService = certificateService;
+        this.ocspCertificateChainValidityChecker = ocspCertificateChainValidityChecker;
     }
 
     public void createCertificateExpiryDateCheckMetrics() {
@@ -34,15 +39,36 @@ public class PrometheusClientService {
 
             CertificateExpiryDateCheckService certificateExpiryDateCheckService = new CertificateExpiryDateCheckService(certificateService, gauge);
 
-            ScheduledExecutorService scheduledCertificateExpiryDateCheckService =
-                environment.lifecycle()
-                           .scheduledExecutorService(VERIFY_CONFIG_CERTIFICATE_EXPIRY, USE_DAEMON_THREADS)
-                           .build();
-            scheduledCertificateExpiryDateCheckService.scheduleWithFixedDelay(
-                certificateExpiryDateCheckService,
-                configuration.getInitialDelay().toSeconds(),
-                configuration.getDelay().toSeconds(),
-                TimeUnit.SECONDS);
+            createScheduledExecutorService(configuration, VERIFY_CONFIG_CERTIFICATE_EXPIRY, certificateExpiryDateCheckService);
         }
+    }
+
+    public void createCertificateOcspRevocationStatusCheckMetrics() {
+        final PrometheusClientServiceConfiguration configuration = configConfiguration.getCertificateOcspRevocationStatusCheckServiceConfiguration();
+        if (configuration.getEnable()) {
+            Gauge gauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_OCSP_SUCCESS, "Valid X.509 certificate")
+                               .labelNames("entity_id", "use", "subject", "fingerprint", "timestamp")
+                               .register();
+
+            OcspCertificateChainValidationService ocspCertificateChainValidationService = new OcspCertificateChainValidationService(
+                ocspCertificateChainValidityChecker,
+                certificateService,
+                gauge);
+
+            createScheduledExecutorService(configuration, VERIFY_CONFIG_CERTIFICATE_OCSP_SUCCESS, ocspCertificateChainValidationService);
+        }
+    }
+
+    private void createScheduledExecutorService(PrometheusClientServiceConfiguration configuration,
+                                                String nameFormat,
+                                                Runnable service) {
+        ScheduledExecutorService scheduledExecutorService = environment.lifecycle()
+                                                                       .scheduledExecutorService(nameFormat, USE_DAEMON_THREADS)
+                                                                       .build();
+        scheduledExecutorService.scheduleWithFixedDelay(
+            service,
+            configuration.getInitialDelay().toSeconds(),
+            configuration.getDelay().toSeconds(),
+            TimeUnit.SECONDS);
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/configuration/PrometheusClientServiceConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/configuration/PrometheusClientServiceConfiguration.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.hub.config.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class PrometheusClientServiceConfiguration {
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Boolean enable = false;
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Duration initialDelay = Duration.seconds(10);
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Duration delay =  Duration.minutes(15);
+
+    public PrometheusClientServiceConfiguration() { }
+
+    public Boolean getEnable() {
+        return enable;
+    }
+
+    public Duration getInitialDelay() {
+        return initialDelay;
+    }
+
+    public Duration getDelay() {
+        return delay;
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigDataBootstrap.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigDataBootstrap.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import io.dropwizard.lifecycle.Managed;
 import uk.gov.ida.hub.config.ConfigEntityData;
 import uk.gov.ida.hub.config.annotations.CertificateConfigValidator;
-import uk.gov.ida.hub.config.application.PrometheusClientService;
 import uk.gov.ida.hub.config.domain.CertificateChainConfigValidator;
 import uk.gov.ida.hub.config.domain.CountriesConfigEntityData;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfigEntityData;
@@ -38,25 +37,23 @@ public class ConfigDataBootstrap implements Managed {
     private final ConfigEntityDataRepository<CountriesConfigEntityData> countriesConfigEntityDataConfigEntityDataRepository;
     private CertificateChainConfigValidator certificateChainConfigValidator = null;
     private LevelsOfAssuranceConfigValidator levelsOfAssuranceConfigValidator = null;
-    private final PrometheusClientService prometheusClientService;
 
     private enum EntityData {IDENTITY_PROVIDER, MATCHING_SERVICE, TRANSACTION, COUNTRIES, TRANSLATIONS}
 
     @Inject
     public ConfigDataBootstrap(
-        ConfigDataSource<IdentityProviderConfigEntityData> identityProviderConfigDataSource,
-        ConfigDataSource<MatchingServiceConfigEntityData> matchingServiceConfigDataSource,
-        ConfigDataSource<TransactionConfigEntityData> transactionConfigDataSource,
-        ConfigDataSource<TranslationData> translationsDataSource,
-        ConfigDataSource<CountriesConfigEntityData> countriesConfigDataSource,
-        ConfigEntityDataRepository<IdentityProviderConfigEntityData> identityProviderConfigEntityDataRepository,
-        ConfigEntityDataRepository<MatchingServiceConfigEntityData> matchingServiceConfigEntityDataRepository,
-        ConfigEntityDataRepository<TransactionConfigEntityData> transactionConfigEntityDataRepository,
-        ConfigEntityDataRepository<TranslationData> translationsRepository,
-        ConfigEntityDataRepository<CountriesConfigEntityData> countriesConfigEntityDataConfigEntityDataRepository,
-        @CertificateConfigValidator CertificateChainConfigValidator certificateChainConfigValidator,
-        LevelsOfAssuranceConfigValidator levelsOfAssuranceConfigValidator,
-        PrometheusClientService prometheusClientService) {
+            ConfigDataSource<IdentityProviderConfigEntityData> identityProviderConfigDataSource,
+            ConfigDataSource<MatchingServiceConfigEntityData> matchingServiceConfigDataSource,
+            ConfigDataSource<TransactionConfigEntityData> transactionConfigDataSource,
+            ConfigDataSource<TranslationData> translationsDataSource,
+            ConfigDataSource<CountriesConfigEntityData> countriesConfigDataSource,
+            ConfigEntityDataRepository<IdentityProviderConfigEntityData> identityProviderConfigEntityDataRepository,
+            ConfigEntityDataRepository<MatchingServiceConfigEntityData> matchingServiceConfigEntityDataRepository,
+            ConfigEntityDataRepository<TransactionConfigEntityData> transactionConfigEntityDataRepository,
+            ConfigEntityDataRepository<TranslationData> translationsRepository,
+            ConfigEntityDataRepository<CountriesConfigEntityData> countriesConfigEntityDataConfigEntityDataRepository,
+            @CertificateConfigValidator CertificateChainConfigValidator certificateChainConfigValidator,
+            LevelsOfAssuranceConfigValidator levelsOfAssuranceConfigValidator) {
 
         this.identityProviderConfigDataSource = identityProviderConfigDataSource;
         this.matchingServiceConfigDataSource = matchingServiceConfigDataSource;
@@ -70,7 +67,6 @@ public class ConfigDataBootstrap implements Managed {
         this.countriesConfigEntityDataConfigEntityDataRepository = countriesConfigEntityDataConfigEntityDataRepository;
         this.certificateChainConfigValidator = certificateChainConfigValidator;
         this.levelsOfAssuranceConfigValidator = levelsOfAssuranceConfigValidator;
-        this.prometheusClientService = prometheusClientService;
     }
 
     @Override
@@ -90,8 +86,6 @@ public class ConfigDataBootstrap implements Managed {
             .andThen(checkThereAreNoInvalidCertificates)
             .andThen(checkIdpAndTransactionsHaveValidLevelsOfAssurance)
             .accept(allConfig);
-
-        prometheusClientService.createCertificateExpiryMetrics();
     }
 
     @Override

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateValidityChecker.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateValidityChecker.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import uk.gov.ida.common.shared.security.verification.CertificateChainValidator;
 import uk.gov.ida.common.shared.security.verification.CertificateValidity;
 import uk.gov.ida.common.shared.security.verification.OCSPCertificateChainValidator;
+import uk.gov.ida.hub.config.dto.FederationEntityType;
 import uk.gov.ida.hub.config.dto.InvalidCertificateDto;
 import uk.gov.ida.hub.config.truststore.TrustStoreForCertificateProvider;
 
@@ -49,6 +50,15 @@ public class CertificateValidityChecker {
         CertificateValidity certificateValidity = certificateChainValidator.validate(
                 certificate.getX509(),
                 trustStoreForCertificateProvider.getTrustStoreFor(certificate.getFederationEntityType()));
+
+        return certificateValidity.isValid();
+    }
+
+    public boolean isValid(final Certificate certificate,
+                           final FederationEntityType federationEntityType) {
+        CertificateValidity certificateValidity = certificateChainValidator.validate(
+            certificate.getX509(),
+            trustStoreForCertificateProvider.getTrustStoreFor(federationEntityType));
 
         return certificateValidity.isValid();
     }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/OCSPCertificateChainValidityChecker.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/OCSPCertificateChainValidityChecker.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.config.domain;
 
 import com.google.common.collect.ImmutableList;
 import uk.gov.ida.common.shared.security.verification.OCSPCertificateChainValidator;
+import uk.gov.ida.hub.config.dto.FederationEntityType;
 import uk.gov.ida.hub.config.dto.InvalidCertificateDto;
 import uk.gov.ida.hub.config.truststore.TrustStoreForCertificateProvider;
 
@@ -22,4 +23,8 @@ public class OCSPCertificateChainValidityChecker {
         return certificateValidityChecker.getInvalidCertificates(certificateDetails);
     }
 
+    public boolean isValid(final Certificate certificate,
+                           final FederationEntityType federationEntityType) {
+        return certificateValidityChecker.isValid(certificate, federationEntityType);
+    }
 }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/ConfigDataBootstrapTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/ConfigDataBootstrapTest.java
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.hub.config.ConfigEntityData;
-import uk.gov.ida.hub.config.application.PrometheusClientService;
 import uk.gov.ida.hub.config.domain.CertificateChainConfigValidator;
 import uk.gov.ida.hub.config.domain.CertificateType;
 import uk.gov.ida.hub.config.domain.CountriesConfigEntityData;
@@ -45,9 +44,6 @@ public class ConfigDataBootstrapTest {
 
     @Mock
     private CertificateChainConfigValidator certificateChainConfigValidator;
-
-    @Mock
-    private PrometheusClientService prometheusClientService;
 
     private final ConfigEntityDataRepository<? extends ConfigEntityData> nullConfigEntityDataRepository = new ConfigEntityDataRepository<>();
     private final LevelsOfAssuranceConfigValidator levelsOfAssuranceConfigValidator = new LevelsOfAssuranceConfigValidator();
@@ -223,8 +219,7 @@ public class ConfigDataBootstrapTest {
                 (ConfigEntityDataRepository<TranslationData>) nullConfigEntityDataRepository,
                 (ConfigEntityDataRepository<CountriesConfigEntityData>) nullConfigEntityDataRepository,
                 certificateChainConfigValidator,
-                levelsOfAssuranceConfigValidator,
-                prometheusClientService);
+                levelsOfAssuranceConfigValidator);
     }
 
     private class TestConfigDataSource<T> implements ConfigDataSource<T> {


### PR DESCRIPTION
This pull request has three commits.

**First commit**
It decouples PrometheusClientService from ConfigDataBootstrap and makes CertificateExpiryDateCheckService a separate background thread (daemon) managed by DropWizard so that it can handle dynamic config changes. It also adds a timestamp to the certificate expiry date metrics to show whether the metrics are stale or not stale. 
 
**Second commit**
Currently, Sensu hits Config application's /config/certificates/invalid endpoint every 15 minutes which causes it to perform OCSP checking of RP and MSA certificates and returns a list of invalid certificates. Sensu alerts if there are invalid certificates. The second commit adds OCSP Revocation Status Check to Prometheus Metrics which returns all RP and MSA certificates' OCSP revocation statuses updated every 15 minutes so that we can add alerts in the new infrastructure for any invalid certificates and also update a dashboard to display a list of certificates' OCSP revocation statuses. This will enable support team to rectify any invalid certificates quickly. 

**Third commit**
Grafana does not recognise timestamp in milliseconds. This commit changes timestamp to use DateTime.now(DateTimeZone.UTC).toString() instead. This change enables Grafana to show the valid timestamp instead of `Invalid Date` message.