### PR TITLE
HUB-42: Communicate to users when IDP is having technical difficulty

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
@@ -101,6 +101,7 @@ public class IdentityProviderConfigEntityData implements ConfigEntityData {
         return enabled;
     }
 
+    @JsonProperty("temporarilyUnavailable")
     public Boolean isTemporarilyUnavailable() {
         return temporarilyUnavailable;
     }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigEntityData.java
@@ -75,6 +75,10 @@ public class IdentityProviderConfigEntityData implements ConfigEntityData {
     @JsonProperty
     protected Boolean useExactComparisonType;
 
+    @Valid
+    @JsonProperty
+    protected Boolean temporarilyUnavailable = false;
+
     @Override
     public String getEntityId() {
         return entityId;
@@ -95,6 +99,10 @@ public class IdentityProviderConfigEntityData implements ConfigEntityData {
 
     public Boolean isEnabled() {
         return enabled;
+    }
+
+    public Boolean isTemporarilyUnavailable() {
+        return temporarilyUnavailable;
     }
     
     public Boolean isRegistrationEnabled() {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
@@ -12,17 +12,20 @@ public class IdpDto {
     private final String entityId;
     private final List<LevelOfAssurance> levelsOfAssurance;
     private final boolean authenticationEnabled;
+    private final boolean temporarilyUnavailable;
 
     @JsonCreator
     public IdpDto(
             @JsonProperty("simpleId") String simpleId,
             @JsonProperty("entityId") String entityId,
             @JsonProperty("supportedLevelsOfAssurance") List<LevelOfAssurance> levelsOfAssurance,
-            @JsonProperty("authenticationEnabled") boolean authenticationEnabled) {
+            @JsonProperty("authenticationEnabled") boolean authenticationEnabled,
+            @JsonProperty("temporarilyUnavailable") boolean temporarilyUnavailable) {
         this.simpleId = simpleId;
         this.entityId = entityId;
         this.levelsOfAssurance = levelsOfAssurance;
         this.authenticationEnabled = authenticationEnabled;
+        this.temporarilyUnavailable = temporarilyUnavailable;
     }
 
     public String getSimpleId() {
@@ -36,8 +39,10 @@ public class IdpDto {
     public List<LevelOfAssurance> getLevelsOfAssurance() {
         return levelsOfAssurance;
     }
-    
+
     public boolean isAuthenticationEnabled() { return authenticationEnabled; }
+
+    public boolean isTemporarilyUnavailable() { return temporarilyUnavailable; }
 
     @Override
     public boolean equals(Object o) {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
@@ -56,7 +56,13 @@ public class IdentityProviderResource {
 
         Collection<IdentityProviderConfigEntityData> matchingIdps = getIdentityProviderConfigEntityData(transactionEntityId);
         return matchingIdps.stream().map(configData ->
-                new IdpDto(configData.getSimpleId(), configData.getEntityId(), configData.getSupportedLevelsOfAssurance(), configData.isAuthenticationEnabled())).collect(Collectors.toList());
+                new IdpDto(
+                        configData.getSimpleId(),
+                        configData.getEntityId(),
+                        configData.getSupportedLevelsOfAssurance(),
+                        configData.isAuthenticationEnabled(),
+                        configData.isTemporarilyUnavailable()))
+                .collect(Collectors.toList());
     }
 
     @GET
@@ -71,7 +77,8 @@ public class IdentityProviderResource {
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
                                 configData.getSupportedLevelsOfAssurance(),
-                                configData.isAuthenticationEnabled()))
+                                configData.isAuthenticationEnabled(),
+                                configData.isTemporarilyUnavailable()))
                 .collect(Collectors.toList());
     }
 
@@ -86,7 +93,8 @@ public class IdentityProviderResource {
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
                                 configData.getSupportedLevelsOfAssurance(),
-                                configData.isAuthenticationEnabled()))
+                                configData.isAuthenticationEnabled(),
+                                configData.isTemporarilyUnavailable()))
                 .collect(Collectors.toList());
     }
 
@@ -101,7 +109,8 @@ public class IdentityProviderResource {
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
                                 configData.getSupportedLevelsOfAssurance(),
-                                configData.isAuthenticationEnabled()))
+                                configData.isAuthenticationEnabled(),
+                                configData.isTemporarilyUnavailable()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
When an IDP is temporarily down, show users a warning. Explain that the IDP is temporarily down.

Add support for a `temporarilyUnavailable` flag in the main IDP config. Default the flag to `false`. Expose this flag via the main config API for the frontend to consume.

See https://trello.com/c/ly1m24h4/