### PR TITLE
saml-proxy SamlTransformationErrorExceptions back to frontend with 400 status code

### DIFF
--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/CountryMetadataConsumerTest.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/CountryMetadataConsumerTest.java
@@ -107,7 +107,7 @@ public class CountryMetadataConsumerTest {
         Response responseFromSamlProxy = postSAML(new SamlRequestDto(samlResponseString, sessionId.getSessionId(), "127.0.0.1"));
 
         // Then
-        assertThat(responseFromSamlProxy.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertThat(responseFromSamlProxy.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
     }
 
     private javax.ws.rs.core.Response postSAML(SamlRequestDto requestDto) {

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/DenialOfServiceAttacksIntegrationTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/DenialOfServiceAttacksIntegrationTests.java
@@ -75,7 +75,7 @@ public class DenialOfServiceAttacksIntegrationTests {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(Entity.json(new SamlRequestDto(samlAuthnRequest, relayState, "12.23.34.45")));
 
-        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
     }
 
 }

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/SamlMessageReceiverApiResourceTest.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/SamlMessageReceiverApiResourceTest.java
@@ -181,7 +181,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST ,clientResponse, ExceptionType.INVALID_SAML);
     }
 
     @Test
@@ -190,7 +190,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST, clientResponse, ExceptionType.INVALID_SAML);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST, clientResponse, ExceptionType.INVALID_SAML);
     }
 
     @Test
@@ -214,7 +214,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_RESOURCE);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST, clientResponse, ExceptionType.INVALID_SAML);
     }
 
     @Test
@@ -230,7 +230,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST, clientResponse, ExceptionType.INVALID_SAML);
     }
 
     @Test
@@ -239,7 +239,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST, clientResponse, ExceptionType.INVALID_SAML);
     }
 
     @Test
@@ -249,7 +249,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST, clientResponse, ExceptionType.INVALID_SAML);
     }
 
     @Test
@@ -262,7 +262,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.NETWORK_ERROR);
+        assertError(Response.Status.INTERNAL_SERVER_ERROR, clientResponse, ExceptionType.NETWORK_ERROR);
     }
 
     @Test
@@ -287,7 +287,7 @@ public class SamlMessageReceiverApiResourceTest {
 
         Response clientResponse = postSAML(authnRequestWrapper, Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
 
-        assertError(clientResponse, ExceptionType.INVALID_SAML);
+        assertError(Response.Status.BAD_REQUEST, clientResponse, ExceptionType.INVALID_SAML);
     }
 
     private Response postSAML(SamlRequestDto requestDTO, String path) {
@@ -296,8 +296,8 @@ public class SamlMessageReceiverApiResourceTest {
                 .APPLICATION_JSON_TYPE));
     }
 
-    private void assertError(final Response response, final ExceptionType exceptionType) {
-        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    private void assertError(Response.StatusType statusType, final Response response, final ExceptionType exceptionType) {
+        assertThat(response.getStatus()).isEqualTo(statusType.getStatusCode());
         ErrorStatusDto entity = response.readEntity(ErrorStatusDto.class);
         assertThat(entity.getErrorId()).isNotNull();
         assertThat(entity.getExceptionType()).isEqualTo(exceptionType);

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/SamlMessageSenderApiResourceTest.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/SamlMessageSenderApiResourceTest.java
@@ -216,7 +216,7 @@ public class SamlMessageSenderApiResourceTest {
         policyStubRule.anAuthnResponseFromHubToRp(sessionId, invalidAuthnResponseFromHubContainerDto);
         javax.ws.rs.core.Response response = getResponseFromSamlProxy(Urls.SamlProxyUrls.SEND_RESPONSE_FROM_HUB_API_RESOURCE, sessionId);
 
-        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
     }
 
     @Test
@@ -274,7 +274,7 @@ public class SamlMessageSenderApiResourceTest {
 
         javax.ws.rs.core.Response response = getResponseFromSamlProxy(Urls.SamlProxyUrls.SEND_ERROR_RESPONSE_FROM_HUB_API_RESOURCE, sessionId);
 
-        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
     }
 
     private Response getResponseFromSamlProxy(String url, SessionId sessionId) {

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapper.java
@@ -39,7 +39,7 @@ public class SamlProxySamlTransformationErrorExceptionMapper extends AbstractCon
 
         ErrorStatusDto auditedErrorStatus = ErrorStatusDto.createAuditedErrorStatus(errorId, getExceptionTypeForSamlException(exception));
 
-        return Response.serverError().entity(auditedErrorStatus).build();
+        return Response.status(Response.Status.BAD_REQUEST).entity(auditedErrorStatus).build();
     }
 
     private ExceptionType getExceptionTypeForSamlException(SamlTransformationErrorException exception) {

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapperTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/SamlProxySamlTransformationErrorExceptionMapperTest.java
@@ -73,7 +73,7 @@ public class SamlProxySamlTransformationErrorExceptionMapperTest {
         Response response = exceptionMapper.handleException(new TestSamlTransformationErrorException("error", new RuntimeException(), Level.DEBUG));
 
         ErrorStatusDto responseEntity = (ErrorStatusDto) response.getEntity();
-        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(responseEntity.isAudited()).isTrue();
         assertThat(responseEntity.getExceptionType()).isEqualTo(ExceptionType.INVALID_SAML);
     }
@@ -83,7 +83,7 @@ public class SamlProxySamlTransformationErrorExceptionMapperTest {
         Response response = exceptionMapper.handleException(new SamlRequestTooOldException("error", new RuntimeException(), Level.DEBUG));
 
         ErrorStatusDto responseEntity = (ErrorStatusDto) response.getEntity();
-        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(responseEntity.isAudited()).isTrue();
         assertThat(responseEntity.getExceptionType()).isEqualTo(ExceptionType.INVALID_SAML_REQUEST_TOO_OLD);
     }


### PR DESCRIPTION
Send back a 400 status code from `saml-proxy` when a `SamlTransformationErrorException` thrown from this service, in preference to a 500 status code.

`frontend` does not currently discriminate between 4xx's and 5xx's, see `lib/api/hub_response_handler.rb:8`

Use of Jersey bean validation on the request DTO was reviewed but not used, as validation is interleaved with base64 decoding and unmarshalling on the /SAML2/SSO/API/RECEIVER resource

A second PR to follow with acceptance tests for invalid payloads.