### PR TITLE
enable prometheus by default

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -54,7 +54,7 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
 
     @Valid
     @JsonProperty
-    protected Boolean prometheusEnabled = false;
+    protected Boolean prometheusEnabled = true;
 
     @Valid
     @JsonProperty

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/PolicyConfiguration.java
@@ -93,7 +93,7 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
 
     @Valid
     @JsonProperty
-    protected Boolean prometheusEnabled = false;
+    protected Boolean prometheusEnabled = true;
 
     protected PolicyConfiguration() {}
 

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -112,7 +112,7 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
 
     @Valid
     @JsonProperty
-    protected Boolean prometheusEnabled = false;
+    protected Boolean prometheusEnabled = true;
 
     public SamlConfiguration getSamlConfiguration() {
         return saml;

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -96,7 +96,7 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
 
     @Valid
     @JsonProperty
-    protected Boolean prometheusEnabled = false;
+    protected Boolean prometheusEnabled = true;
 
     public SamlConfiguration getSamlConfiguration() {
         return saml;

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -97,7 +97,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
 
     @Valid
     @JsonProperty
-    protected Boolean prometheusEnabled = false;
+    protected Boolean prometheusEnabled = true;
 
     @Valid
     @JsonProperty


### PR DESCRIPTION
We turn prometheus on in all environments now.  I'd like to remove
this configuration item, but first we have to set the default
behaviour to be enabled so we can remove it from all the config files.