### PR TITLE
BAU: Fix remaining keepAlive issue in SAML SOAP Proxy

### DIFF
--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -16,7 +16,7 @@ httpClient:
   timeToLive: 10m
   connectionTimeout: 4s
   retries: 3
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   tls:

--- a/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
+++ b/hub/saml-soap-proxy/src/test/resources/saml-soap-proxy.yml
@@ -2,6 +2,7 @@ server:
   applicationConnectors:
     - type: http
       port: ${SAML_SOAP_PROXY_PORT:-50160}
+      idleTimeout: 70 seconds
   adminConnectors:
     - type: http
       port: ${SAML_SOAP_PROXY_ADMIN_PORT:-50161}
@@ -39,7 +40,7 @@ httpClient:
   cookiesEnabled: false
   connectionTimeout: 1s
   retries: 3
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
 
@@ -50,7 +51,7 @@ soapHttpClient:
   timeToLive: 10m
   cookiesEnabled: false
   connectionTimeout: 2s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
 
@@ -59,7 +60,7 @@ healthCheckSoapHttpClient:
   timeToLive: 10m
   cookiesEnabled: false
   connectionTimeout: 2s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
 


### PR DESCRIPTION
There are few remaining NoHttpResponseException in SAML SOAP Proxy log file coming from SAML Engine only (for generating attribute query requests). This commit updates httpClient keepAlive to 10 seconds instead of 60 seconds to eliminate these exceptions. This commit also updates clients' keepAlive to 10 seconds in SAML SOAP Proxy configuration file used for unit testing and integration testing.

Author: @adityapahuja