### PR TITLE
dGJgfILT: Change response status on duplicate request exception to 400

### DIFF
--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
@@ -14,6 +14,7 @@ import uk.gov.ida.bundles.ServiceStatusBundle;
 import uk.gov.ida.eventemitter.EventEmitterModule;
 import uk.gov.ida.hub.samlproxy.exceptions.NoKeyConfiguredForEntityExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyApplicationExceptionMapper;
+import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyDuplicateRequestExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxySamlTransformationErrorExceptionMapper;
 import uk.gov.ida.hub.samlproxy.filters.SessionIdQueryParamLoggingFilter;
@@ -92,6 +93,7 @@ public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
         classes.add(NoKeyConfiguredForEntityExceptionMapper.class);
         classes.add(SamlProxySamlTransformationErrorExceptionMapper.class);
         classes.add(SamlProxyApplicationExceptionMapper.class);
+        classes.add(SamlProxyDuplicateRequestExceptionMapper.class);
         classes.add(SamlProxyExceptionMapper.class);
         return classes;
     }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -35,6 +35,7 @@ import uk.gov.ida.hub.samlproxy.controllogic.SamlMessageSenderHandler;
 import uk.gov.ida.hub.samlproxy.exceptions.ExceptionAuditor;
 import uk.gov.ida.hub.samlproxy.exceptions.NoKeyConfiguredForEntityExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyApplicationExceptionMapper;
+import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyDuplicateRequestExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxyExceptionMapper;
 import uk.gov.ida.hub.samlproxy.exceptions.SamlProxySamlTransformationErrorExceptionMapper;
 import uk.gov.ida.hub.samlproxy.factories.EidasValidatorFactory;
@@ -128,6 +129,7 @@ public class SamlProxyModule extends AbstractModule {
         bind(ProtectiveMonitoringLogger.class);
         bind(SessionProxy.class);
         bind(new TypeLiteral<LevelLoggerFactory<SamlProxySamlTransformationErrorExceptionMapper>>(){}).toInstance(new LevelLoggerFactory<>());
+        bind(new TypeLiteral<LevelLoggerFactory<SamlProxyDuplicateRequestExceptionMapper>>(){}).toInstance(new LevelLoggerFactory<>());
         bind(new TypeLiteral<LevelLoggerFactory<NoKeyConfiguredForEntityExceptionMapper>>(){}).toInstance(new LevelLoggerFactory<>());
         bind(new TypeLiteral<LevelLoggerFactory<SamlProxyApplicationExceptionMapper>>(){}).toInstance(new LevelLoggerFactory<>());
         bind(new TypeLiteral<LevelLoggerFactory<SamlProxyExceptionMapper>>(){}).toInstance(new LevelLoggerFactory<>());

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/ExceptionAuditor.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/ExceptionAuditor.java
@@ -28,11 +28,11 @@ public class ExceptionAuditor {
                     downstream_uri,
                     exception.getUri().or(URI.create("uri-not-present")).toASCIIString());
 
-            if (sessionId.isPresent()) {
-                eventSinkMessageSender.audit(exception, exception.getErrorId(), sessionId.get(), eventDetails);
-            } else {
-                eventSinkMessageSender.audit(exception, exception.getErrorId(), NO_SESSION_CONTEXT_IN_ERROR, eventDetails);
-            }
+            eventSinkMessageSender.audit(
+                    exception,
+                    exception.getErrorId(),
+                    sessionId.orElse(SessionId.NO_SESSION_CONTEXT_IN_ERROR),
+                    eventDetails);
 
             isAudited = true;
         }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapper.java
@@ -12,7 +12,6 @@ import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
-import java.util.Optional;
 import java.util.UUID;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static uk.gov.ida.common.ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID;
@@ -36,14 +35,9 @@ public class SamlProxyDuplicateRequestExceptionMapper extends AbstractContextExc
     protected Response handleException(SamlDuplicateRequestIdException exception) {
         UUID errorId = UUID.randomUUID();
 
-        Optional<SessionId> sessionId = getSessionId();
-        if (sessionId.isPresent()) {
-            eventSinkMessageSender.audit(exception, errorId, sessionId.get());
-        } else {
-            eventSinkMessageSender.audit(exception, errorId, SessionId.NO_SESSION_CONTEXT_IN_ERROR);
-        }
-
+        eventSinkMessageSender.audit(exception, errorId, getSessionId().orElse(SessionId.NO_SESSION_CONTEXT_IN_ERROR));
         levelLogger.log(ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID.getLevel(), exception, errorId);
+
         return Response.status(BAD_REQUEST)
                 .entity(ErrorStatusDto.createAuditedErrorStatus(errorId, INVALID_SAML_DUPLICATE_REQUEST_ID))
                 .build();

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapper.java
@@ -3,6 +3,8 @@ package uk.gov.ida.hub.samlproxy.exceptions;
 import com.google.inject.Provider;
 import uk.gov.ida.common.ErrorStatusDto;
 import uk.gov.ida.common.ExceptionType;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.eventsink.EventSinkMessageSender;
 import uk.gov.ida.saml.hub.exception.SamlDuplicateRequestIdException;
 import uk.gov.ida.shared.utils.logging.LevelLogger;
 import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
@@ -10,26 +12,38 @@ import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
+import java.util.Optional;
 import java.util.UUID;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static uk.gov.ida.common.ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID;
 
 public class SamlProxyDuplicateRequestExceptionMapper extends AbstractContextExceptionMapper<SamlDuplicateRequestIdException> {
 
+    private EventSinkMessageSender eventSinkMessageSender;
     private final LevelLogger levelLogger;
 
     @Inject
     public SamlProxyDuplicateRequestExceptionMapper(
             Provider<HttpServletRequest> contextProvider,
+            EventSinkMessageSender eventSinkMessageSender,
             LevelLoggerFactory<SamlProxyDuplicateRequestExceptionMapper> levelLoggerFactory) {
         super(contextProvider);
+        this.eventSinkMessageSender = eventSinkMessageSender;
         this.levelLogger = levelLoggerFactory.createLevelLogger(SamlProxyDuplicateRequestExceptionMapper.class);
     }
 
     @Override
     protected Response handleException(SamlDuplicateRequestIdException exception) {
         UUID errorId = UUID.randomUUID();
-        levelLogger.log(ExceptionType.UNKNOWN.getLevel(), exception, errorId);
+
+        Optional<SessionId> sessionId = getSessionId();
+        if (sessionId.isPresent()) {
+            eventSinkMessageSender.audit(exception, errorId, sessionId.get());
+        } else {
+            eventSinkMessageSender.audit(exception, errorId, SessionId.NO_SESSION_CONTEXT_IN_ERROR);
+        }
+
+        levelLogger.log(ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID.getLevel(), exception, errorId);
         return Response.status(BAD_REQUEST)
                 .entity(ErrorStatusDto.createAuditedErrorStatus(errorId, INVALID_SAML_DUPLICATE_REQUEST_ID))
                 .build();

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapper.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.hub.samlproxy.exceptions;
+
+import com.google.inject.Provider;
+import uk.gov.ida.common.ErrorStatusDto;
+import uk.gov.ida.common.ExceptionType;
+import uk.gov.ida.saml.hub.exception.SamlDuplicateRequestIdException;
+import uk.gov.ida.shared.utils.logging.LevelLogger;
+import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static uk.gov.ida.common.ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID;
+
+public class SamlProxyDuplicateRequestExceptionMapper extends AbstractContextExceptionMapper<SamlDuplicateRequestIdException> {
+
+    private final LevelLogger levelLogger;
+
+    @Inject
+    public SamlProxyDuplicateRequestExceptionMapper(
+            Provider<HttpServletRequest> contextProvider,
+            LevelLoggerFactory<SamlProxyDuplicateRequestExceptionMapper> levelLoggerFactory) {
+        super(contextProvider);
+        this.levelLogger = levelLoggerFactory.createLevelLogger(SamlProxyDuplicateRequestExceptionMapper.class);
+    }
+
+    @Override
+    protected Response handleException(SamlDuplicateRequestIdException exception) {
+        UUID errorId = UUID.randomUUID();
+        levelLogger.log(ExceptionType.UNKNOWN.getLevel(), exception, errorId);
+        return Response.status(BAD_REQUEST)
+                .entity(ErrorStatusDto.createAuditedErrorStatus(errorId, INVALID_SAML_DUPLICATE_REQUEST_ID))
+                .build();
+    }
+}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapper.java
@@ -50,9 +50,7 @@ public class SamlProxySamlTransformationErrorExceptionMapper extends AbstractCon
     }
 
     private ExceptionType getExceptionTypeForSamlException(SamlTransformationErrorException exception) {
-        if (exception instanceof SamlDuplicateRequestIdException) {
-            return ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID;
-        } else if (exception instanceof SamlRequestTooOldException) {
+        if (exception instanceof SamlRequestTooOldException) {
             return ExceptionType.INVALID_SAML_REQUEST_TOO_OLD;
         } else {
             return ExceptionType.INVALID_SAML;

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapper.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlproxy.exceptions;
 
-import java.util.Optional;
 import javax.inject.Inject;
 import com.google.inject.Provider;
 import uk.gov.ida.common.ErrorStatusDto;
@@ -8,7 +7,6 @@ import uk.gov.ida.common.ExceptionType;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.eventsink.EventSinkMessageSender;
-import uk.gov.ida.saml.hub.exception.SamlDuplicateRequestIdException;
 import uk.gov.ida.saml.hub.exception.SamlRequestTooOldException;
 import uk.gov.ida.shared.utils.logging.LevelLogger;
 import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
@@ -35,13 +33,8 @@ public class SamlProxySamlTransformationErrorExceptionMapper extends AbstractCon
     @Override
     protected Response handleException(SamlTransformationErrorException exception) {
         UUID errorId = UUID.randomUUID();
-        Optional<SessionId> sessionId = getSessionId();
-        if (sessionId.isPresent()) {
-            eventSinkMessageSender.audit(exception, errorId, sessionId.get());
-        } else {
-            eventSinkMessageSender.audit(exception, errorId, SessionId.NO_SESSION_CONTEXT_IN_ERROR);
-        }
 
+        eventSinkMessageSender.audit(exception, errorId, getSessionId().orElse(SessionId.NO_SESSION_CONTEXT_IN_ERROR));
         levelLogger.log(exception.getLogLevel(), exception, errorId);
 
         ErrorStatusDto auditedErrorStatus = ErrorStatusDto.createAuditedErrorStatus(errorId, getExceptionTypeForSamlException(exception));

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapperTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxyDuplicateRequestExceptionMapperTest.java
@@ -1,0 +1,57 @@
+package uk.gov.ida.hub.samlproxy.exceptions;
+
+import com.google.inject.Provider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.event.Level;
+import uk.gov.ida.common.ErrorStatusDto;
+import uk.gov.ida.common.ExceptionType;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.eventsink.EventSinkMessageSender;
+import uk.gov.ida.hub.samlproxy.Urls;
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.hub.exception.SamlDuplicateRequestIdException;
+import uk.gov.ida.saml.hub.exception.SamlRequestTooOldException;
+import uk.gov.ida.shared.utils.logging.LevelLogger;
+import uk.gov.ida.shared.utils.logging.LevelLoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SamlProxyDuplicateRequestExceptionMapperTest {
+    @Mock
+    private LevelLogger levelLogger;
+    @Mock
+    private Provider<HttpServletRequest> contextProvider;
+    @Mock
+    private LevelLoggerFactory<SamlProxyDuplicateRequestExceptionMapper> levelLoggerFactory;
+
+    private SamlProxyDuplicateRequestExceptionMapper exceptionMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        when(levelLoggerFactory.createLevelLogger(SamlProxyDuplicateRequestExceptionMapper.class)).thenReturn(levelLogger);
+        exceptionMapper = new SamlProxyDuplicateRequestExceptionMapper(contextProvider, levelLoggerFactory);
+    }
+
+    @Test
+    public void shouldCreateAuditedErrorResponseForDuplicateRequestIdError() throws Exception {
+        Response response = exceptionMapper.handleException(new SamlDuplicateRequestIdException("error", new RuntimeException(), Level.DEBUG));
+
+        ErrorStatusDto responseEntity = (ErrorStatusDto) response.getEntity();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(responseEntity.isAudited()).isTrue();
+        assertThat(responseEntity.getExceptionType()).isEqualTo(ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID);
+    }
+}

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapperTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapperTest.java
@@ -89,16 +89,6 @@ public class SamlProxySamlTransformationErrorExceptionMapperTest {
     }
 
     @Test
-    public void shouldCreateAuditedErrorResponseForDuplicateRequestIdError() throws Exception {
-        Response response = exceptionMapper.handleException(new SamlDuplicateRequestIdException("error", new RuntimeException(), Level.DEBUG));
-
-        ErrorStatusDto responseEntity = (ErrorStatusDto) response.getEntity();
-        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
-        assertThat(responseEntity.isAudited()).isTrue();
-        assertThat(responseEntity.getExceptionType()).isEqualTo(ExceptionType.INVALID_SAML_DUPLICATE_REQUEST_ID);
-    }
-
-    @Test
     public void shouldLogExceptionAtCorrectLevel() throws Exception {
         Level logLevel = Level.DEBUG;
         TestSamlTransformationErrorException exception = new TestSamlTransformationErrorException("error", new RuntimeException(), logLevel);


### PR DESCRIPTION
Stop treating it as an 'internal server error'. Makes no difference to the front-end, which still displays the same 'something has gone wrong' error to the user.

Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>