### PR TITLE
AUTO-152: Add Matching Service Health metrics to Prometheus metrics

### DIFF
--- a/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/HealthCheckResponseFromMatchingService.java
+++ b/hub-saml-test-utils/src/main/java/uk/gov/ida/saml/msa/test/outbound/HealthCheckResponseFromMatchingService.java
@@ -1,11 +1,18 @@
 package uk.gov.ida.saml.msa.test.outbound;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import uk.gov.ida.saml.core.domain.IdaMatchingServiceResponse;
 
 public class HealthCheckResponseFromMatchingService extends IdaMatchingServiceResponse {
     public HealthCheckResponseFromMatchingService(String entityId, String healthCheckReqeustId) {
         super("healthcheck-response-id", healthCheckReqeustId, entityId, DateTime.now());
+    }
+
+    public HealthCheckResponseFromMatchingService(final String responseId,
+                                                  final String entityId,
+                                                  final String healthCheckReqeustId) {
+        super(responseId, healthCheckReqeustId, entityId, DateTime.now(DateTimeZone.UTC));
     }
 }
 

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceHealthCheckIntegrationTests.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceHealthCheckIntegrationTests.java
@@ -26,7 +26,7 @@ import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.dto.AggregatedMatchi
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.dto.MatchingServiceHealthCheckResultDto;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.ConfigStubRule;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.EventSinkStubRule;
-import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MSAStubRule;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlEngineStubRule;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlSoapProxyAppRule;
 import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatus;
@@ -53,6 +53,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.xml.HasXPath.hasXPath;
 import static uk.gov.ida.hub.samlsoapproxy.builders.MatchingServiceHealthCheckerResponseDtoBuilder.anInboundResponseFromMatchingServiceDto;
+import static uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule.msaStubRule;
+import static uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlEngineStubRule.stackedSamlEngineStubRule;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT;
@@ -81,13 +83,13 @@ public class MatchingServiceHealthCheckIntegrationTests {
     public static EventSinkStubRule eventSinkStub = new EventSinkStubRule();
 
     @ClassRule
-    public static SamlEngineStubRule samlEngineStub = new SamlEngineStubRule();
+    public static SamlEngineStubRule samlEngineStub = stackedSamlEngineStubRule();
 
     @ClassRule
-    public static MSAStubRule msaStubRule1 = new MSAStubRule();
+    public static MsaStubRule msaStubRule1 = msaStubRule();
 
     @ClassRule
-    public static MSAStubRule msaStubRule2 = new MSAStubRule();
+    public static MsaStubRule msaStubRule2 = msaStubRule();
 
     @ClassRule
     public static SamlSoapProxyAppRule samlSoapProxyAppRule = new SamlSoapProxyAppRule(

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceRequestSenderTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceRequestSenderTest.java
@@ -31,7 +31,7 @@ import uk.gov.ida.hub.samlsoapproxy.exceptions.InvalidSamlRequestInAttributeQuer
 import uk.gov.ida.hub.samlsoapproxy.soap.SoapMessageManager;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.ConfigStubRule;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.EventSinkStubRule;
-import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MSAStubRule;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.PolicyStubRule;
 import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlSoapProxyAppRule;
 import uk.gov.ida.restclient.ClientProvider;
@@ -67,6 +67,7 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.samlsoapproxy.Urls.PolicyUrls.ATTRIBUTE_QUERY_RESPONSE_RESOURCE;
+import static uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule.msaStubRule;
 import static uk.gov.ida.jerseyclient.JerseyClientWithRetryBackoffHandlerConfigurationBuilder.aJerseyClientWithRetryBackoffHandlerConfiguration;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
@@ -95,7 +96,7 @@ public class MatchingServiceRequestSenderTest {
     public static EventSinkStubRule eventSinkStubRule = new EventSinkStubRule();
 
     @ClassRule
-    public static MSAStubRule msaStubRule = new MSAStubRule();
+    public static MsaStubRule msaStubRule = msaStubRule();
 
     @ClassRule
     public static PolicyStubRule policyStubRule = new PolicyStubRule();

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
@@ -1,0 +1,334 @@
+package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.Sets;
+import helpers.JerseyClientConfigurationBuilder;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
+import org.w3c.dom.Element;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
+import uk.gov.ida.hub.samlsoapproxy.contract.MatchingServiceHealthCheckerRequestDto;
+import uk.gov.ida.hub.samlsoapproxy.contract.SamlMessageDto;
+import uk.gov.ida.hub.samlsoapproxy.soap.SoapMessageManager;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.ConfigStubRule;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.EventSinkStubRule;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MatchingServiceDetails;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlEngineStubRule;
+import uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlSoapProxyAppRule;
+import uk.gov.ida.saml.msa.test.api.MsaTransformersFactory;
+import uk.gov.ida.saml.msa.test.outbound.HealthCheckResponseFromMatchingService;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
+import uk.gov.ida.shared.utils.xml.XmlUtils;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.glassfish.jersey.internal.util.Base64.encodeAsString;
+import static uk.gov.ida.hub.samlsoapproxy.builders.MatchingServiceHealthCheckerResponseDtoBuilder.anInboundResponseFromMatchingServiceDto;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_HELP;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED_HELP;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP;
+import static uk.gov.ida.hub.samlsoapproxy.service.MatchingServiceHealthCheckTask.HEALTHY;
+import static uk.gov.ida.hub.samlsoapproxy.service.MatchingServiceHealthCheckTask.UNHEALTHY;
+import static uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule.msaStubRule;
+import static uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule.sleepyMsaStubRule;
+import static uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.SamlEngineStubRule.samlEngineStubRule;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PUBLIC_ENCRYPTION_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_MS_PUBLIC_SIGNING_CERT;
+import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
+import static uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatus.Healthy;
+
+public class PrometheusMetricsIntegrationTest {
+    private static Client client;
+    private static final int WAIT_FOR_MSA_HEALTH_METRICS_TO_BE_UPDATED = 5_000;
+    private static final String GAUGE_HELP_TEMPLATE = "# HELP %s %s\n";
+    private static final String GAUGE_TYPE_TEMPLATE = "# TYPE %s gauge\n";
+    private static final String MSA_HEALTH_METRICS_TEMPLATE = "%s{matchingService=\"%s\",} %s\n";
+    private static final String MSA_INFO_METRICS_TEMPLATE = "%s{matchingService=\"%s\",versionNumber=\"%s\",versionSupported=\"%s\",eidasEnabled=\"%s\",shouldSignWithSha1=\"%s\",onboarding=\"%s\",} %s\n";
+    private static final String MSA_RESPONSE_ID_TEMPLATE = "healthcheck-response-id-version-%s-eidasenabled-%s-shouldsignwithsha1-%s";
+    private static final String MSA_ONE_ENTITY_ID = "https://ms-one.local/SAML2/MD";
+    private static final String MSA_TWO_ENTITY_ID = "https://ms-two.local/SAML2/MD";
+    private static final String MSA_THREE_ENTITY_ID = "https://ms-three.local/SAML2/MD";
+    private static final String MSA_FOUR_ENTITY_ID = "https://ms-four.local/SAML2/MD";
+    private static final String MSA_ONE_VERSION = "592";
+    private static final String MSA_TWO_VERSION = "33.3";
+    private static final String MSA_FOUR_VERSION = "592";
+    private static final String MSA_ONE_VERSION_SUPPORTED = "true";
+    private static final String MSA_TWO_VERSION_SUPPORTED = "false";
+    private static final String ONBOARDING = "false";
+    private static final boolean MSA_ONE_EIDAS_ENABLED = true;
+    private static final boolean MSA_TWO_EIDAS_ENABLED = false;
+    private static final boolean MSA_FOUR_EIDAS_ENABLED = false;
+    private static final boolean MSA_ONE_SHOULD_SIGN_WITH_SHA_1 = false;
+    private static final boolean MSA_TWO_SHOULD_SIGN_WITH_SHA_1 = true;
+    private static final boolean MSA_FOUR_SHOULD_SIGN_WITH_SHA_1 = false;
+    private static final String MSA_ONE_RESPONSE_ID = String.format(MSA_RESPONSE_ID_TEMPLATE, MSA_ONE_VERSION, MSA_ONE_EIDAS_ENABLED, MSA_ONE_SHOULD_SIGN_WITH_SHA_1);
+    private static final String MSA_TWO_RESPONSE_ID = String.format(MSA_RESPONSE_ID_TEMPLATE, MSA_TWO_VERSION, MSA_TWO_EIDAS_ENABLED, MSA_TWO_SHOULD_SIGN_WITH_SHA_1);
+    private static final String MSA_FOUR_RESPONSE_ID = String.format(MSA_RESPONSE_ID_TEMPLATE, MSA_FOUR_VERSION, MSA_FOUR_EIDAS_ENABLED, MSA_FOUR_SHOULD_SIGN_WITH_SHA_1);
+    private static final String RP_ONE_ENTITY_ID = "https://rp-one.local/SAML2/MD";
+    private static final String RP_TWO_ENTITY_ID = "https://rp-two.local/SAML2/MD";
+    private static final String RP_THREE_ENTITY_ID = "https://rp-three.local/SAML2/MD";
+    private static final String RP_FOUR_ENTITY_ID = "https://rp-four.local/SAML2/MD";
+    private static final SignatureAlgorithm SIGNATURE_ALGORITHM = new SignatureRSASHA256();
+    private static final DigestAlgorithm DIGEST_ALGORITHM = new DigestSHA256();
+    private static final SoapMessageManager SOAP_MESSAGE_MANAGER = new SoapMessageManager();
+
+    @ClassRule
+    public static ConfigStubRule configStub = new ConfigStubRule();
+
+    @ClassRule
+    public static EventSinkStubRule eventSinkStub = new EventSinkStubRule();
+
+    @ClassRule
+    public static SamlEngineStubRule samlEngineStub = samlEngineStubRule();
+
+    @ClassRule
+    public static MsaStubRule msaStubOne = msaStubRule();
+
+    @ClassRule
+    public static MsaStubRule msaStubTwo = msaStubRule();
+
+    @ClassRule
+    public static MsaStubRule msaStubThree = msaStubRule();
+
+    @ClassRule
+    public static MsaStubRule msaStubFour = sleepyMsaStubRule(5_000);
+
+    @ClassRule
+    public static SamlSoapProxyAppRule samlSoapProxyAppRule = new SamlSoapProxyAppRule(
+        config("logging.level", "INFO"),
+        config("httpClient.gzipEnabledForRequests", "false"),
+        config("prometheusEnabled", "true"),
+        config("matchingServiceHealthCheckServiceConfiguration.enable", "true"),
+        config("matchingServiceHealthCheckServiceConfiguration.initialDelay", "1s"),
+        config("matchingServiceHealthCheckServiceConfiguration.delay", "3s"),
+        config("configUri", configStub.baseUri().build().toASCIIString()),
+        config("eventSinkUri", eventSinkStub.baseUri().build().toASCIIString()),
+        config("samlEngineUri", samlEngineStub.baseUri().build().toASCIIString())
+    );
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        JerseyClientConfiguration jerseyClientConfiguration = JerseyClientConfigurationBuilder.aJerseyClientConfiguration()
+                                                                                              .withTimeout(Duration.seconds(10)).build();
+        client = new JerseyClientBuilder(samlSoapProxyAppRule.getEnvironment()).using(jerseyClientConfiguration)
+                                                                               .build(PrometheusMetricsIntegrationTest.class.getSimpleName());
+    }
+
+    @Before
+    public void setUp() throws JsonProcessingException {
+        final MatchingServiceDetails msaOneDetails = new MatchingServiceDetails(
+            msaStubOne.getAttributeQueryRequestUri(), MSA_ONE_ENTITY_ID, RP_ONE_ENTITY_ID);
+        final MatchingServiceDetails msaTwoDetails = new MatchingServiceDetails(
+            msaStubTwo.getAttributeQueryRequestUri(), MSA_TWO_ENTITY_ID, RP_TWO_ENTITY_ID);
+        final MatchingServiceDetails msaThreeDetails = new MatchingServiceDetails(
+            msaStubThree.getAttributeQueryRequestUri(), MSA_THREE_ENTITY_ID, RP_THREE_ENTITY_ID);
+        final MatchingServiceDetails msaFourDetails = new MatchingServiceDetails(
+            msaStubFour.getAttributeQueryRequestUri(), MSA_FOUR_ENTITY_ID, RP_FOUR_ENTITY_ID);
+        Set<MatchingServiceDetails> msaDetailsSet = new HashSet<>(Sets.newHashSet(msaOneDetails, msaTwoDetails, msaThreeDetails, msaFourDetails));
+        final Element msaOneResponse = aHealthyHealthCheckResponse(MSA_ONE_ENTITY_ID, MSA_ONE_RESPONSE_ID);
+        final Element msaTwoResponse = aHealthyHealthCheckResponse(MSA_TWO_ENTITY_ID, MSA_TWO_RESPONSE_ID);
+        final Element msaFourResponse = aHealthyHealthCheckResponse(MSA_FOUR_ENTITY_ID, MSA_FOUR_RESPONSE_ID);
+        final SamlMessageDto msaOneSamlMessage = new SamlMessageDto(encodeAsString(XmlUtils.writeToString(msaOneResponse)));
+        final SamlMessageDto msaTwoSamlMessage = new SamlMessageDto(encodeAsString(XmlUtils.writeToString(msaTwoResponse)));
+        final SamlMessageDto msaFourSamlMessage = new SamlMessageDto(encodeAsString(XmlUtils.writeToString(msaFourResponse)));
+        final MatchingServiceHealthCheckerRequestDto msaOneHealthCheckerRequest = new MatchingServiceHealthCheckerRequestDto(RP_ONE_ENTITY_ID, MSA_ONE_ENTITY_ID);
+        final MatchingServiceHealthCheckerRequestDto msaTwoHealthCheckerRequest = new MatchingServiceHealthCheckerRequestDto(RP_TWO_ENTITY_ID, MSA_TWO_ENTITY_ID);
+        final MatchingServiceHealthCheckerRequestDto msaThreeHealthCheckerRequest = new MatchingServiceHealthCheckerRequestDto(RP_THREE_ENTITY_ID, MSA_THREE_ENTITY_ID);
+        final MatchingServiceHealthCheckerRequestDto msaFourHealthCheckerRequest = new MatchingServiceHealthCheckerRequestDto(RP_FOUR_ENTITY_ID, MSA_FOUR_ENTITY_ID);
+
+        eventSinkStub.setupStubForLogging();
+        configStub.setUpStubForMatchingServiceHealthCheckRequests(msaDetailsSet);
+        configStub.setupStubForCertificates(MSA_ONE_ENTITY_ID, TEST_RP_MS_PUBLIC_SIGNING_CERT, TEST_RP_MS_PUBLIC_ENCRYPTION_CERT);
+        configStub.setupStubForCertificates(MSA_TWO_ENTITY_ID, TEST_RP_MS_PUBLIC_SIGNING_CERT, TEST_RP_MS_PUBLIC_ENCRYPTION_CERT);
+        configStub.setupStubForCertificates(MSA_FOUR_ENTITY_ID, TEST_RP_MS_PUBLIC_SIGNING_CERT, TEST_RP_MS_PUBLIC_ENCRYPTION_CERT);
+        msaStubOne.prepareForHealthCheckRequest(
+            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaOneResponse)), MSA_ONE_VERSION);
+        msaStubTwo.prepareForHealthCheckRequest(
+            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaTwoResponse)), MSA_TWO_VERSION);
+        msaStubFour.prepareForHealthCheckRequest(
+            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaFourResponse)), MSA_FOUR_VERSION);
+        samlEngineStub.prepareForHealthCheckSamlGeneration(msaOneHealthCheckerRequest);
+        samlEngineStub.prepareForHealthCheckSamlGeneration(msaTwoHealthCheckerRequest);
+        samlEngineStub.prepareForHealthCheckSamlGeneration(msaThreeHealthCheckerRequest);
+        samlEngineStub.prepareForHealthCheckSamlGeneration(msaFourHealthCheckerRequest);
+        samlEngineStub.setupStubForAttributeResponseTranslate(
+            msaOneSamlMessage,
+            anInboundResponseFromMatchingServiceDto().withIssuer(MSA_ONE_ENTITY_ID)
+                                                     .withStatus(Healthy)
+                                                     .build());
+        samlEngineStub.setupStubForAttributeResponseTranslate(
+            msaTwoSamlMessage,
+            anInboundResponseFromMatchingServiceDto().withIssuer(MSA_TWO_ENTITY_ID)
+                                                     .withStatus(Healthy)
+                                                     .build());
+        samlEngineStub.setupStubForAttributeResponseTranslate(
+            msaFourSamlMessage,
+            anInboundResponseFromMatchingServiceDto().withIssuer(MSA_FOUR_ENTITY_ID)
+                                                     .withStatus(Healthy)
+                                                     .build());
+    }
+
+    @Test
+    public void shouldHaveUpdatedMsaHealthMetrics() throws InterruptedException {
+        DateTimeFreezer.freezeTime();
+        final DateTime firstTimestamp = DateTime.now(DateTimeZone.UTC);
+        Thread.sleep(WAIT_FOR_MSA_HEALTH_METRICS_TO_BE_UPDATED);
+        Response response = getPrometheusMetrics();
+
+        assertThatMsasHealthMetricsAreCorrect(response);
+        DateTimeFreezer.unfreezeTime();
+
+        DateTimeFreezer.freezeTime();
+        final DateTime secondTimestamp = DateTime.now(DateTimeZone.UTC);
+        Thread.sleep(WAIT_FOR_MSA_HEALTH_METRICS_TO_BE_UPDATED);
+        response = getPrometheusMetrics();
+
+        assertThat(firstTimestamp).isNotEqualTo(secondTimestamp);
+        assertThatMsasHealthMetricsAreCorrect(response);
+        DateTimeFreezer.unfreezeTime();
+    }
+
+    private void assertThatMsasHealthMetricsAreCorrect(final Response response) {
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        final String entity = response.readEntity(String.class);
+        assertThat(entity).contains(String.format(GAUGE_HELP_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_HELP));
+        assertThat(entity).contains(String.format(GAUGE_TYPE_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS));
+        assertThat(entity).contains(String.format(GAUGE_HELP_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED_HELP));
+        assertThat(entity).contains(String.format(GAUGE_TYPE_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED));
+
+        assertThat(entity).contains(String.format(GAUGE_HELP_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO, VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP));
+        assertThat(entity).contains(String.format(GAUGE_TYPE_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO));
+        assertThat(entity).contains(String.format(GAUGE_HELP_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP));
+        assertThat(entity).contains(String.format(GAUGE_TYPE_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED));
+
+        assertThatAHealthyMsaHasBothCorrectHealthAndInfoMetrics(entity, msaStubOne, MSA_ONE_VERSION, MSA_ONE_VERSION_SUPPORTED, MSA_ONE_EIDAS_ENABLED, MSA_ONE_SHOULD_SIGN_WITH_SHA_1);
+        assertThatAHealthyMsaHasBothCorrectHealthAndInfoMetrics(entity, msaStubTwo, MSA_TWO_VERSION, MSA_TWO_VERSION_SUPPORTED, MSA_TWO_EIDAS_ENABLED, MSA_TWO_SHOULD_SIGN_WITH_SHA_1);
+        assertThatAnUnhealthyMsaHasACorrectHealthMetric(entity, msaStubThree);
+        assertThatAnUnhealthyMsaHasACorrectHealthMetric(entity, msaStubFour);
+    }
+
+    private void assertThatAnUnhealthyMsaHasACorrectHealthMetric(final String entity,
+                                                                 final MsaStubRule msa) {
+        assertThat(entity).contains(String.format(
+            MSA_HEALTH_METRICS_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS,
+            msa.getAttributeQueryRequestUri(),
+            UNHEALTHY));
+        assertThat(entity).contains(String.format(
+            MSA_HEALTH_METRICS_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED,
+            msa.getAttributeQueryRequestUri(),
+            (double) DateTime.now(DateTimeZone.UTC).getMillis()));
+        assertThat(entity).doesNotContain(String.format(VERIFY_SAML_SOAP_PROXY_MSA_INFO + "{matchingService=\"%s\",", msa.getAttributeQueryRequestUri()));
+        assertThat(entity).doesNotContain(String.format(VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED + "{matchingService=\"%s\",", msa.getAttributeQueryRequestUri()));
+    }
+
+    private void assertThatAHealthyMsaHasBothCorrectHealthAndInfoMetrics(final String entity,
+                                                                         final MsaStubRule msa,
+                                                                         final String msaVersion,
+                                                                         final String msaVersionSupported,
+                                                                         final boolean msaEidasEnabled,
+                                                                         final boolean msaShouldSignWithSha1) {
+        assertThat(entity).contains(String.format(
+            MSA_HEALTH_METRICS_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS,
+            msa.getAttributeQueryRequestUri(),
+            HEALTHY));
+        assertThat(entity).contains(String.format(
+            MSA_HEALTH_METRICS_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED,
+            msa.getAttributeQueryRequestUri(),
+            (double) DateTime.now(DateTimeZone.UTC).getMillis()));
+        assertThat(entity).contains(String.format(
+            MSA_INFO_METRICS_TEMPLATE,
+            VERIFY_SAML_SOAP_PROXY_MSA_INFO,
+            msa.getAttributeQueryRequestUri(),
+            msaVersion,
+            msaVersionSupported,
+            msaEidasEnabled,
+            msaShouldSignWithSha1,
+            ONBOARDING,
+            HEALTHY));
+        assertThat(entity).contains(String.format(
+            MSA_INFO_METRICS_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED,
+            msa.getAttributeQueryRequestUri(),
+            msaVersion,
+            msaVersionSupported,
+            msaEidasEnabled,
+            msaShouldSignWithSha1,
+            ONBOARDING,
+            (double) DateTime.now(DateTimeZone.UTC).getMillis()));
+    }
+
+    private Response getPrometheusMetrics() {
+        return client.target(UriBuilder.fromUri("http://localhost")
+                                       .path("/prometheus/metrics")
+                                       .port(samlSoapProxyAppRule.getAdminPort())
+                                       .build())
+                     .request()
+                     .get();
+    }
+
+    private static Element aHealthyHealthCheckResponse(final String msaEntityId,
+                                                       final String responseId) {
+        Function<HealthCheckResponseFromMatchingService, Element> transformer = new MsaTransformersFactory().getHealthcheckResponseFromMatchingServiceToElementTransformer(
+            null,
+            getKeyStore(),
+            s -> HUB_ENTITY_ID,
+            SIGNATURE_ALGORITHM,
+            DIGEST_ALGORITHM);
+        final HealthCheckResponseFromMatchingService healthCheckResponse = new HealthCheckResponseFromMatchingService(
+            responseId,
+            msaEntityId,
+            "request-id"
+        );
+        return transformer.apply(healthCheckResponse);
+    }
+
+    private static IdaKeyStore getKeyStore() {
+        List<KeyPair> encryptionKeyPairs = new ArrayList<>();
+        PublicKeyFactory publicKeyFactory = new PublicKeyFactory(new X509CertificateFactory());
+        PrivateKeyFactory privateKeyFactory = new PrivateKeyFactory();
+        PublicKey encryptionPublicKey = publicKeyFactory.createPublicKey(HUB_TEST_PUBLIC_ENCRYPTION_CERT);
+        PrivateKey encryptionPrivateKey = privateKeyFactory.createPrivateKey(Base64.getDecoder().decode(HUB_TEST_PRIVATE_ENCRYPTION_KEY.getBytes()));
+        encryptionKeyPairs.add(new KeyPair(encryptionPublicKey, encryptionPrivateKey));
+        PublicKey publicSigningKey = publicKeyFactory.createPublicKey(HUB_TEST_PUBLIC_SIGNING_CERT);
+        PrivateKey privateSigningKey = privateKeyFactory.createPrivateKey(Base64.getDecoder().decode(HUB_TEST_PRIVATE_SIGNING_KEY.getBytes()));
+        KeyPair signingKeyPair = new KeyPair(publicSigningKey, privateSigningKey);
+
+        return new IdaKeyStore(signingKeyPair, encryptionKeyPairs);
+    }
+}

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
@@ -58,8 +58,6 @@ import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_S
 import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED_HELP;
 import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO;
 import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP;
-import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED;
-import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP;
 import static uk.gov.ida.hub.samlsoapproxy.service.MatchingServiceHealthCheckTask.HEALTHY;
 import static uk.gov.ida.hub.samlsoapproxy.service.MatchingServiceHealthCheckTask.UNHEALTHY;
 import static uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support.MsaStubRule.msaStubRule;
@@ -235,8 +233,6 @@ public class PrometheusMetricsIntegrationTest {
 
         assertThat(entity).contains(String.format(GAUGE_HELP_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO, VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP));
         assertThat(entity).contains(String.format(GAUGE_TYPE_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO));
-        assertThat(entity).contains(String.format(GAUGE_HELP_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP));
-        assertThat(entity).contains(String.format(GAUGE_TYPE_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED));
 
         assertThatAHealthyMsaHasBothCorrectHealthAndInfoMetrics(entity, msaStubOne, MSA_ONE_VERSION, MSA_ONE_VERSION_SUPPORTED, MSA_ONE_EIDAS_ENABLED, MSA_ONE_SHOULD_SIGN_WITH_SHA_1);
         assertThatAHealthyMsaHasBothCorrectHealthAndInfoMetrics(entity, msaStubTwo, MSA_TWO_VERSION, MSA_TWO_VERSION_SUPPORTED, MSA_TWO_EIDAS_ENABLED, MSA_TWO_SHOULD_SIGN_WITH_SHA_1);
@@ -255,7 +251,6 @@ public class PrometheusMetricsIntegrationTest {
             msa.getAttributeQueryRequestUri(),
             (double) DateTime.now(DateTimeZone.UTC).getMillis()));
         assertThat(entity).doesNotContain(String.format(VERIFY_SAML_SOAP_PROXY_MSA_INFO + "{matchingService=\"%s\",", msa.getAttributeQueryRequestUri()));
-        assertThat(entity).doesNotContain(String.format(VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED + "{matchingService=\"%s\",", msa.getAttributeQueryRequestUri()));
     }
 
     private void assertThatAHealthyMsaHasBothCorrectHealthAndInfoMetrics(final String entity,
@@ -282,15 +277,6 @@ public class PrometheusMetricsIntegrationTest {
             msaShouldSignWithSha1,
             ONBOARDING,
             HEALTHY));
-        assertThat(entity).contains(String.format(
-            MSA_INFO_METRICS_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED,
-            msa.getAttributeQueryRequestUri(),
-            msaVersion,
-            msaVersionSupported,
-            msaEidasEnabled,
-            msaShouldSignWithSha1,
-            ONBOARDING,
-            (double) DateTime.now(DateTimeZone.UTC).getMillis()));
     }
 
     private Response getPrometheusMetrics() {

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/ConfigStubRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/ConfigStubRule.java
@@ -15,7 +15,11 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.Response.Status.OK;
 
 public class ConfigStubRule extends HttpStubRule {
@@ -69,4 +73,21 @@ public class ConfigStubRule extends HttpStubRule {
         register(uri, OK.getStatusCode(), matchingServices);
     }
 
+    public void setUpStubForMatchingServiceHealthCheckRequests(final Set<MatchingServiceDetails> matchingServiceDetailsSet) throws JsonProcessingException {
+        final Collection<MatchingServiceConfigEntityDataDto> matchingServices =
+            matchingServiceDetailsSet.stream()
+                                     .map(matchingServiceDetails ->
+                                              new MatchingServiceConfigEntityDataDto(
+                                                  matchingServiceDetails.getMsaEntityId(),
+                                                  matchingServiceDetails.getMsaUri(),
+                                                  matchingServiceDetails.getRpEntityId(),
+                                                  true,
+                                                  false,
+                                                  null))
+                                     .collect(collectingAndThen(toList(), Collections::unmodifiableList));
+        final String uri = UriBuilder.fromPath(Urls.ConfigUrls.ENABLED_MATCHING_SERVICES_RESOURCE)
+                                     .build()
+                                     .getPath();
+        register(uri, OK.getStatusCode(), matchingServices);
+    }
 }

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/MatchingServiceDetails.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/MatchingServiceDetails.java
@@ -1,0 +1,47 @@
+package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support;
+
+import java.net.URI;
+import java.util.Objects;
+
+public final class MatchingServiceDetails {
+    private final URI msaUri;
+    private final String msaEntityId;
+    private final String rpEntityId;
+
+    public MatchingServiceDetails(final URI msaUri,
+                                  final String msaEntityId,
+                                  final String rpEntityId) {
+        this.msaUri = msaUri;
+        this.msaEntityId = msaEntityId;
+        this.rpEntityId = rpEntityId;
+    }
+
+    public URI getMsaUri() {
+        return msaUri;
+    }
+
+    public String getMsaEntityId() {
+        return msaEntityId;
+    }
+
+    public String getRpEntityId() {
+        return rpEntityId;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MatchingServiceDetails that = (MatchingServiceDetails) o;
+        return Objects.equals(msaUri, that.msaUri) && Objects.equals(msaEntityId, that.msaEntityId) && Objects.equals(rpEntityId, that.rpEntityId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(msaUri, msaEntityId, rpEntityId);
+    }
+}

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/MsaStubRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/MsaStubRule.java
@@ -2,10 +2,10 @@ package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
+import httpstub.AbstractHttpStub;
+import httpstub.HttpStub;
 import httpstub.HttpStubRule;
 import httpstub.RegisteredResponse;
-import org.opensaml.core.xml.io.MarshallingException;
-import org.opensaml.xmlsec.signature.support.SignatureException;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -13,15 +13,27 @@ import java.net.URI;
 
 import static httpstub.builders.RegisteredResponseBuilder.aRegisteredResponse;
 
-public class MSAStubRule extends HttpStubRule {
+public class MsaStubRule extends HttpStubRule {
 
     public static final String ATTRIBUTE_QUERY_RESOURCE = "/attribute-query-request";
+
+    private MsaStubRule(AbstractHttpStub abstractHttpStub) {
+        super(abstractHttpStub);
+    }
+
+    public static MsaStubRule sleepyMsaStubRule(final long sleepTime) {
+        return new MsaStubRule(new SleepyHttpStub(sleepTime));
+    }
+
+    public static MsaStubRule msaStubRule() {
+        return new MsaStubRule(new HttpStub());
+    }
 
     public void prepareForAttributeQueryRequest(String response) throws JsonProcessingException {
         register(ATTRIBUTE_QUERY_RESOURCE, Response.Status.OK.getStatusCode(), response);
     }
 
-    public void prepareForHealthCheckRequest(String response, String msaVersion) throws JsonProcessingException, MarshallingException, SignatureException {
+    public void prepareForHealthCheckRequest(String response, String msaVersion) {
         RegisteredResponse registeredResponse = aRegisteredResponse()
                 .withStatus(Response.Status.OK.getStatusCode())
                 .withContentType(MediaType.TEXT_XML_TYPE.toString())

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlEngineStubRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlEngineStubRule.java
@@ -1,47 +1,96 @@
 package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import httpstub.AbstractHttpStub;
+import httpstub.HttpStub;
 import httpstub.HttpStubRule;
+import httpstub.RequestAndResponse;
 import httpstub.StackedHttpStub;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.opensaml.security.credential.Credential;
 import uk.gov.ida.common.ErrorStatusDto;
-import uk.gov.ida.hub.samlsoapproxy.Urls;
+import uk.gov.ida.hub.samlsoapproxy.contract.MatchingServiceHealthCheckerRequestDto;
 import uk.gov.ida.hub.samlsoapproxy.contract.MatchingServiceHealthCheckerResponseDto;
 import uk.gov.ida.hub.samlsoapproxy.contract.SamlMessageDto;
 import uk.gov.ida.saml.core.test.TestCredentialFactory;
-import uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder;
-import uk.gov.ida.saml.core.test.builders.IssuerBuilder;
-import uk.gov.ida.saml.core.test.builders.SignatureBuilder;
 import uk.gov.ida.shared.utils.xml.XmlUtils;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import static httpstub.builders.ExpectedRequestBuilder.expectRequest;
+import static javax.ws.rs.core.Response.Status.OK;
+import static uk.gov.ida.hub.samlsoapproxy.Urls.SamlEngineUrls.GENERATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESOURCE;
+import static uk.gov.ida.hub.samlsoapproxy.Urls.SamlEngineUrls.TRANSLATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESPONSE_RESOURCE;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
+import static uk.gov.ida.saml.core.test.builders.AttributeQueryBuilder.anAttributeQuery;
+import static uk.gov.ida.saml.core.test.builders.IssuerBuilder.anIssuer;
+import static uk.gov.ida.saml.core.test.builders.SignatureBuilder.aSignature;
 
 public class SamlEngineStubRule extends HttpStubRule {
 
     private final Credential signingCredential;
 
-    public SamlEngineStubRule() {
-        super(new StackedHttpStub());
+    private SamlEngineStubRule(AbstractHttpStub abstractHttpStub) {
+        super(abstractHttpStub);
         signingCredential = new TestCredentialFactory(HUB_TEST_PUBLIC_SIGNING_CERT, HUB_TEST_PRIVATE_SIGNING_KEY).getSigningCredential();
     }
 
-    public void setupStubForAttributeResponseTranslate(MatchingServiceHealthCheckerResponseDto matchingServiceHealthCheckerResponseDto) throws JsonProcessingException {
-        register(Urls.SamlEngineUrls.TRANSLATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESPONSE_RESOURCE, Response.Status.OK.getStatusCode(), matchingServiceHealthCheckerResponseDto);
+    public static SamlEngineStubRule stackedSamlEngineStubRule() {
+        return new SamlEngineStubRule(new StackedHttpStub());
+    }
+
+    public static SamlEngineStubRule samlEngineStubRule() {
+        return new SamlEngineStubRule(new HttpStub());
+    }
+
+    public void setupStubForAttributeResponseTranslate(MatchingServiceHealthCheckerResponseDto msaHealthCheckerResponseDto) throws JsonProcessingException {
+        register(TRANSLATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESPONSE_RESOURCE, OK.getStatusCode(), msaHealthCheckerResponseDto);
     }
 
     public void setupStubForAttributeResponseTranslateReturningError(ErrorStatusDto errorStatusDto) throws JsonProcessingException {
-        register(Urls.SamlEngineUrls.TRANSLATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESPONSE_RESOURCE, Response.Status.BAD_REQUEST.getStatusCode(), errorStatusDto);
+        register(TRANSLATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESPONSE_RESOURCE, Response.Status.BAD_REQUEST.getStatusCode(), errorStatusDto);
     }
 
     public void prepareForHealthCheckSamlGeneration() throws JsonProcessingException {
-        AttributeQuery attributeQuery = AttributeQueryBuilder.anAttributeQuery().withSignature(SignatureBuilder.aSignature().withSigningCredential(signingCredential).build()).withIssuer(IssuerBuilder.anIssuer().withIssuerId(HUB_ENTITY_ID).build()).build();
+        AttributeQuery attributeQuery = anAttributeQuery().withSignature(aSignature().withSigningCredential(signingCredential).build())
+                                                          .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+                                                          .build();
         SamlMessageDto samlMessageDto = new SamlMessageDto(XmlUtils.writeToString(attributeQuery.getDOM()));
 
-        register(Urls.SamlEngineUrls.GENERATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESOURCE, Response.Status.OK.getStatusCode(), samlMessageDto);
+        register(GENERATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESOURCE, OK.getStatusCode(), samlMessageDto);
+    }
+
+    public void prepareForHealthCheckSamlGeneration(final MatchingServiceHealthCheckerRequestDto msaHealthCheckerRequest) throws JsonProcessingException {
+
+        final AttributeQuery attributeQuery = anAttributeQuery().withSignature(aSignature().withSigningCredential(signingCredential).build())
+                                                                .withIssuer(anIssuer().withIssuerId(HUB_ENTITY_ID).build())
+                                                                .build();
+        final SamlMessageDto samlMessage = new SamlMessageDto(XmlUtils.writeToString(attributeQuery.getDOM()));
+        final RequestAndResponse requestAndResponse = expectRequest().withPath(GENERATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESOURCE)
+                                                                     .withMethod("POST")
+                                                                     .withBody(msaHealthCheckerRequest)
+                                                                     .andWillRespondWith()
+                                                                     .withStatus(OK.getStatusCode())
+                                                                     .withContentType(MediaType.APPLICATION_JSON)
+                                                                     .withBody(samlMessage)
+                                                                     .build();
+        register(requestAndResponse);
+    }
+
+    public void setupStubForAttributeResponseTranslate(final SamlMessageDto samlMessage,
+                                                       final MatchingServiceHealthCheckerResponseDto msaHealthCheckerResponse) throws JsonProcessingException {
+
+        final RequestAndResponse requestAndResponse = expectRequest().withPath(TRANSLATE_MSA_HEALTHCHECK_ATTRIBUTE_QUERY_RESPONSE_RESOURCE)
+                                                                     .withMethod("POST")
+                                                                     .withBody(samlMessage)
+                                                                     .andWillRespondWith()
+                                                                     .withStatus(OK.getStatusCode())
+                                                                     .withContentType(MediaType.APPLICATION_JSON)
+                                                                     .withBody(msaHealthCheckerResponse)
+                                                                     .build();
+        register(requestAndResponse);
     }
 }

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SleepyHttpStub.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SleepyHttpStub.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support;
+
+import httpstub.AbstractHttpStub;
+import httpstub.ReceivedRequest;
+import httpstub.RecordedRequest;
+import httpstub.RequestAndResponse;
+import httpstub.StubHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+public class SleepyHttpStub extends AbstractHttpStub {
+    private static final Logger LOG = LoggerFactory.getLogger(SleepyHttpStub.class);
+    private final long sleepTime;
+
+    public SleepyHttpStub(final long sleepTime) {
+        this(RANDOM_PORT, sleepTime);
+    }
+
+    public SleepyHttpStub(final int port,
+                          final long sleepTime) {
+        super(port);
+        this.sleepTime = sleepTime;
+    }
+
+    @Override
+    public StubHandler createHandler() {
+        return new SleepyHttpStub.Handler();
+    }
+
+    private class Handler extends StubHandler {
+
+        @Override
+        protected void recordRequest(RecordedRequest recordedRequest) {
+            recordedRequests.add(recordedRequest);
+        }
+
+        @Override
+        public Optional<RequestAndResponse> findResponse(ReceivedRequest receivedRequest) {
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                LOG.warn(e.getMessage());
+            }
+            return requestsAndResponses
+                       .stream()
+                       .filter(requestAndResponse -> requestAndResponse.getRequest().applies(receivedRequest))
+                       .min(Comparator.comparingInt(RequestAndResponse::callCount));
+        }
+    }
+}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -8,6 +8,7 @@ import io.dropwizard.client.JerseyClientConfiguration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.configuration.JerseyClientWithRetryBackoffConfiguration;
 import uk.gov.ida.configuration.ServiceNameConfiguration;
+import uk.gov.ida.hub.samlsoapproxy.config.PrometheusClientServiceConfiguration;
 import uk.gov.ida.hub.samlsoapproxy.config.SamlConfiguration;
 import uk.gov.ida.restclient.RestfulClientConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
@@ -98,6 +99,10 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @JsonProperty
     protected Boolean prometheusEnabled = false;
 
+    @Valid
+    @JsonProperty
+    private PrometheusClientServiceConfiguration matchingServiceHealthCheckServiceConfiguration = new PrometheusClientServiceConfiguration();
+
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -163,5 +168,9 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Override
     public boolean isPrometheusEnabled() {
         return prometheusEnabled;
+    }
+
+    public PrometheusClientServiceConfiguration getMatchingServiceHealthCheckServiceConfiguration() {
+        return matchingServiceHealthCheckServiceConfiguration;
     }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -31,6 +31,7 @@ import uk.gov.ida.hub.samlsoapproxy.annotations.SamlEngine;
 import uk.gov.ida.hub.samlsoapproxy.client.AttributeQueryRequestClient;
 import uk.gov.ida.hub.samlsoapproxy.client.HealthCheckSoapRequestClient;
 import uk.gov.ida.hub.samlsoapproxy.client.MatchingServiceHealthCheckClient;
+import uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient;
 import uk.gov.ida.hub.samlsoapproxy.client.SoapRequestClient;
 import uk.gov.ida.hub.samlsoapproxy.config.CertificatesConfigProxy;
 import uk.gov.ida.hub.samlsoapproxy.config.ConfigServiceKeyStore;
@@ -133,6 +134,23 @@ public class SamlSoapProxyModule extends AbstractModule {
         bind(IpAddressResolver.class).toInstance(new IpAddressResolver());
         bind(TimeoutEvaluator.class).toInstance(new TimeoutEvaluator());
         bind(MetadataHealthCheckRegistry.class).asEagerSingleton();
+    }
+
+    @Provides
+    @Singleton
+    private PrometheusClient getPrometheusClientService(
+        Environment environment,
+        SamlSoapProxyConfiguration configConfiguration,
+        MatchingServiceConfigProxy matchingServiceConfigProxy,
+        MatchingServiceHealthChecker matchingServiceHealthChecker) {
+
+        PrometheusClient prometheusClientService = new PrometheusClient(
+            environment,
+            configConfiguration,
+            matchingServiceConfigProxy,
+            matchingServiceHealthChecker);
+        prometheusClientService.createMatchingServiceHealthCheckMetrics();
+        return prometheusClientService;
     }
 
     @Provides

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/PrometheusClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/PrometheusClient.java
@@ -8,6 +8,7 @@ import uk.gov.ida.hub.samlsoapproxy.SamlSoapProxyConfiguration;
 import uk.gov.ida.hub.samlsoapproxy.config.PrometheusClientServiceConfiguration;
 import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthChecker;
 import uk.gov.ida.hub.samlsoapproxy.proxy.MatchingServiceConfigProxy;
+import uk.gov.ida.hub.samlsoapproxy.service.MatchingServiceInfoMetric;
 import uk.gov.ida.hub.samlsoapproxy.service.MatchingServiceHealthCheckService;
 
 import javax.inject.Inject;
@@ -20,11 +21,9 @@ public class PrometheusClient {
     public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS = "verify_saml_soap_proxy_msa_health_status";
     public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED = "verify_saml_soap_proxy_msa_health_status_last_updated";
     public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO = "verify_saml_soap_proxy_msa_info";
-    public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED = "verify_saml_soap_proxy_msa_info_last_updated";
     public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_HELP = "Matching Service Health Status (1 = healthy and 0 = unhealthy)";
     public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED_HELP = "Matching Service Health Status Metric Last Updated (ms)";
     public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP = "Matching Service Information (1 = healthy)";
-    public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP = "Matching Service Information Metric Last Updated (ms)";
     private static final String MSA_HEALTH_CHECK_TASK_MANAGER = "MatchingServiceHealthCheckTaskManager";
     private static final boolean USE_DAEMON_THREADS = true;
     private final Environment environment;
@@ -52,12 +51,7 @@ public class PrometheusClient {
             Gauge healthStatusLastUpdatedGauge = Gauge.build(VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED_HELP)
                                                  .labelNames("matchingService")
                                                  .register();
-            Gauge informationGauge = Gauge.build(VERIFY_SAML_SOAP_PROXY_MSA_INFO, VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP)
-                                          .labelNames("matchingService", "versionNumber", "versionSupported", "eidasEnabled", "shouldSignWithSha1", "onboarding")
-                                          .register();
-            Gauge informationLastUpdatedGauge = Gauge.build(VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP)
-                                                     .labelNames("matchingService", "versionNumber", "versionSupported", "eidasEnabled", "shouldSignWithSha1", "onboarding")
-                                                     .register();
+            MatchingServiceInfoMetric infoMetric = new MatchingServiceInfoMetric().register();
 
             ExecutorService matchingServiceHealthCheckTaskManager =
                 environment.lifecycle()
@@ -75,8 +69,7 @@ public class PrometheusClient {
                 matchingServiceHealthChecker,
                 healthStatusGauge,
                 healthStatusLastUpdatedGauge,
-                informationGauge,
-                informationLastUpdatedGauge);
+                infoMetric);
 
             createScheduledExecutorService(configuration, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS, matchingServiceHealthCheckService);
         }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/PrometheusClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/PrometheusClient.java
@@ -1,0 +1,97 @@
+package uk.gov.ida.hub.samlsoapproxy.client;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Duration;
+import io.prometheus.client.Gauge;
+import uk.gov.ida.hub.samlsoapproxy.SamlSoapProxyConfiguration;
+import uk.gov.ida.hub.samlsoapproxy.config.PrometheusClientServiceConfiguration;
+import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthChecker;
+import uk.gov.ida.hub.samlsoapproxy.proxy.MatchingServiceConfigProxy;
+import uk.gov.ida.hub.samlsoapproxy.service.MatchingServiceHealthCheckService;
+
+import javax.inject.Inject;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+
+public class PrometheusClient {
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS = "verify_saml_soap_proxy_msa_health_status";
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED = "verify_saml_soap_proxy_msa_health_status_last_updated";
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO = "verify_saml_soap_proxy_msa_info";
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED = "verify_saml_soap_proxy_msa_info_last_updated";
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_HELP = "Matching Service Health Status (1 = healthy and 0 = unhealthy)";
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED_HELP = "Matching Service Health Status Metric Last Updated (ms)";
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP = "Matching Service Information (1 = healthy)";
+    public static final String VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP = "Matching Service Information Metric Last Updated (ms)";
+    private static final String MSA_HEALTH_CHECK_TASK_MANAGER = "MatchingServiceHealthCheckTaskManager";
+    private static final boolean USE_DAEMON_THREADS = true;
+    private final Environment environment;
+    private final SamlSoapProxyConfiguration samlSoapProxyConfiguration;
+    private final MatchingServiceConfigProxy matchingServiceConfigProxy;
+    private final MatchingServiceHealthChecker matchingServiceHealthChecker;
+
+    @Inject
+    public PrometheusClient(final Environment environment,
+                            final SamlSoapProxyConfiguration samlSoapProxyConfiguration,
+                            final MatchingServiceConfigProxy matchingServiceConfigProxy,
+                            final MatchingServiceHealthChecker matchingServiceHealthChecker) {
+        this.environment = environment;
+        this.samlSoapProxyConfiguration = samlSoapProxyConfiguration;
+        this.matchingServiceConfigProxy = matchingServiceConfigProxy;
+        this.matchingServiceHealthChecker = matchingServiceHealthChecker;
+    }
+
+    public void createMatchingServiceHealthCheckMetrics() {
+        final PrometheusClientServiceConfiguration configuration = samlSoapProxyConfiguration.getMatchingServiceHealthCheckServiceConfiguration();
+        if (configuration.getEnable()) {
+            Gauge healthStatusGauge = Gauge.build(VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_HELP)
+                                      .labelNames("matchingService")
+                                      .register();
+            Gauge healthStatusLastUpdatedGauge = Gauge.build(VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED_HELP)
+                                                 .labelNames("matchingService")
+                                                 .register();
+            Gauge informationGauge = Gauge.build(VERIFY_SAML_SOAP_PROXY_MSA_INFO, VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP)
+                                          .labelNames("matchingService", "versionNumber", "versionSupported", "eidasEnabled", "shouldSignWithSha1", "onboarding")
+                                          .register();
+            Gauge informationLastUpdatedGauge = Gauge.build(VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED, VERIFY_SAML_SOAP_PROXY_MSA_INFO_LAST_UPDATED_HELP)
+                                                     .labelNames("matchingService", "versionNumber", "versionSupported", "eidasEnabled", "shouldSignWithSha1", "onboarding")
+                                                     .register();
+
+            ExecutorService matchingServiceHealthCheckTaskManager =
+                environment.lifecycle()
+                           .executorService(MSA_HEALTH_CHECK_TASK_MANAGER)
+                           .threadFactory(new ThreadFactoryBuilder().setNameFormat(MSA_HEALTH_CHECK_TASK_MANAGER).setDaemon(USE_DAEMON_THREADS).build())
+                           .minThreads(0)
+                           .maxThreads(Integer.MAX_VALUE)
+                           .keepAliveTime(Duration.seconds(60L))
+                           .workQueue(new SynchronousQueue<>())
+                           .build();
+            MatchingServiceHealthCheckService matchingServiceHealthCheckService = new MatchingServiceHealthCheckService(
+                matchingServiceHealthCheckTaskManager,
+                samlSoapProxyConfiguration.getHealthCheckSoapHttpClient().getTimeout(),
+                matchingServiceConfigProxy,
+                matchingServiceHealthChecker,
+                healthStatusGauge,
+                healthStatusLastUpdatedGauge,
+                informationGauge,
+                informationLastUpdatedGauge);
+
+            createScheduledExecutorService(configuration, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS, matchingServiceHealthCheckService);
+        }
+    }
+
+    private void createScheduledExecutorService(final PrometheusClientServiceConfiguration configuration,
+                                                final String nameFormat,
+                                                final Runnable service) {
+        ScheduledExecutorService scheduledExecutorService = environment.lifecycle()
+                                                                       .scheduledExecutorService(nameFormat, USE_DAEMON_THREADS)
+                                                                       .build();
+        scheduledExecutorService.scheduleAtFixedRate(
+            service,
+            configuration.getInitialDelay().toSeconds(),
+            configuration.getDelay().toSeconds(),
+            TimeUnit.SECONDS);
+    }
+}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/config/PrometheusClientServiceConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/config/PrometheusClientServiceConfiguration.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.hub.samlsoapproxy.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class PrometheusClientServiceConfiguration {
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Boolean enable = false;
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Duration initialDelay = Duration.seconds(10);
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Duration delay =  Duration.minutes(1);
+
+    public PrometheusClientServiceConfiguration() { }
+
+    public Boolean getEnable() {
+        return enable;
+    }
+
+    public Duration getInitialDelay() {
+        return initialDelay;
+    }
+
+    public Duration getDelay() {
+        return delay;
+    }
+}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/healthcheck/MatchingServiceHealthChecker.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/healthcheck/MatchingServiceHealthChecker.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlsoapproxy.healthcheck;
 
-import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.internal.util.Base64;
 import org.opensaml.saml.saml2.core.AttributeQuery;
@@ -32,6 +31,7 @@ import javax.inject.Named;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static java.text.MessageFormat.format;

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 public class MatchingServiceHealthCheckService implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(MatchingServiceHealthCheckService.class);
+    private static final long WAIT_FOR_THREAD_TO_MARK_TIMEOUT_MATCHING_SERVICE_UNHEALTHY = 1L;
     private final ExecutorService matchingServiceHealthCheckTaskManager;
     private final Duration timeout;
     private final MatchingServiceConfigProxy matchingServiceConfigProxy;
@@ -57,7 +58,7 @@ public class MatchingServiceHealthCheckService implements Runnable {
                                                           healthStatusLastUpdatedGauge,
                                                           infoMetric))
                                              .collect(Collectors.toList());
-            matchingServiceHealthCheckTaskManager.invokeAll(callables, timeout.toSeconds() + 1L, TimeUnit.SECONDS);
+            matchingServiceHealthCheckTaskManager.invokeAll(callables, timeout.toSeconds() + WAIT_FOR_THREAD_TO_MARK_TIMEOUT_MATCHING_SERVICE_UNHEALTHY, TimeUnit.SECONDS);
         } catch (Exception e) {
             LOG.warn(e.getMessage());
         }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
@@ -25,8 +25,7 @@ public class MatchingServiceHealthCheckService implements Runnable {
     private final MatchingServiceHealthChecker matchingServiceHealthChecker;
     private final Gauge healthStatusGauge;
     private final Gauge healthStatusLastUpdatedGauge;
-    private final Gauge informationGauge;
-    private final Gauge informationLastUpdatedGauge;
+    private final MatchingServiceInfoMetric infoMetric;
 
     public MatchingServiceHealthCheckService(final ExecutorService matchingServiceHealthCheckTaskManager,
                                              final Duration timeout,
@@ -34,16 +33,14 @@ public class MatchingServiceHealthCheckService implements Runnable {
                                              final MatchingServiceHealthChecker matchingServiceHealthChecker,
                                              final Gauge healthStatusGauge,
                                              final Gauge healthStatusLastUpdatedGauge,
-                                             final Gauge informationGauge,
-                                             final Gauge informationLastUpdatedGauge) {
+                                             final MatchingServiceInfoMetric infoMetric) {
         this.matchingServiceHealthCheckTaskManager = matchingServiceHealthCheckTaskManager;
         this.timeout = timeout;
         this.matchingServiceConfigProxy = matchingServiceConfigProxy;
         this.matchingServiceHealthChecker = matchingServiceHealthChecker;
         this.healthStatusGauge = healthStatusGauge;
         this.healthStatusLastUpdatedGauge = healthStatusLastUpdatedGauge;
-        this.informationGauge = informationGauge;
-        this.informationLastUpdatedGauge = informationLastUpdatedGauge;
+        this.infoMetric = infoMetric;
     }
 
     @Override
@@ -58,8 +55,7 @@ public class MatchingServiceHealthCheckService implements Runnable {
                                                           matchingServiceInformation,
                                                           healthStatusGauge,
                                                           healthStatusLastUpdatedGauge,
-                                                          informationGauge,
-                                                          informationLastUpdatedGauge))
+                                                          infoMetric))
                                              .collect(Collectors.toList());
             matchingServiceHealthCheckTaskManager.invokeAll(callables, timeout.toSeconds() + 1L, TimeUnit.SECONDS);
         } catch (Exception e) {

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
@@ -1,0 +1,90 @@
+package uk.gov.ida.hub.samlsoapproxy.service;
+
+import io.dropwizard.util.Duration;
+import io.prometheus.client.Gauge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.hub.samlsoapproxy.contract.MatchingServiceConfigEntityDataDto;
+import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthChecker;
+import uk.gov.ida.hub.samlsoapproxy.proxy.MatchingServiceConfigProxy;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class MatchingServiceHealthCheckService implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(MatchingServiceHealthCheckService.class);
+    private final ExecutorService matchingServiceHealthCheckTaskManager;
+    private final Duration timeout;
+    private final MatchingServiceConfigProxy matchingServiceConfigProxy;
+    private final MatchingServiceHealthChecker matchingServiceHealthChecker;
+    private final Gauge healthStatusGauge;
+    private final Gauge healthStatusLastUpdatedGauge;
+    private final Gauge informationGauge;
+    private final Gauge informationLastUpdatedGauge;
+
+    public MatchingServiceHealthCheckService(final ExecutorService matchingServiceHealthCheckTaskManager,
+                                             final Duration timeout,
+                                             final MatchingServiceConfigProxy matchingServiceConfigProxy,
+                                             final MatchingServiceHealthChecker matchingServiceHealthChecker,
+                                             final Gauge healthStatusGauge,
+                                             final Gauge healthStatusLastUpdatedGauge,
+                                             final Gauge informationGauge,
+                                             final Gauge informationLastUpdatedGauge) {
+        this.matchingServiceHealthCheckTaskManager = matchingServiceHealthCheckTaskManager;
+        this.timeout = timeout;
+        this.matchingServiceConfigProxy = matchingServiceConfigProxy;
+        this.matchingServiceHealthChecker = matchingServiceHealthChecker;
+        this.healthStatusGauge = healthStatusGauge;
+        this.healthStatusLastUpdatedGauge = healthStatusLastUpdatedGauge;
+        this.informationGauge = informationGauge;
+        this.informationLastUpdatedGauge = informationLastUpdatedGauge;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Collection<MatchingServiceConfigEntityDataDto> matchingServicesToHealthCheck = getUniqueHealthCheckEnabledMatchingServiceConfigs();
+            List<Callable<String>> callables =
+                matchingServicesToHealthCheck.stream()
+                                             .map(matchingServiceInformation ->
+                                                      new MatchingServiceHealthCheckTask(
+                                                          matchingServiceHealthChecker,
+                                                          matchingServiceInformation,
+                                                          healthStatusGauge,
+                                                          healthStatusLastUpdatedGauge,
+                                                          informationGauge,
+                                                          informationLastUpdatedGauge))
+                                             .collect(Collectors.toList());
+            matchingServiceHealthCheckTaskManager.invokeAll(callables, timeout.toSeconds() + 1L, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOG.warn(e.getMessage());
+        }
+    }
+
+    private Collection<MatchingServiceConfigEntityDataDto> getUniqueHealthCheckEnabledMatchingServiceConfigs() {
+        final Collection<MatchingServiceConfigEntityDataDto> allMatchingServices = matchingServiceConfigProxy.getMatchingServices();
+
+        // remove duplicated MSAs from the list; we ignore transactionEntityIds when reporting results, so just take the
+        // first instance of each MSA
+        Set<String> uniqueMatchingServiceEntityIds = new HashSet<>();
+        final List<MatchingServiceConfigEntityDataDto> uniqueMatchingServices =
+            allMatchingServices.stream()
+                               .filter(dto -> uniqueMatchingServiceEntityIds.add(dto.getEntityId()))
+                               .collect(Collectors.toList());
+
+        return getMatchingServicesWithEnabledHealthCheck(uniqueMatchingServices);
+    }
+
+    private Collection<MatchingServiceConfigEntityDataDto> getMatchingServicesWithEnabledHealthCheck(
+        final Collection<MatchingServiceConfigEntityDataDto> matchingServices) {
+        return matchingServices.stream()
+                               .filter(MatchingServiceConfigEntityDataDto::isHealthCheckEnabled)
+                               .collect(Collectors.toList());
+    }
+}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckTask.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckTask.java
@@ -1,0 +1,75 @@
+package uk.gov.ida.hub.samlsoapproxy.service;
+
+import io.prometheus.client.Gauge;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.hub.samlsoapproxy.contract.MatchingServiceConfigEntityDataDto;
+import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthCheckResult;
+import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthChecker;
+
+import java.util.concurrent.Callable;
+
+public class MatchingServiceHealthCheckTask implements Callable<String> {
+    private static final Logger LOG = LoggerFactory.getLogger(MatchingServiceHealthCheckTask.class);
+    private final MatchingServiceHealthChecker matchingServiceHealthChecker;
+    private final MatchingServiceConfigEntityDataDto matchingServiceConfig;
+    private final Gauge healthStatusGauge;
+    private final Gauge healthStatusLastUpdatedGauge;
+    private final Gauge informationGauge;
+    private final Gauge informationLastUpdatedGauge;
+    public static final double HEALTHY = 1.0;
+    public static final double UNHEALTHY = 0.0;
+
+    public MatchingServiceHealthCheckTask(final MatchingServiceHealthChecker matchingServiceHealthChecker,
+                                          final MatchingServiceConfigEntityDataDto matchingServiceConfig,
+                                          final Gauge healthStatusGauge,
+                                          final Gauge healthStatusLastUpdatedGauge,
+                                          final Gauge informationGauge,
+                                          final Gauge informationLastUpdatedGauge) {
+        this.matchingServiceHealthChecker = matchingServiceHealthChecker;
+        this.matchingServiceConfig = matchingServiceConfig;
+        this.healthStatusGauge = healthStatusGauge;
+        this.healthStatusLastUpdatedGauge = healthStatusLastUpdatedGauge;
+        this.informationGauge = informationGauge;
+        this.informationLastUpdatedGauge = informationLastUpdatedGauge;
+    }
+
+    @Override
+    public String call() {
+        try {
+            final MatchingServiceHealthCheckResult matchingServiceHealthCheckResult = matchingServiceHealthChecker.performHealthCheck(matchingServiceConfig);
+            final double timestamp = DateTime.now(DateTimeZone.UTC).getMillis();
+            if (matchingServiceHealthCheckResult.isHealthy()) {
+                healthStatusGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
+                                 .set(HEALTHY);
+                healthStatusLastUpdatedGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
+                                            .set(timestamp);
+                addAnInformationGauge(informationGauge, matchingServiceHealthCheckResult, HEALTHY);
+                addAnInformationGauge(informationLastUpdatedGauge, matchingServiceHealthCheckResult, timestamp);
+            } else {
+                healthStatusGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
+                                 .set(UNHEALTHY);
+                healthStatusLastUpdatedGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
+                                            .set(timestamp);
+            }
+        } catch (Exception e) {
+            LOG.warn(e.getMessage());
+        }
+        return DateTime.now(DateTimeZone.UTC) + matchingServiceConfig.getEntityId();
+    }
+
+    private void addAnInformationGauge(final Gauge gauge,
+                                       final MatchingServiceHealthCheckResult matchingServiceHealthCheckResult,
+                                       final double value) {
+        gauge.labels(
+            matchingServiceHealthCheckResult.getDetails().getMatchingService().toString(),
+            matchingServiceHealthCheckResult.getDetails().getVersionNumber(),
+            String.valueOf(matchingServiceHealthCheckResult.getDetails().isVersionSupported()),
+            matchingServiceHealthCheckResult.getDetails().getEidasEnabled(),
+            matchingServiceHealthCheckResult.getDetails().getShouldSignWithSha1(),
+            String.valueOf(matchingServiceHealthCheckResult.getDetails().isOnboarding()))
+             .set(value);
+    }
+}

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceInfoMetric.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceInfoMetric.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.hub.samlsoapproxy.service;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthCheckDetails;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO;
+import static uk.gov.ida.hub.samlsoapproxy.client.PrometheusClient.VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP;
+
+public class MatchingServiceInfoMetric extends Collector {
+    private final ConcurrentMap<String, MatchingServiceHealthCheckDetails> data;
+
+    public MatchingServiceInfoMetric() {
+        this.data = new ConcurrentHashMap<>();
+    }
+
+    public void recordDetails(MatchingServiceHealthCheckDetails details) {
+        data.put(details.getMatchingService().toString(), details);
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        return data.values().stream().map(this::infoMetricFor).collect(Collectors.toList());
+    }
+
+    private MetricFamilySamples infoMetricFor(MatchingServiceHealthCheckDetails details) {
+        GaugeMetricFamily info = new GaugeMetricFamily(VERIFY_SAML_SOAP_PROXY_MSA_INFO, VERIFY_SAML_SOAP_PROXY_MSA_INFO_HELP, Arrays.asList("matchingService", "versionNumber", "versionSupported", "eidasEnabled", "shouldSignWithSha1", "onboarding"));
+        info.addMetric(Arrays.asList(details.getMatchingService().toString(),
+                details.getVersionNumber(),
+                String.valueOf(details.isVersionSupported()),
+                details.getEidasEnabled(),
+                details.getShouldSignWithSha1(),
+                String.valueOf(details.isOnboarding())),
+                1.0
+                );
+        return info;
+    }
+}


### PR DESCRIPTION
Currently, Sensu hits SAML SOAP Proxy application's /saml-soap-proxy/matching-service-health-check endpoint every 60 seconds which causes it to make a health-check SOAP request to each MSA and then aggregates all of responses from MSAs together into a single yes/no response to the Sensu check. If the Sensu check comes back as "yes", sensu fires a notification to PagerDuty.

This commits adds Matching Service Health Check Service to check MSAs concurrently and provides two metrics to prometheus metrics. The first metric `verify_saml_soap_proxy_msa_health_status` returns a list of MSA health statuses (healthy and unhealthy). For example,

verify_saml_soap_proxy_msa_health_status{matchingService="http://localhost:63846/attribute-query-request",} 1.0
verify_saml_soap_proxy_msa_health_status_last_updated{matchingService="http://localhost:63846/attribute-query-request",} 1.549057838452E12

The second metric returns a list of matching services' information provided that they are healthy. For example,

verify_saml_soap_proxy_msa_info{matchingService="http://localhost:63845/attribute-query-request",versionNumber="592",versionSupported="true",eidasEnabled="true",shouldSignWithSha1="false",onboarding="false",} 1.0

These metrics are updated every 60 seconds.

It has an integration test which tests Matching Service Health Check Service to send health requests to the following 4 matching services, get responses from them and create Matching Service health metrics.

1. Healthy MSA (supported version)
2. Healthy MSA (unsupported version)
3. Unresponsive MSA
4. Slow response MSA

Author: @adityapahuja