### PR TITLE
Add trust store metrics for all the trust stores

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
@@ -39,9 +39,12 @@ import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
 import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanBundle;
 import uk.gov.ida.shared.dropwizard.infinispan.util.InfinispanCacheManager;
+import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
+import uk.gov.ida.truststore.KeyStoreLoader;
 
 import javax.inject.Provider;
 import javax.servlet.DispatcherType;
+import java.security.KeyStore;
 import java.util.EnumSet;
 
 import static com.hubspot.dropwizard.guicier.GuiceBundle.defaultBuilder;
@@ -144,9 +147,12 @@ public class SamlEngineApplication extends Application<SamlEngineConfiguration> 
 
         // calling .get() here is safe because the Optional is never empty
         MetadataResolverConfiguration metadataConfiguration = configuration.getMetadataConfiguration().get();
+        ClientTrustStoreConfiguration rpTrustStoreConfiguration = configuration.getRpTrustStoreConfiguration();
+        KeyStore rpTrustStore = new KeyStoreLoader().load(rpTrustStoreConfiguration.getPath(), rpTrustStoreConfiguration.getPassword());
         TrustStoreMetrics trustStoreMetrics = new TrustStoreMetrics();
         metadataConfiguration.getHubTrustStore().ifPresent(hubTrustStore -> trustStoreMetrics.registerTrustStore("hub", hubTrustStore));
         metadataConfiguration.getIdpTrustStore().ifPresent(idpTrustStore -> trustStoreMetrics.registerTrustStore("idp", idpTrustStore));
+        trustStoreMetrics.registerTrustStore("rp", rpTrustStore);
 
         environment.servlets().addFilter("Logging SessionId registration Filter", SessionIdQueryParamLoggingFilter.class).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
     }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyApplication.java
@@ -24,9 +24,12 @@ import uk.gov.ida.hub.samlproxy.resources.SamlMessageReceiverApi;
 import uk.gov.ida.hub.samlproxy.resources.SamlMessageSenderApi;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
+import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
+import uk.gov.ida.truststore.KeyStoreLoader;
 
 import javax.servlet.DispatcherType;
 import javax.ws.rs.ext.ExceptionMapper;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -80,9 +83,12 @@ public class SamlProxyApplication extends Application<SamlProxyConfiguration> {
         }
 
         MetadataResolverConfiguration metadataConfiguration = configuration.getMetadataConfiguration();
+        ClientTrustStoreConfiguration rpTrustStoreConfiguration = configuration.getRpTrustStoreConfiguration();
+        KeyStore rpTrustStore = new KeyStoreLoader().load(rpTrustStoreConfiguration.getPath(), rpTrustStoreConfiguration.getPassword());
         TrustStoreMetrics trustStoreMetrics = new TrustStoreMetrics();
         metadataConfiguration.getHubTrustStore().ifPresent(hubTrustStore -> trustStoreMetrics.registerTrustStore("hub", hubTrustStore));
         metadataConfiguration.getIdpTrustStore().ifPresent(idpTrustStore -> trustStoreMetrics.registerTrustStore("idp", idpTrustStore));
+        trustStoreMetrics.registerTrustStore("rp", rpTrustStore);
 
         environment.servlets().addFilter("Logging SessionId registration Filter", SessionIdQueryParamLoggingFilter.class).addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
     }


### PR DESCRIPTION
PR #240 introduced metrics for hub and idp trust stores but missed out
these other ones.

saml-soap-proxy, saml-proxy, saml-engine and config all have "rp"
trust stores.  In addition, config has a "client" trust store - I'm
not sure if this is the best name for it but I don't know what else to
call it.