### PR TITLE
BAU: Update to use latest version of verify-saml-libs library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-34',
-            saml_libs:"$opensaml_version-169",
+            saml_libs:"$opensaml_version-170",
         ]
 
 subprojects {

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/session/RedisSessionStoreTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/session/RedisSessionStoreTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.redisson.api.RMap;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.State;


### PR DESCRIPTION
Currently, verify-hub has two versions of mockito-core (1.9.6) and (2.23.0) libraries loaded. The old version of mockito-core uses ArgumentMatcher (Abstract class) whereas the new version of mockito-core uses ArgumentMatcher (Interface class). This causes Integrated Development Environment (IDE) to be confused and to throw an error message not letting me to compile in IDE. This commit updates verify-hub to use latest version of verify-saml-libs containing the following changes.

- use latest version of verify-test-utils which uses the latest version of mockito-core (2.23.0)
- remove the old version of mockito-core (1.9.6)

These changes resolve the issue mentioned before.
This commit also updates RedisSessionStoreTest class to use org.mockito.junit.MockitoJUnitRunner instead of org.mockito.runners.MockitoJUnitRunner since org.mockito.runners.MockitoJUnitRunner is deprecated.

Author: @adityapahuja