### PR TITLE
BAU: Fix state serialization

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionResource.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionResource.java
@@ -175,7 +175,7 @@ public class TestSessionResource {
                 dto.getTransactionSupportsEidas(),
                 dto.getIdentityProviderEntityId(),
                 dto.getMatchingServiceAdapterEntityId(),
-                dto.getRelayState(),
+                dto.getRelayState().orNull(),
                 dto.getPersistentId(),
                 dto.getLevelOfAssurance(),
                 dto.getEncryptedIdentityAssertion(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/AbstractAwaitingCycle3DataStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/AbstractAwaitingCycle3DataStateController.java
@@ -116,7 +116,7 @@ public abstract class AbstractAwaitingCycle3DataStateController<S extends Abstra
         Cycle3DataInputCancelledState cycle3DataInputCancelledState = new Cycle3DataInputCancelledState(
                 state.getRequestId(),
                 state.getSessionExpiryTimestamp(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getRequestIssuerEntityId(),
                 state.getAssertionConsumerServiceUri(),
                 new SessionId(state.getSessionId().getSessionId()),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/AbstractMatchRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/AbstractMatchRequestSentStateController.java
@@ -198,7 +198,7 @@ public abstract class AbstractMatchRequestSentStateController<T extends Abstract
                 state.getRequestIssuerEntityId(),
                 state.getSessionExpiryTimestamp(),
                 state.getAssertionConsumerServiceUri(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getSessionId(),
                 state.getTransactionSupportsEidas());
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/AbstractMatchRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/AbstractMatchRequestSentStateController.java
@@ -73,7 +73,7 @@ public abstract class AbstractMatchRequestSentStateController<T extends Abstract
                 state.getSessionExpiryTimestamp(),
                 state.getAssertionConsumerServiceUri(),
                 state.getIdentityProviderEntityId(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getSessionId(),
                 state.getTransactionSupportsEidas());
         stateTransitionAction.transitionTo(matchingServiceRequestErrorState);
@@ -89,7 +89,7 @@ public abstract class AbstractMatchRequestSentStateController<T extends Abstract
                     state.getSessionExpiryTimestamp(),
                     state.getAssertionConsumerServiceUri(),
                     state.getIdentityProviderEntityId(),
-                    state.getRelayState(),
+                    state.getRelayState().orNull(),
                     state.getSessionId(),
                     state.getTransactionSupportsEidas());
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -247,7 +247,7 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 state.getAssertionConsumerServiceUri(),
                 new SessionId(state.getSessionId().getSessionId()),
                 state.getTransactionSupportsEidas(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 translatedResponse.getEncryptedIdentityAssertionBlob().transform(Collections::singleton).or(emptySet())
         );
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateController.java
@@ -91,7 +91,7 @@ public class EidasCycle0And1MatchRequestSentStateController extends EidasMatchRe
                 state.getTransactionSupportsEidas(),
                 state.getIdentityProviderEntityId(),
                 state.getMatchingServiceAdapterEntityId(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getPersistentId(),
                 state.getIdpLevelOfAssurance(),
                 state.getEncryptedIdentityAssertion(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasUserAccountCreationRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasUserAccountCreationRequestSentStateController.java
@@ -54,7 +54,7 @@ public class EidasUserAccountCreationRequestSentStateController extends EidasMat
                 state.getRequestIssuerEntityId(),
                 state.getSessionExpiryTimestamp(),
                 state.getAssertionConsumerServiceUri(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getSessionId(),
                 state.getForceAuthentication().orNull()
         );

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -257,7 +257,7 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
                 state.getAssertionConsumerServiceUri(),
                 state.getSessionId(),
                 state.getTransactionSupportsEidas(),
-                state.getRelayState());
+                state.getRelayState().orNull());
     }
 
     private State createCycle0And1MatchRequestSentState(SuccessFromIdp successFromIdp) {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -292,7 +292,7 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
             state.getAssertionConsumerServiceUri(),
             new SessionId(state.getSessionId().getSessionId()),
             state.getTransactionSupportsEidas(),
-            state.getRelayState(),
+            state.getRelayState().orNull(),
             encryptedAssertions
         );
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/UserAccountCreationRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/UserAccountCreationRequestSentStateController.java
@@ -54,7 +54,7 @@ public class UserAccountCreationRequestSentStateController extends MatchRequestS
                 state.getRequestIssuerEntityId(),
                 state.getSessionExpiryTimestamp(),
                 state.getAssertionConsumerServiceUri(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 state.getSessionId(),
                 state.getTransactionSupportsEidas()
         );

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AbstractAwaitingCycle3DataState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AbstractAwaitingCycle3DataState.java
@@ -35,7 +35,7 @@ public abstract class AbstractAwaitingCycle3DataState extends AbstractState impl
         final boolean transactionSupportsEidas,
         final String identityProviderEntityId,
         final String matchingServiceEntityId,
-        final Optional<String> relayState,
+        final String relayState,
         final PersistentId persistentId,
         final LevelOfAssurance levelOfAssurance,
         final Boolean forceAuthentication) {
@@ -52,7 +52,7 @@ public abstract class AbstractAwaitingCycle3DataState extends AbstractState impl
 
         this.identityProviderEntityId = identityProviderEntityId;
         this.matchingServiceEntityId = matchingServiceEntityId;
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
         this.persistentId = persistentId;
         this.levelOfAssurance = levelOfAssurance;
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AbstractUserAccountCreationFailedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AbstractUserAccountCreationFailedState.java
@@ -20,7 +20,7 @@ public abstract class AbstractUserAccountCreationFailedState extends AbstractSta
         final String authnRequestIssuerEntityId,
         final DateTime sessionExpiryTimestamp,
         final URI assertionConsumerServiceUri,
-        final Optional<String> relayState,
+        final String relayState,
         final SessionId sessionId,
         final boolean transactionSupportsEidas,
         final Boolean forceAuthentication) {
@@ -35,7 +35,7 @@ public abstract class AbstractUserAccountCreationFailedState extends AbstractSta
             forceAuthentication
         );
 
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AwaitingCycle3DataState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/AwaitingCycle3DataState.java
@@ -2,7 +2,6 @@ package uk.gov.ida.hub.policy.domain.state;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
@@ -47,7 +46,7 @@ public class AwaitingCycle3DataState extends AbstractAwaitingCycle3DataState {
                 transactionSupportsEidas,
                 identityProviderEntityId,
                 matchingServiceEntityId,
-                Optional.fromNullable(relayState),
+                relayState,
                 persistentId,
                 levelOfAssurance,
                 null

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/Cycle3DataInputCancelledState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/Cycle3DataInputCancelledState.java
@@ -9,7 +9,6 @@ import uk.gov.ida.hub.policy.domain.SessionId;
 
 import java.io.Serializable;
 import java.net.URI;
-import java.util.Objects;
 
 public class Cycle3DataInputCancelledState extends AbstractState implements ResponsePreparedState, Serializable {
 
@@ -22,7 +21,7 @@ public class Cycle3DataInputCancelledState extends AbstractState implements Resp
     public Cycle3DataInputCancelledState(
         @JsonProperty("requestId") final String requestId,
         @JsonProperty("sessionExpiryTimestamp") final DateTime sessionExpiryTimestamp,
-        @JsonProperty("relayState") final Optional<String> relayState,
+        @JsonProperty("relayState") final String relayState,
         @JsonProperty("requestIssuerId") final String requestIssuerId,
         @JsonProperty("assertionConsumerServiceUri") final URI assertionConsumerServiceUri,
         @JsonProperty("sessionId") final SessionId sessionId,
@@ -37,7 +36,7 @@ public class Cycle3DataInputCancelledState extends AbstractState implements Resp
             transactionSupportsEidas,
             null);
 
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
     }
 
     public Optional<String> getRelayState() {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasAwaitingCycle3DataState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasAwaitingCycle3DataState.java
@@ -2,16 +2,12 @@ package uk.gov.ida.hub.policy.domain.state;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.StandardToStringStyle;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
 
 import java.net.URI;
-import java.util.Objects;
 
 public class EidasAwaitingCycle3DataState extends AbstractAwaitingCycle3DataState {
 
@@ -30,7 +26,7 @@ public class EidasAwaitingCycle3DataState extends AbstractAwaitingCycle3DataStat
         @JsonProperty("transactionSupportsEidas") final boolean transactionSupportsEidas,
         @JsonProperty("identityProviderEntityId") final String identityProviderEntityId,
         @JsonProperty("matchingServiceAdapterEntityId") final String matchingServiceAdapterEntityId,
-        @JsonProperty("relayState") final Optional<String> relayState,
+        @JsonProperty("relayState") final String relayState,
         @JsonProperty("persistentId") final PersistentId persistentId,
         @JsonProperty("levelOfAssurance") final LevelOfAssurance levelOfAssurance,
         @JsonProperty("encryptedIdentityAssertion") final String encryptedIdentityAssertion,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasUserAccountCreationFailedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasUserAccountCreationFailedState.java
@@ -2,7 +2,6 @@ package uk.gov.ida.hub.policy.domain.state;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 
@@ -18,7 +17,7 @@ public class EidasUserAccountCreationFailedState extends AbstractUserAccountCrea
             @JsonProperty("authnRequestIssuerEntityId") final String authnRequestIssuerEntityId,
             @JsonProperty("sessionExpiryTimestamp") final DateTime sessionExpiryTimestamp,
             @JsonProperty("assertionConsumerServiceUri") final URI assertionConsumerServiceUri,
-            @JsonProperty("relayState") final Optional<String> relayState,
+            @JsonProperty("relayState") final String relayState,
             @JsonProperty("sessionId") final SessionId sessionId,
             @JsonProperty("forceAuthentication") final Boolean forceAuthentication) {
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/MatchingServiceRequestErrorState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/MatchingServiceRequestErrorState.java
@@ -26,7 +26,7 @@ public class MatchingServiceRequestErrorState extends AbstractState implements R
             @JsonProperty("sessionExpiryTimestamp") final DateTime sessionExpiryTimestamp,
             @JsonProperty("assertionConsumerServiceUri") final URI assertionConsumerServiceUri,
             @JsonProperty("identityProviderEntityId") final String identityProviderEntityId,
-            @JsonProperty("relayState") final Optional<String> relayState,
+            @JsonProperty("relayState") final String relayState,
             @JsonProperty("sessionId") final SessionId sessionId,
             @JsonProperty("transactionSupportsEidas") final boolean transactionSupportsEidas) {
 
@@ -41,7 +41,7 @@ public class MatchingServiceRequestErrorState extends AbstractState implements R
         );
 
         this.identityProviderEntityId = identityProviderEntityId;
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
     }
 
     public String getIdentityProviderEntityId() {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/NoMatchState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/NoMatchState.java
@@ -9,7 +9,6 @@ import uk.gov.ida.hub.policy.domain.SessionId;
 
 import java.io.Serializable;
 import java.net.URI;
-import java.util.Objects;
 
 public class NoMatchState extends AbstractState implements ResponseProcessingState, ResponsePreparedState, Serializable {
 
@@ -25,7 +24,7 @@ public class NoMatchState extends AbstractState implements ResponseProcessingSta
             @JsonProperty("requestIssuerId") final String requestIssuerId,
             @JsonProperty("sessionExpiryTimestamp") final DateTime sessionExpiryTimestamp,
             @JsonProperty("assertionConsumerServiceUri") final URI assertionConsumerServiceUri,
-            @JsonProperty("relayState") final Optional<String> relayState,
+            @JsonProperty("relayState") final String relayState,
             @JsonProperty("sessionId") final SessionId sessionId,
             @JsonProperty("transactionSupportsEidas") final boolean transactionSupportsEidas) {
 
@@ -40,7 +39,7 @@ public class NoMatchState extends AbstractState implements ResponseProcessingSta
         );
 
         this.identityProviderEntityId = identityProviderEntityId;
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
     }
 
     public String getIdentityProviderEntityId() {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/NonMatchingJourneySuccessState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/NonMatchingJourneySuccessState.java
@@ -25,7 +25,7 @@ public class NonMatchingJourneySuccessState extends AbstractState implements Res
             @JsonProperty("assertionConsumerServiceUri") final URI assertionConsumerServiceUri,
             @JsonProperty("sessionId") final SessionId sessionId,
             @JsonProperty("transactionSupportsEidas") final boolean transactionSupportsEidas,
-            @JsonProperty("relayState") final Optional<String> relayState,
+            @JsonProperty("relayState") final String relayState,
             @JsonProperty("encryptedAssertions") final Set<String> encryptedAssertions) {
 
         super(
@@ -38,7 +38,7 @@ public class NonMatchingJourneySuccessState extends AbstractState implements Res
                 null
         );
 
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
         this.encryptedAssertions = encryptedAssertions;
     }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/PausedRegistrationState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/PausedRegistrationState.java
@@ -25,7 +25,7 @@ public class PausedRegistrationState extends AbstractState implements State {
            @JsonProperty("assertionConsumerServiceUri") final URI assertionConsumerServiceUri,
            @JsonProperty("sessionId") final SessionId sessionId,
            @JsonProperty("transactionSupportsEidas") final boolean transactionSupportsEidas,
-           @JsonProperty("relayState") final Optional<String> relayState) {
+           @JsonProperty("relayState") final String relayState) {
 
         super(
                 requestId,
@@ -37,7 +37,7 @@ public class PausedRegistrationState extends AbstractState implements State {
                 null
         );
 
-        this.relayState = relayState;
+        this.relayState = Optional.fromNullable(relayState);
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/UserAccountCreationFailedState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/UserAccountCreationFailedState.java
@@ -2,7 +2,6 @@ package uk.gov.ida.hub.policy.domain.state;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.SessionId;
 
@@ -18,7 +17,7 @@ public class UserAccountCreationFailedState extends AbstractUserAccountCreationF
             @JsonProperty("authnRequestIssuerEntityId") final String authnRequestIssuerEntityId,
             @JsonProperty("sessionExpiryTimestamp") final DateTime sessionExpiryTimestamp,
             @JsonProperty("assertionConsumerServiceUri") final URI assertionConsumerServiceUri,
-            @JsonProperty("relayState") final Optional<String> relayState,
+            @JsonProperty("relayState") final String relayState,
             @JsonProperty("sessionId") final SessionId sessionId,
             @JsonProperty("transactionSupportsEidas") final boolean transactionSupportsEidas) {
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/Cycle3DataInputCancelledStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/Cycle3DataInputCancelledStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
@@ -13,7 +12,6 @@ import java.util.UUID;
 public class Cycle3DataInputCancelledStateBuilder {
 
     private SessionId sessionId = SessionIdBuilder.aSessionId().build();
-    private Optional<String> relayState = Optional.absent();
     private String requestIssuerId = "requestIssuerId";
     private URI assertionConsumerServiceUri = URI.create("/default-service-index");
     private DateTime sessionExpiryTimestamp = DateTime.now(DateTimeZone.UTC).plusMinutes(10);
@@ -25,7 +23,7 @@ public class Cycle3DataInputCancelledStateBuilder {
     }
 
     public Cycle3DataInputCancelledState build() {
-        return new Cycle3DataInputCancelledState(requestId, sessionExpiryTimestamp, relayState, requestIssuerId, assertionConsumerServiceUri, sessionId, transactionSupportsEidas);
+        return new Cycle3DataInputCancelledState(requestId, sessionExpiryTimestamp, null, requestIssuerId, assertionConsumerServiceUri, sessionId, transactionSupportsEidas);
     }
 
     public Cycle3DataInputCancelledStateBuilder withSessionId(SessionId sessionId) {

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasAwaitingCycle3DataStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasAwaitingCycle3DataStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
@@ -33,7 +32,7 @@ public class EidasAwaitingCycle3DataStateBuilder {
             true,
             "identityProviderEntityId",
             "matchingServiceAdapterEntityId",
-            Optional.of("relayState"),
+            "relayState",
             new PersistentId("nameId"),
             LevelOfAssurance.LEVEL_2,
             "encryptedIdentityAssertion",

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasUserAccountCreationFailedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasUserAccountCreationFailedStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
@@ -28,7 +27,7 @@ public class EidasUserAccountCreationFailedStateBuilder {
                 requestIssuerId,
                 sessionExpiryTimestamp,
                 assertionConsumerServiceUri,
-                Optional.absent(),
+                null,
                 sessionId,
                 forceAuthentication
         );

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/MatchingServiceRequestErrorStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/MatchingServiceRequestErrorStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
@@ -30,7 +29,7 @@ public class MatchingServiceRequestErrorStateBuilder {
                 sessionExpiryTimestamp,
                 assertionConsumerServiceUri,
                 identityProviderEntityId,
-                Optional.<String>absent(),
+                null,
                 sessionId,
                 transactionSupportsEidas);
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/NoMatchStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/NoMatchStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.domain.SessionId;
@@ -10,7 +9,7 @@ import java.net.URI;
 
 public class NoMatchStateBuilder {
     private String identityProviderEntityId = "idp entity id";
-    private Optional<String> relayState = Optional.absent();
+    private String relayState = null;
 
     public static NoMatchStateBuilder aNoMatchState() {
         return new NoMatchStateBuilder();
@@ -33,7 +32,7 @@ public class NoMatchStateBuilder {
         return this;
     }
 
-    public NoMatchStateBuilder withRelayState(final Optional<String> relayState) {
+    public NoMatchStateBuilder withRelayState(final String relayState) {
         this.relayState = relayState;
         return this;
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/NoMatchStateBuilderTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/NoMatchStateBuilderTest.java
@@ -57,7 +57,7 @@ public class NoMatchStateBuilderTest {
 
     @Test
     public void withRelayState() throws Exception {
-        NoMatchState noMatchState = NoMatchStateBuilder.aNoMatchState().withRelayState(Optional.of(RELAY_STATE)).build();
+        NoMatchState noMatchState = NoMatchStateBuilder.aNoMatchState().withRelayState(RELAY_STATE).build();
 
         assertThat(noMatchState.getRelayState()).isEqualTo(Optional.of(RELAY_STATE));
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/PausedRegistrationStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/PausedRegistrationStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.domain.SessionId;
@@ -30,7 +29,7 @@ public class PausedRegistrationStateBuilder {
             assertionConsumerServiceUri,
             sessionId,
             transactionSupportsEidas,
-            Optional.of(relayState)
+            relayState
         );
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/UserAccountCreationFailedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/UserAccountCreationFailedStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
@@ -29,7 +28,7 @@ public class UserAccountCreationFailedStateBuilder {
                 requestIssuerId,
                 sessionExpiryTimestamp,
                 assertionConsumerServiceUri,
-                Optional.fromNullable(relayState),
+                relayState,
                 sessionId,
                 transactionSupportsEidas
         );

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateControllerTest.java
@@ -145,7 +145,7 @@ public class EidasAwaitingCycle3DataStateControllerTest {
         final Cycle3DataInputCancelledState expectedState = new Cycle3DataInputCancelledState(
             state.getRequestId(),
             state.getSessionExpiryTimestamp(),
-            state.getRelayState(),
+            state.getRelayState().orNull(),
             state.getRequestIssuerEntityId(),
             state.getAssertionConsumerServiceUri(),
             new SessionId(state.getSessionId().getSessionId()),

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -290,7 +290,7 @@ public class EidasCountrySelectedStateControllerTest {
                 state.getAssertionConsumerServiceUri(),
                 new SessionId(state.getSessionId().getSessionId()),
                 state.getTransactionSupportsEidas(),
-                state.getRelayState(),
+                state.getRelayState().orNull(),
                 singleton(eidasAttributeQueryRequestDto.getEncryptedIdentityAssertion())
         );
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateControllerTest.java
@@ -145,7 +145,7 @@ public class EidasCycle0And1MatchRequestSentStateControllerTest {
             state.getTransactionSupportsEidas(),
             state.getIdentityProviderEntityId(),
             state.getMatchingServiceAdapterEntityId(),
-            state.getRelayState(),
+            state.getRelayState().orNull(),
             state.getPersistentId(),
             state.getIdpLevelOfAssurance(),
             state.getEncryptedIdentityAssertion(),

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateControllerTest.java
@@ -210,7 +210,7 @@ public class EidasCycle0And1MatchRequestSentStateControllerTest {
             state.getRequestIssuerEntityId(),
             state.getSessionExpiryTimestamp(),
             state.getAssertionConsumerServiceUri(),
-            state.getRelayState(),
+            state.getRelayState().orNull(),
             state.getSessionId(),
             state.getTransactionSupportsEidas()
         );


### PR DESCRIPTION
This pull requests fixes the following states to resolve serialization issues.

* AbstractAwaitingCycle3DataState
* Cycle3DataInputCancelledState
* AbstractUserAccountCreationFailedState
* MatchingServiceRequestErrorState
* NoMatchState
* NonMatchingJourneySuccessState

The field type for relayState is Optional but it was being serialized to `null` when absent. This meant that when we tried to deserialize it, the Optional was set to null (since it is a reference type). This commit fixes it so that the constructor takes just a String and wraps it in Optional if it is null.

Author: @adityapahuja
