### PR TITLE
AUTO: Fix entrypoint/cmd in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,5 @@ COPY --from=build-app /verify-hub/hub/$hub_app/build/install/$hub_app .
 # ARG is not available at runtime so set an env var with
 # name of app/app-config to run
 ENV HUB_APP $hub_app
-CMD bin/$HUB_APP server $HUB_APP.yml
+ENTRYPOINT ["sh", "-c", "bin/$HUB_APP"]
+CMD ["server", "$HUB_APP.yml"]


### PR DESCRIPTION
- Best practice is to use the exec syntax and define entrypoint as the
  main program and CMD as the command you expect to use
- This will come in handy when we want to do things such as
  fed-config-check with the image