### PR TITLE
BAU Bump utils to build 350

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'347',
+            ida_utils:'350',
             dropwizard:"$dropwizard_version",
             dropwizard_infinispan:"$dropwizard_version-47",
             pact:'3.5.6',


### PR DESCRIPTION
It removes a redundant SLF4J binding and fixes security vulnerabilities
in jackson-bind and guava.