### PR TITLE
AUTO: Fix eIDAS state serialization

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasAuthnFailedErrorStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasAuthnFailedErrorStateController.java
@@ -29,7 +29,7 @@ public class EidasAuthnFailedErrorStateController extends AbstractAuthnFailedErr
     public void selectCountry(final String countryEntityId) {
         EidasCountrySelectedState countrySelectedState = new EidasCountrySelectedState(
                 countryEntityId,
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getRequestId(),
                 state.getRequestIssuerEntityId(),
                 state.getSessionExpiryTimestamp(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -130,7 +130,7 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
     public void selectCountry(String countryEntityId) {
         EidasCountrySelectedState countrySelectedState = new EidasCountrySelectedState(
                 countryEntityId,
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getRequestId(),
                 state.getRequestIssuerEntityId(),
                 state.getSessionExpiryTimestamp(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/SessionStartedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/SessionStartedStateController.java
@@ -85,7 +85,7 @@ public class SessionStartedStateController implements IdpSelectingStateControlle
     public void selectCountry(String countryEntityId) {
         EidasCountrySelectedState eidasCountrySelectedState = new EidasCountrySelectedState(
                 countryEntityId,
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getRequestId(),
                 state.getRequestIssuerEntityId(),
                 state.getSessionExpiryTimestamp(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCountrySelectedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCountrySelectedState.java
@@ -26,7 +26,7 @@ public class EidasCountrySelectedState extends AbstractState implements EidasCou
     @JsonCreator
     public EidasCountrySelectedState(
             @JsonProperty("countryEntityId") final String countryEntityId,
-            @JsonProperty("relayState") final Optional<String> relayState,
+            @JsonProperty("relayState") final String relayState,
             @JsonProperty("requestId") final String requestId,
             @JsonProperty("requestIssuerId") final String requestIssuerId,
             @JsonProperty("sessionExpiryTimestamp") final DateTime sessionExpiryTimestamp,
@@ -45,7 +45,7 @@ public class EidasCountrySelectedState extends AbstractState implements EidasCou
             forceAuthentication
         );
 
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
         this.countryEntityId = countryEntityId;
         this.levelsOfAssurance = levelsOfAssurance;
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasCountrySelectedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasCountrySelectedStateBuilder.java
@@ -19,7 +19,6 @@ public class EidasCountrySelectedStateBuilder {
     private String requestId = UUID.randomUUID().toString();
     private String requestIssuerId = "requestIssuerId";
     private URI assertionConsumerServiceUri = URI.create("/default-service-index");
-    private Optional<String> relayState = absent();
     private DateTime sessionExpiryTimestamp = DateTime.now(DateTimeZone.UTC).plusMinutes(10);
     private SessionId sessionId = aSessionId().build();
     private List<LevelOfAssurance> levelOfAssurance;
@@ -39,7 +38,7 @@ public class EidasCountrySelectedStateBuilder {
     public EidasCountrySelectedState build() {
         return new EidasCountrySelectedState(
             countryCode,
-            relayState,
+            null,
             requestId,
             requestIssuerId,
             sessionExpiryTimestamp,


### PR DESCRIPTION
- The field type for relayState is Optional but it was being serialized
  to `null` when absent
- This meant that when we tried to deserialize it, the Optional was set
  to null (since it is a reference type)
- Fix it so that the constructor takes just a String and wraps it in
  Optional if it is null