### PR TITLE
BAU: Increase MSA healthcheck timeout

### DIFF
--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -47,9 +47,9 @@ soapHttpClient:
     - org.apache.http.conn.HttpHostConnectException
 
 healthCheckSoapHttpClient:
-  timeout: 2s
+  timeout: 50s
   timeToLive: 10m
-  connectionTimeout: 2s
+  connectionTimeout: 50s
   keepAlive: 60s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s


### PR DESCRIPTION
MSA timeout is 50 seconds whereas MSA healthcheck timeout is 2 seconds. There are 281 timeouts in MSA healthcheck in production over the last 7 days via Kibana. This commit updates the MSA healthcheck timeout to 50 seconds which is same as MSA timeout. This change will reduce the number of timeouts occurred in MSA healthcheck.

Author: @adityapahuja