### PR TITLE
Put cfg files where verify-infrastructure expects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,10 @@ ARG hub_app
 
 WORKDIR /verify-hub
 
-COPY configuration/$hub_app.yml /tmp/config.yml
+COPY configuration/$hub_app.yml /tmp/$hub_app.yml
 COPY --from=build-app /verify-hub/hub/$hub_app/build/install/$hub_app .
 
 # ARG is not available at runtime so set an env var with
 # name of app/app-config to run
 ENV HUB_APP $hub_app
-CMD bin/$HUB_APP server /tmp/config.yml
+CMD bin/$HUB_APP server /tmp/$hub_app.yml


### PR DESCRIPTION
The config files in alphagov/verify-infrastructure ([example](https://github.com/alphagov/verify-infrastructure/blob/master/terraform/modules/hub/files/tasks/hub-policy.json)) expect config files with the name of the application.

This PR introduces that behaviour.

Also `bin/policy server config.yml` confuses me in the context of `bin/config server config.yml`