### PR TITLE
BAU Upgrade dropwizard to 1.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,14 +25,14 @@ apply plugin: 'com.github.ben-manes.versions'
 
 ext {
     opensaml_version = '3.4.0'
-    dropwizard_version = '1.3.5'
+    dropwizard_version = '1.3.9'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
 def dependencyVersions = [
-            ida_utils:'350',
+            ida_utils:'351',
             dropwizard:"$dropwizard_version",
-            dropwizard_infinispan:"$dropwizard_version-47",
+            dropwizard_infinispan:"$dropwizard_version-48",
             pact:'3.5.6',
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
@@ -119,6 +119,11 @@ subprojects {
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:rest-utils:2.0.0-$dependencyVersions.ida_utils"
+
+        // To resolve an issue with httpclient:4.5.7 introduced via dropwizard:1.3.9 with dropping consecutive slashes in a URI.
+        ida_utils("org.apache.httpcomponents:httpclient:4.5.6") {
+            force = true
+        }
 
         ida_test_utils "uk.gov.ida:common-test-utils:$dependencyVersions.ida_test_utils"
 


### PR DESCRIPTION
1.3.5 was susceptible to a range of CVE's which are fixed by [1.3.9](https://github.com/dropwizard/dropwizard/blob/master/docs/source/about/release-notes.rst#v139-feb-24-2019).

One of the dependencies that was bumped by this patch was Apache
HttpClient to v4.5.7 which 4.5.7 introduced an issue where double forward
slashes in URIs would be normalised to just one.

This caused a regression in SAML engine as we use entityIds, which are a
URL, as part of the URL when fetching their encryption keys from config.

This issue is discussed in detail [here](https://issues.apache.org/jira/browse/HTTPCLIENT-1968)
and should be fixed in future (potentially late March or early April).