### PR TITLE
BAU: Speed up startup.sh script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if test ! "$1" == "skip-build"; then
-    ./gradlew clean build installDist -x test
+    ./gradlew --parallel --daemon clean build installDist -x test
 fi
 
 pushd ../ida-hub-acceptance-tests >/dev/null


### PR DESCRIPTION
This commit adds `--parallel` and `--daemon` to the gradle command in startup.sh script to reduce the time it takes to run all tests including integration tests. This change saves 1 minute 2 seconds (39.2%).

Before the change : 2m 38s
After the change  : 1m 36s

Author: @adityapahuja