### PR TITLE
BAU: Fix keepAlive issue

### DIFF
--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -2,6 +2,7 @@ server:
   applicationConnectors:
     - type: http
       port: 8080
+      idleTimeout: 70 seconds
   requestLog:
     type: classic
     appenders:
@@ -28,7 +29,7 @@ soapHttpClient:
   timeout: 50s
   timeToLive: 10m
   connectionTimeout: 50s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   tls:
@@ -50,7 +51,7 @@ healthCheckSoapHttpClient:
   timeout: 50s
   timeToLive: 10m
   connectionTimeout: 50s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   tls:


### PR DESCRIPTION
The keepAlive value determines how long a persistent connection is kept open on the client side without being used (between two http requests). This value must be set less than the server side idleTimeout (defaults to 30 seconds in Dropwizard server) otherwise the connection can be closed on the server’s end resulting a org.apache.http.NoHttpResponseException when the client tries to reuse the connection.

SAML SOAP Proxy MSA client and SAML SOAP Proxy MSA HealthCheck client both have keepAlive set to 60 seconds. MSA server's idleTimeout defaults to 30 seconds. The clients' keepAlive are greater than the server's idleTimeout. There are 5,422 org.apache.http.NoHttpResponseException in SAML SOAP Proxy log file in production over the last 7 days via Kibana. This commit sets the keepAlive to 10 seconds instead of 60 seconds so that it is less than the server's idleTimeout. This change will remove org.apache.http.NoHttpResponseException.

This commit also sets SAML SOAP Proxy's idleTimeout to 70 seconds since MSA client has keepAlive to 60 seconds. This will also help remove org.apache.http.NoHttpResponseException on MSA side (not SAML SOAP Proxy side).

Author: @adityapahuja