### PR TITLE
AUTO-143: Run tests on master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,12 @@ subprojects {
         redis('org.redisson:redisson:3.10.1')
         redis_test('com.github.kstyrc:embedded-redis:0.6')
     }
+
+}
+
+task downloadDependencies(type: Exec) {
+    configurations.testRuntime.files
+    commandLine 'echo', 'Downloaded all dependencies'
 }
 
 task(outputDependencies) doLast {


### PR DESCRIPTION
- Docker is now responsible for running the whole build on Concourse in
  the new pipeline
- Add test and intTest as tasks to run when building images
- Refactored the docker build quite a bit to allow us to eventually use
  a base image on Concourse to reduce build times
- Added a task to gradle to allow us to greedily fetch all the
  dependencies to take advantage of docker layer caching