### PR TITLE
AUTO: Add a splunk appender to SAML engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ subprojects {
         }
         else {
           maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+          maven { url 'http://splunk.jfrog.io/splunk/ext-releases-local' }
         }
     }
 
@@ -93,6 +94,7 @@ subprojects {
         prometheus
         redis
         redis_test
+        splunk
     }
 
     dependencies {
@@ -170,6 +172,8 @@ subprojects {
 
         redis('io.lettuce:lettuce-core:5.1.4.RELEASE')
         redis_test('com.github.kstyrc:embedded-redis:0.6')
+
+        splunk('com.splunk.logging:splunk-library-javalogging:1.6.2')
     }
 
 }

--- a/hub/saml-engine/build.gradle
+++ b/hub/saml-engine/build.gradle
@@ -13,7 +13,8 @@ dependencies {
             configurations.common,
             configurations.ida_utils,
             configurations.redis,
-            configurations.prometheus
+            configurations.prometheus,
+            configurations.splunk
 }
 
 apply plugin: 'application'

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerTest.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.integrationtest.hub.samlengine.apprule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import httpstub.HttpStubRule;
+import httpstub.RecordedRequest;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule;
+
+import java.io.IOException;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SplunkLoggerTest {
+
+    private static final String SOURCE_TYPE = "IntegrationTest";
+    private static final String TOKEN = "SomeToken";
+    private static final String SOURCE = "SplunkLoggerTest";
+
+    private static HttpStubRule splunkStub = new HttpStubRule();
+    public static SamlEngineAppRule samlEngineAppRule = new SamlEngineAppRule(
+            config("logging.appenders[0].type", "splunk"),
+            config("logging.appenders[0].url", () -> String.valueOf(splunkStub.baseUri())),
+            config("logging.appenders[0].token", TOKEN),
+            config("logging.appenders[0].source", SOURCE),
+            config("logging.appenders[0].sourceType", SOURCE_TYPE)
+    );
+
+    @ClassRule
+    public static RuleChain rules = RuleChain.outerRule(splunkStub).around(samlEngineAppRule);
+
+    @Before
+    public void setUp() {
+        splunkStub.register("/services/collector/event/1.0", OK.getStatusCode());
+    }
+
+    @Test
+    public void shouldSendLogsToSplunkWithCorrectContent() throws IOException {
+        RecordedRequest lastRequest = splunkStub.getLastRequest();
+        assertThat(lastRequest.getHeader("Authorization")).contains(TOKEN);
+        JsonNode requestBody = new ObjectMapper().readTree(lastRequest.getEntityBytes());
+        assertThat(requestBody.get("source").asText()).isEqualTo(SOURCE);
+        assertThat(requestBody.get("sourcetype").asText()).isEqualTo(SOURCE_TYPE);
+    }
+}

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
@@ -22,6 +22,7 @@ import uk.gov.ida.common.shared.security.TrustStoreMetrics;
 import uk.gov.ida.hub.samlengine.exceptions.IdaJsonProcessingExceptionMapperBundle;
 import uk.gov.ida.hub.samlengine.exceptions.SamlEngineExceptionMapper;
 import uk.gov.ida.hub.samlengine.filters.SessionIdQueryParamLoggingFilter;
+import uk.gov.ida.hub.samlengine.logging.SplunkAppenderFactory;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryAuthnRequestGeneratorResource;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryAuthnResponseTranslatorResource;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryMatchingServiceRequestGeneratorResource;
@@ -71,6 +72,7 @@ public class SamlEngineApplication extends Application<SamlEngineConfiguration> 
                         new EnvironmentVariableSubstitutor(false)
                 )
         );
+        bootstrap.getObjectMapper().registerSubtypes(SplunkAppenderFactory.class);
 
         MDC.clear();
         bootstrap.addBundle(new ServiceStatusBundle());

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.hub.samlengine.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.splunk.logging.HttpEventCollectorLogbackAppender;
+import io.dropwizard.logging.AbstractAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+
+import javax.validation.constraints.NotNull;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@JsonTypeName("splunk")
+public class SplunkAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> {
+    @JsonProperty
+    @NotNull
+    private String url;
+
+    @JsonProperty
+    @NotNull
+    private String token;
+
+    @JsonProperty
+    @NotNull
+    private String source;
+
+    @JsonProperty
+    @NotNull
+    private String sourceType;
+
+    @JsonProperty
+    private Long batchSizeCount = 10L;
+
+    @Override
+    public Appender<ILoggingEvent> build(LoggerContext context, String applicationName, LayoutFactory<ILoggingEvent> layoutFactory, LevelFilterFactory<ILoggingEvent> levelFilterFactory, AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory) {
+        HttpEventCollectorLogbackAppender<ILoggingEvent> appender = new HttpEventCollectorLogbackAppender<ILoggingEvent>();
+        checkNotNull(context);
+
+        appender.setUrl(url);
+        appender.setToken(token);
+        appender.setSource(source);
+        appender.setSourcetype(sourceType);
+        appender.setbatch_size_count(batchSizeCount.toString());
+        appender.setLayout(buildLayout(context, layoutFactory));
+
+        appender.addFilter(levelFilterFactory.build(threshold));
+        appender.start();
+
+        return wrapAsync(appender, asyncAppenderFactory, context);
+    }
+}

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -28,14 +28,6 @@ metrics:
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/saml-engine.log
-      archivedLogFilenamePattern: apps-home/saml-engine.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/saml-engine.log
-      archivedLogFilenamePattern: apps-home/logstash/saml-engine.log.%d.gz
-      archivedFileCount: 7
     - type: console
       logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
 


### PR DESCRIPTION
- We want to get our SAML Engine logs to Splunk but at the moment SAML
  engine logs to Logit via an egress proxy
- As there is no intermediate service such as Cloudwatch to bounce logs
  from into Splunk, we need to either get SAML Engine to send this stuff
to Splunk itself (this commit) or bounce logs from Logit
- This uses an external maven source that we would probably want to make
  a mirror from artifactory or build it ourselves