### PR TITLE
AUTO-146: Move last updated from labels to a separate metric

### DIFF
--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/Message.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/Message.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.integrationtest.hub.config.apprule.support;
+
+public class Message {
+    private final String message;
+    private final boolean present;
+
+    private Message(final String message, final boolean present) {
+        this.message = message;
+        this.present = present;
+    }
+
+    public static Message messageShouldBePresent(final String message) {
+        return new Message(message, true);
+    }
+
+    public static Message messageShouldNotBePresent(final String message) {
+        return new Message(message, false);
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isPresent() {
+        return present;
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
@@ -17,37 +17,51 @@ public class OcspCertificateChainValidationService implements Runnable {
     public static final double INVALID = 0.0;
     private final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker;
     private final CertificateService certificateService;
-    private final Gauge gauge;
+    private final Gauge ocspStatusGauge;
+    private final Gauge lastUpdatedGauge;
 
     public OcspCertificateChainValidationService(final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker,
                                                  final CertificateService certificateService,
-                                                 final Gauge gauge) {
+                                                 final Gauge ocspStatusGauge,
+                                                 final Gauge lastUpdatedGauge) {
         this.ocspCertificateChainValidityChecker = ocspCertificateChainValidityChecker;
         this.certificateService = certificateService;
-        this.gauge = gauge;
+        this.ocspStatusGauge = ocspStatusGauge;
+        this.lastUpdatedGauge = lastUpdatedGauge;
     }
 
     @Override
     public void run() {
-        final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
-        final String TIMESTAMP = DateTime.now(DateTimeZone.UTC).toString();
-        gauge.clear();
-        certificateDetailsSet.forEach(
-            certificateDetails -> {
+        try {
+            final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+            final double timestamp = DateTime.now(DateTimeZone.UTC).getMillis();
+            certificateDetailsSet.forEach(certificateDetails -> {
                 try {
-                    gauge.labels(
-                        certificateDetails.getIssuerId(),
-                        certificateDetails.getCertificate().getCertificateType().toString(),
-                        certificateDetails.getCertificate().getSubject(),
-                        certificateDetails.getCertificate().getFingerprint(),
-                        TIMESTAMP)
-                         .set(ocspCertificateChainValidityChecker.isValid(
-                             certificateDetails.getCertificate(),
-                             certificateDetails.getFederationEntityType()) ? VALID : INVALID);
+                    addAGauge(
+                        ocspStatusGauge,
+                        certificateDetails,
+                        ocspCertificateChainValidityChecker.isValid(
+                            certificateDetails.getCertificate(),
+                            certificateDetails.getFederationEntityType()) ? VALID : INVALID);
+                    addAGauge(lastUpdatedGauge, certificateDetails, timestamp);
                 } catch (CertificateException e) {
                     LOG.warn(String.format("Invalid X.509 certificate [issuer id: %s]", certificateDetails.getIssuerId()));
                 }
             });
-        LOG.info("Updated Certificates OCSP Revocation Statuses Metrics.");
+            LOG.info("Updated Certificates OCSP Revocation Statuses Metrics.");
+        } catch (Exception e) {
+            LOG.warn(e.getMessage());
+        }
+    }
+
+    private void addAGauge(final Gauge gauge,
+                           final CertificateDetails certificateDetails,
+                           final double value) throws CertificateException {
+        gauge.labels(certificateDetails.getIssuerId(),
+            certificateDetails.getCertificate().getCertificateType().toString(),
+            certificateDetails.getCertificate().getSubject(),
+            certificateDetails.getCertificate().getFingerprint(),
+            String.valueOf(certificateDetails.getCertificate().getSerialNumber()))
+             .set(value);
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
@@ -14,11 +14,11 @@ public class PrometheusClientService {
     public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE = "verify_config_certificate_expiry_date";
     public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_LAST_UPDATED = "verify_config_certificate_expiry_date_last_updated";
     public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS = "verify_config_certificate_ocsp_revocation_status";
-    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED = "verify_config_certificate_ocsp_revocation_status_last_updated";
+    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_LAST_SUCCESS_TIMESTAMP = "verify_config_certificate_ocsp_last_success_timestamp";
     public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_HELP = "X.509 Certificate Expiry Date (ms)";
     public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_LAST_UPDATED_HELP = "X.509 Certificate Expiry Date Metric Last Updated (ms)";
     public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_HELP = "X.509 Certificate OCSP Revocation Status (1 = valid and 0 = invalid)";
-    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED_HELP = "X.509 Certificate OCSP Revocation Status Metric Last Updated (ms)";
+    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_LAST_SUCCESS_TIMESTAMP_HELP = "X.509 Certificate OCSP Last Success Timestamp (ms)";
     private static final boolean USE_DAEMON_THREADS = true;
     private final Environment environment;
     private final ConfigConfiguration configConfiguration;
@@ -60,7 +60,7 @@ public class PrometheusClientService {
             Gauge ocspStatusGauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS, VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_HELP)
                                          .labelNames("entity_id", "use", "subject", "fingerprint", "serial")
                                          .register();
-            Gauge lastUpdatedGauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED, VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED_HELP)
+            Gauge lastUpdatedGauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_OCSP_LAST_SUCCESS_TIMESTAMP, VERIFY_CONFIG_CERTIFICATE_OCSP_LAST_SUCCESS_TIMESTAMP_HELP)
                                           .labelNames("entity_id", "use", "subject", "fingerprint", "serial")
                                           .register();
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/PrometheusClientService.java
@@ -11,8 +11,14 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class PrometheusClientService {
-    public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY = "verify_config_certificate_expiry";
-    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_SUCCESS = "verify_config_certificate_ocsp_success";
+    public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE = "verify_config_certificate_expiry_date";
+    public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_LAST_UPDATED = "verify_config_certificate_expiry_date_last_updated";
+    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS = "verify_config_certificate_ocsp_revocation_status";
+    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED = "verify_config_certificate_ocsp_revocation_status_last_updated";
+    public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_HELP = "X.509 Certificate Expiry Date (ms)";
+    public static final String VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_LAST_UPDATED_HELP = "X.509 Certificate Expiry Date Metric Last Updated (ms)";
+    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_HELP = "X.509 Certificate OCSP Revocation Status (1 = valid and 0 = invalid)";
+    public static final String VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED_HELP = "X.509 Certificate OCSP Revocation Status Metric Last Updated (ms)";
     private static final boolean USE_DAEMON_THREADS = true;
     private final Environment environment;
     private final ConfigConfiguration configConfiguration;
@@ -33,29 +39,38 @@ public class PrometheusClientService {
     public void createCertificateExpiryDateCheckMetrics() {
         final PrometheusClientServiceConfiguration configuration = configConfiguration.getCertificateExpiryDateCheckServiceConfiguration();
         if (configuration.getEnable()) {
-            Gauge gauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_EXPIRY, "Timestamp of NotAfter value of X.509 certificate")
-                               .labelNames("entity_id", "use", "subject", "fingerprint", "timestamp")
-                               .register();
+            Gauge expiryDateGauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE, VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_HELP)
+                                         .labelNames("entity_id", "use", "subject", "fingerprint", "serial")
+                                         .register();
+            Gauge lastUpdatedGauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_LAST_UPDATED, VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE_LAST_UPDATED_HELP)
+                                          .register();
 
-            CertificateExpiryDateCheckService certificateExpiryDateCheckService = new CertificateExpiryDateCheckService(certificateService, gauge);
+            CertificateExpiryDateCheckService certificateExpiryDateCheckService = new CertificateExpiryDateCheckService(
+                certificateService,
+                expiryDateGauge,
+                lastUpdatedGauge);
 
-            createScheduledExecutorService(configuration, VERIFY_CONFIG_CERTIFICATE_EXPIRY, certificateExpiryDateCheckService);
+            createScheduledExecutorService(configuration, VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE, certificateExpiryDateCheckService);
         }
     }
 
     public void createCertificateOcspRevocationStatusCheckMetrics() {
         final PrometheusClientServiceConfiguration configuration = configConfiguration.getCertificateOcspRevocationStatusCheckServiceConfiguration();
         if (configuration.getEnable()) {
-            Gauge gauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_OCSP_SUCCESS, "Valid X.509 certificate")
-                               .labelNames("entity_id", "use", "subject", "fingerprint", "timestamp")
-                               .register();
+            Gauge ocspStatusGauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS, VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_HELP)
+                                         .labelNames("entity_id", "use", "subject", "fingerprint", "serial")
+                                         .register();
+            Gauge lastUpdatedGauge = Gauge.build(VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED, VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS_LAST_UPDATED_HELP)
+                                          .labelNames("entity_id", "use", "subject", "fingerprint", "serial")
+                                          .register();
 
             OcspCertificateChainValidationService ocspCertificateChainValidationService = new OcspCertificateChainValidationService(
                 ocspCertificateChainValidityChecker,
                 certificateService,
-                gauge);
+                ocspStatusGauge,
+                lastUpdatedGauge);
 
-            createScheduledExecutorService(configuration, VERIFY_CONFIG_CERTIFICATE_OCSP_SUCCESS, ocspCertificateChainValidationService);
+            createScheduledExecutorService(configuration, VERIFY_CONFIG_CERTIFICATE_OCSP_REVOCATION_STATUS, ocspCertificateChainValidationService);
         }
     }
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/Certificate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/Certificate.java
@@ -10,6 +10,7 @@ import uk.gov.ida.hub.config.dto.CertificateExpiryStatus;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -84,6 +85,10 @@ public abstract class Certificate {
             LOG.warn(String.format("Algorithm [algorithm = %s] is not available.", FINGERPRINT_ALGORITHM));
         }
         return "";
+    }
+
+    public BigInteger getSerialNumber() throws CertificateException {
+        return getCertificate().getSerialNumber();
     }
 
     private Date getNotBefore() throws CertificateException {


### PR DESCRIPTION
Every unique combination of key-value label pairs represents a new time series which can dramatically increase the amount of data stored. We should not use labels to store dimensions with high cardinality (many different label values) such as timestamp or other unbounded sets of values. This commit updates to have pair of metrics (one for expiry date or OCSP revocation status and another one for last updated (timestamp)). The last updated metric is used to indicate whether expiry date metric or OCSP revocation status metric is stale or not. It will be used to alert support team that the metrics are out of date and the team will fix the issue. This commit also adds a serial number to certificate metrics since metadata certificate metrics already have serial numbers.

Author: @adityapahuja