### PR TITLE
Remove prometheusEnabled config item

### DIFF
--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -27,7 +27,6 @@ clientTrustStoreConfiguration:
 rpTrustStoreConfiguration:
   path: /tmp/truststores/${DEPLOYMENT}/rp_ca_certs.ts
   password: puppet
-prometheusEnabled: true
 certificateExpiryDateCheckServiceConfiguration:
   enable: true
 certificateOcspRevocationStatusCheckServiceConfiguration:

--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -63,4 +63,3 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
-prometheusEnabled: true

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -113,4 +113,3 @@ country:
         protocol: TLSv1.2
         verifyHostname: false
         trustSelfSignedCertificates: true
-prometheusEnabled: true

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -102,4 +102,3 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
-prometheusEnabled: true

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -122,6 +122,5 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
-prometheusEnabled: true
 matchingServiceHealthCheckServiceConfiguration:
   enable: true

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
@@ -78,7 +78,6 @@ public class PrometheusMetricsIntegrationTest {
 
     @ClassRule
     public static ConfigAppRule configAppRule = new ConfigAppRule(
-        config("prometheusEnabled", "true"),
         config("certificateExpiryDateCheckServiceConfiguration.enable", "true"),
         config("certificateExpiryDateCheckServiceConfiguration.initialDelay", "1s"),
         config("certificateExpiryDateCheckServiceConfiguration.delay", "2s"),

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -54,10 +54,6 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
 
     @Valid
     @JsonProperty
-    protected Boolean prometheusEnabled = true;
-
-    @Valid
-    @JsonProperty
     private PrometheusClientServiceConfiguration certificateExpiryDateCheckServiceConfiguration = new PrometheusClientServiceConfiguration();
 
     @Valid
@@ -103,7 +99,7 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
 
     @Override
     public boolean isPrometheusEnabled() {
-        return prometheusEnabled;
+        return true;
     }
 
     public PrometheusClientServiceConfiguration getCertificateExpiryDateCheckServiceConfiguration() {

--- a/hub/config/src/test/resources/config.yml
+++ b/hub/config/src/test/resources/config.yml
@@ -43,5 +43,3 @@ clientTrustStoreConfiguration:
 rpTrustStoreConfiguration:
   path: ${RP_TRUSTSTORE_PATH}
   password: ${RP_TRUSTSTORE_PASSWORD}
-
-prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/PolicyConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/PolicyConfiguration.java
@@ -91,10 +91,6 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
 
-    @Valid
-    @JsonProperty
-    protected Boolean prometheusEnabled = true;
-
     protected PolicyConfiguration() {}
 
     public URI getSamlSoapProxyUri() { return samlSoapProxyUri;  }
@@ -164,7 +160,7 @@ public class PolicyConfiguration extends Configuration implements RestfulClientC
 
     @Override
     public boolean isPrometheusEnabled() {
-        return prometheusEnabled;
+        return true;
     }
 
     public SessionStoreConfiguration getSessionStoreConfiguration() {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -110,10 +110,6 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
-    @Valid
-    @JsonProperty
-    protected Boolean prometheusEnabled = true;
-
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -191,6 +187,6 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
 
     @Override
     public boolean isPrometheusEnabled() {
-        return prometheusEnabled;
+        return true;
     }
 }

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -146,5 +146,3 @@ country:
         protocol: TLSv1.2
         verifyHostname: false
         trustSelfSignedCertificates: true
-
-prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -94,10 +94,6 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
 
-    @Valid
-    @JsonProperty
-    protected Boolean prometheusEnabled = true;
-
     public SamlConfiguration getSamlConfiguration() {
         return saml;
     }
@@ -162,6 +158,6 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
 
     @Override
     public boolean isPrometheusEnabled() {
-        return prometheusEnabled;
+        return true;
     }
 }

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -127,5 +127,3 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}
-
-prometheusEnabled: ${PROMETHEUS_ENABLED:-false}

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
@@ -132,7 +132,6 @@ public class PrometheusMetricsIntegrationTest {
     public static SamlSoapProxyAppRule samlSoapProxyAppRule = new SamlSoapProxyAppRule(
         config("logging.level", "INFO"),
         config("httpClient.gzipEnabledForRequests", "false"),
-        config("prometheusEnabled", "true"),
         config("matchingServiceHealthCheckServiceConfiguration.enable", "true"),
         config("matchingServiceHealthCheckServiceConfiguration.initialDelay", "1s"),
         config("matchingServiceHealthCheckServiceConfiguration.delay", "3s"),

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -97,10 +97,6 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
 
     @Valid
     @JsonProperty
-    protected Boolean prometheusEnabled = true;
-
-    @Valid
-    @JsonProperty
     private PrometheusClientServiceConfiguration matchingServiceHealthCheckServiceConfiguration = new PrometheusClientServiceConfiguration();
 
     public SamlConfiguration getSamlConfiguration() {
@@ -167,7 +163,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
 
     @Override
     public boolean isPrometheusEnabled() {
-        return prometheusEnabled;
+        return true;
     }
 
     public PrometheusClientServiceConfiguration getMatchingServiceHealthCheckServiceConfiguration() {

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -107,5 +107,3 @@ eventEmitterConfiguration:
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
   apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}
-
-prometheusEnabled: ${PROMETHEUS_ENABLED:-false}


### PR DESCRIPTION
Set prometheus support to be enabled everywhere, and remove this as a configuration item.

Configuration items are only worth keeping if we actually intend to use them.