### PR TITLE
GVzYvzsG: add response details on invalid session state

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
@@ -67,6 +67,12 @@ public class SessionRepository {
     }
 
     @Timed(name = Urls.SESSION_REPO_TIMED_GROUP)
+    public StateController getUnknownStateController(final SessionId sessionId) {
+        State currentState = getCurrentState(sessionId);
+        return controllerFactory.build(currentState, state -> dataStore.replace(sessionId, state));
+    }
+
+    @Timed(name = Urls.SESSION_REPO_TIMED_GROUP)
     public boolean sessionExists(SessionId sessionId) {
         return dataStore.hasSession(sessionId);
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/SessionRepository.java
@@ -66,8 +66,9 @@ public class SessionRepository {
         throw new InvalidSessionStateException(sessionId, expectedStateClass, currentState.getClass());
     }
 
+
     @Timed(name = Urls.SESSION_REPO_TIMED_GROUP)
-    public StateController getUnknownStateController(final SessionId sessionId) {
+    public StateController getStateControllerRegardlessOfCurrentState(final SessionId sessionId) {
         State currentState = getCurrentState(sessionId);
         return controllerFactory.build(currentState, state -> dataStore.replace(sessionId, state));
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/exception/UnexpectedAuthnResponseException.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/exception/UnexpectedAuthnResponseException.java
@@ -1,0 +1,15 @@
+package uk.gov.ida.hub.policy.exception;
+
+import uk.gov.ida.hub.policy.domain.IdpIdaStatus;
+import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.hub.policy.domain.State;
+
+import static java.text.MessageFormat.format;
+
+public class UnexpectedAuthnResponseException extends RuntimeException {
+
+    public UnexpectedAuthnResponseException(SessionId sessionId, String requestIssuerId, IdpIdaStatus.Status responseStatus, Class<? extends State> actualState) {
+        super(format("SessionId: {0}, RequestIssuer: {1}, ResponseStatus: {2}, CurrentState: {3}, ExpectedState: IdpSelectedState",
+                sessionId.getSessionId(), requestIssuerId, responseStatus.toString(), actualState.getSimpleName()));
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
@@ -61,7 +61,7 @@ public class AuthnResponseFromIdpService {
             IdpSelectedStateController idpSelectedController = (IdpSelectedStateController) sessionRepository.getStateController(sessionId, IdpSelectedState.class);
             return getResponseActionForValidState(sessionId, samlResponseDto, idpSelectedController);
         } catch (InvalidSessionStateException e) {
-            StateController uncheckedStateController = sessionRepository.getUnknownStateController(sessionId);
+            StateController uncheckedStateController = sessionRepository.getStateControllerRegardlessOfCurrentState(sessionId);
             if (uncheckedStateController instanceof IdpSelectingStateController) {
                 String requestIssuerId = ((IdpSelectingStateController) uncheckedStateController).getRequestIssuerId();
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
@@ -1,5 +1,8 @@
 package uk.gov.ida.hub.policy.services;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.ida.hub.policy.contracts.AttributeQueryRequestDto;
 import uk.gov.ida.hub.policy.contracts.SamlAuthnResponseContainerDto;
 import uk.gov.ida.hub.policy.contracts.SamlAuthnResponseTranslatorDto;
@@ -38,6 +41,8 @@ public class AuthnResponseFromIdpService {
     private final SamlAuthnResponseTranslatorDtoFactory samlAuthnResponseTranslatorDtoFactory;
     private SessionRepository sessionRepository;
 
+    private static final Logger LOG = LoggerFactory.getLogger(AuthnResponseFromIdpService.class);
+
     @Inject
     public AuthnResponseFromIdpService(SamlEngineProxy samlEngineProxy,
                                        AttributeQueryService attributeQueryService,
@@ -62,6 +67,11 @@ public class AuthnResponseFromIdpService {
 
                 final SamlAuthnResponseTranslatorDto samlAuthnResponseTranslatorDto = samlAuthnResponseTranslatorDtoFactory.fromSamlAuthnResponseContainerDto(samlResponseDto, requestIssuerId);
                 final InboundResponseFromIdpDto idaResponseFromIdpDto = samlEngineProxy.translateAuthnResponseFromIdp(samlAuthnResponseTranslatorDto);
+
+                MDC.put("RequestIssuer", requestIssuerId);
+                MDC.put("ResponseStatus", idaResponseFromIdpDto.getStatus().toString());
+                MDC.put("CurrentState",  e.getActualState().toString());
+                LOG.warn("Unexpected session state. Expected: IdpSelectedState");
 
                 throw new UnexpectedAuthnResponseException(sessionId, requestIssuerId, idaResponseFromIdpDto.getStatus(), e.getActualState());
             }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpService.java
@@ -13,9 +13,13 @@ import uk.gov.ida.hub.policy.domain.RequesterErrorResponse;
 import uk.gov.ida.hub.policy.domain.ResponseAction;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.SessionRepository;
+import uk.gov.ida.hub.policy.domain.StateController;
 import uk.gov.ida.hub.policy.domain.SuccessFromIdp;
 import uk.gov.ida.hub.policy.domain.controller.IdpSelectedStateController;
+import uk.gov.ida.hub.policy.domain.controller.IdpSelectingStateController;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
+import uk.gov.ida.hub.policy.exception.InvalidSessionStateException;
+import uk.gov.ida.hub.policy.exception.UnexpectedAuthnResponseException;
 import uk.gov.ida.hub.policy.factories.SamlAuthnResponseTranslatorDtoFactory;
 import uk.gov.ida.hub.policy.proxy.SamlEngineProxy;
 
@@ -23,11 +27,10 @@ import javax.inject.Inject;
 
 import static uk.gov.ida.hub.policy.domain.ResponseAction.cancel;
 import static uk.gov.ida.hub.policy.domain.ResponseAction.failedUplift;
+import static uk.gov.ida.hub.policy.domain.ResponseAction.nonMatchingJourneySuccess;
 import static uk.gov.ida.hub.policy.domain.ResponseAction.other;
 import static uk.gov.ida.hub.policy.domain.ResponseAction.pending;
 import static uk.gov.ida.hub.policy.domain.ResponseAction.success;
-import static uk.gov.ida.hub.policy.domain.ResponseAction.nonMatchingJourneySuccess;
-
 
 public class AuthnResponseFromIdpService {
     private final SamlEngineProxy samlEngineProxy;
@@ -49,8 +52,24 @@ public class AuthnResponseFromIdpService {
     public ResponseAction receiveAuthnResponseFromIdp(SessionId sessionId,
                                                       SamlAuthnResponseContainerDto samlResponseDto) {
 
-        IdpSelectedStateController idpSelectedController = (IdpSelectedStateController) sessionRepository.getStateController(sessionId, IdpSelectedState.class);
+        try {
+            IdpSelectedStateController idpSelectedController = (IdpSelectedStateController) sessionRepository.getStateController(sessionId, IdpSelectedState.class);
+            return getResponseActionForValidState(sessionId, samlResponseDto, idpSelectedController);
+        } catch (InvalidSessionStateException e) {
+            StateController uncheckedStateController = sessionRepository.getUnknownStateController(sessionId);
+            if (uncheckedStateController instanceof IdpSelectingStateController) {
+                String requestIssuerId = ((IdpSelectingStateController) uncheckedStateController).getRequestIssuerId();
 
+                final SamlAuthnResponseTranslatorDto samlAuthnResponseTranslatorDto = samlAuthnResponseTranslatorDtoFactory.fromSamlAuthnResponseContainerDto(samlResponseDto, requestIssuerId);
+                final InboundResponseFromIdpDto idaResponseFromIdpDto = samlEngineProxy.translateAuthnResponseFromIdp(samlAuthnResponseTranslatorDto);
+
+                throw new UnexpectedAuthnResponseException(sessionId, requestIssuerId, idaResponseFromIdpDto.getStatus(), e.getActualState());
+            }
+            throw e;
+        }
+    }
+
+    private ResponseAction getResponseActionForValidState(SessionId sessionId, SamlAuthnResponseContainerDto samlResponseDto, IdpSelectedStateController idpSelectedController) {
         boolean matchingJourney = idpSelectedController.isMatchingJourney();
         String entityToEncryptFor = matchingJourney ? idpSelectedController.getMatchingServiceEntityId() : idpSelectedController.getRequestIssuerId();
         final SamlAuthnResponseTranslatorDto samlAuthnResponseTranslatorDto = samlAuthnResponseTranslatorDtoFactory.fromSamlAuthnResponseContainerDto(samlResponseDto, entityToEncryptFor);
@@ -168,14 +187,14 @@ public class AuthnResponseFromIdpService {
 
     private ResponseAction handleFraudResponse(InboundResponseFromIdpDto inboundResponseFromIdpDto, SessionId sessionId, String principalIPAddressAsSeenByHub, IdpSelectedStateController idpSelectedStateController, String analyticsSessionId, String journeyType) {
         FraudFromIdp fraudFromIdp = new FraudFromIdp(
-                        inboundResponseFromIdpDto.getIssuer(),
-                        principalIPAddressAsSeenByHub,
-                        new PersistentId(inboundResponseFromIdpDto.getPersistentId().get()),
-                        new FraudDetectedDetails(inboundResponseFromIdpDto.getIdpFraudEventId().get(), inboundResponseFromIdpDto.getFraudIndicator().get()),
-                        inboundResponseFromIdpDto.getPrincipalIpAddressAsSeenByIdp(),
-                        analyticsSessionId,
-                        journeyType
-                    );
+                inboundResponseFromIdpDto.getIssuer(),
+                principalIPAddressAsSeenByHub,
+                new PersistentId(inboundResponseFromIdpDto.getPersistentId().get()),
+                new FraudDetectedDetails(inboundResponseFromIdpDto.getIdpFraudEventId().get(), inboundResponseFromIdpDto.getFraudIndicator().get()),
+                inboundResponseFromIdpDto.getPrincipalIpAddressAsSeenByIdp(),
+                analyticsSessionId,
+                journeyType
+        );
         idpSelectedStateController.handleFraudResponseFromIdp(fraudFromIdp);
         return other(sessionId, idpSelectedStateController.isRegistrationContext());
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
@@ -76,6 +76,18 @@ public class SessionRepositoryTest {
     }
 
     @Test
+    public void getUncheckedStateController_shouldGetSession() {
+        SessionId expectedSessionId = aSessionId().build();
+        SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
+        SessionId sessionId = sessionRepository.createSession(sessionStartedState);
+        sessionRepository.getUnknownStateController(sessionId);
+
+        assertThat(sessionId).isEqualTo(expectedSessionId);
+        assertThat(dataStore.containsKey(expectedSessionId)).isEqualTo(true);
+        verify(controllerFactory).build(eq(sessionStartedState), any(StateTransitionAction.class));
+    }
+
+    @Test
     public void stateTransitionAction_shouldUpdateDatastore() {
         SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).build();
         SessionId sessionId = sessionRepository.createSession(sessionStartedState);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/SessionRepositoryTest.java
@@ -76,11 +76,11 @@ public class SessionRepositoryTest {
     }
 
     @Test
-    public void getUncheckedStateController_shouldGetSession() {
+    public void getStateControllerRegardlessOfCurrentState_shouldGetSession() {
         SessionId expectedSessionId = aSessionId().build();
         SessionStartedState sessionStartedState = aSessionStartedState().withSessionExpiryTimestamp(defaultSessionExpiry).withSessionId(expectedSessionId).build();
         SessionId sessionId = sessionRepository.createSession(sessionStartedState);
-        sessionRepository.getUnknownStateController(sessionId);
+        sessionRepository.getStateControllerRegardlessOfCurrentState(sessionId);
 
         assertThat(sessionId).isEqualTo(expectedSessionId);
         assertThat(dataStore.containsKey(expectedSessionId)).isEqualTo(true);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpServiceTest.java
@@ -30,7 +30,12 @@ import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.SessionRepository;
 import uk.gov.ida.hub.policy.domain.SuccessFromIdp;
 import uk.gov.ida.hub.policy.domain.controller.IdpSelectedStateController;
+import uk.gov.ida.hub.policy.domain.controller.SessionStartedStateController;
 import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
+import uk.gov.ida.hub.policy.domain.state.NoMatchState;
+import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
+import uk.gov.ida.hub.policy.exception.InvalidSessionStateException;
+import uk.gov.ida.hub.policy.exception.UnexpectedAuthnResponseException;
 import uk.gov.ida.hub.policy.factories.SamlAuthnResponseTranslatorDtoFactory;
 import uk.gov.ida.hub.policy.proxy.SamlEngineProxy;
 
@@ -76,6 +81,41 @@ public class AuthnResponseFromIdpServiceTest {
                 PRINCIPAL_IP_ADDRESS).withAnalyticsSessionId(ANALYTICS_SESSION_ID).withJourneyType(JOURNEY_TYPE).build();
         service = new AuthnResponseFromIdpService(samlEngineProxy, attributeQueryService, sessionRepository, samlAuthnResponseTranslatorDtoFactory);
         when(sessionRepository.getStateController(sessionId, IdpSelectedState.class)).thenReturn(idpSelectedStateController);
+    }
+
+    @Test(expected = UnexpectedAuthnResponseException.class)
+    public void shouldLogInvalidSessionStateException() {
+        // Given
+        InboundResponseFromIdpDto successResponseFromIdp = InboundResponseFromIdpDtoBuilder.successResponse(UUID.randomUUID().toString(), LevelOfAssurance.LEVEL_2, null);
+        mockOutStubs(REGISTERING, false, successResponseFromIdp);
+        when(sessionRepository.getStateController(sessionId, IdpSelectedState.class)).thenThrow(new InvalidSessionStateException(
+                sessionId,
+                IdpSelectedState.class,
+                SessionStartedState.class));
+        SessionStartedStateController controller = new SessionStartedStateController(
+                new SessionStartedState("testRequestId", "testRelayState", REQUEST_ISSUER_ID, null, true, null, sessionId, false),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        when(sessionRepository.getUnknownStateController(sessionId)).thenReturn(controller);
+
+        // When
+        service.receiveAuthnResponseFromIdp(sessionId, samlAuthnResponseContainerDto);
+    }
+
+    @Test(expected = InvalidSessionStateException.class)
+    public void shouldPassThroughUnexpectedState() {
+        // Given
+        when(sessionRepository.getStateController(sessionId, IdpSelectedState.class)).thenThrow(new InvalidSessionStateException(
+                sessionId,
+                IdpSelectedState.class,
+                NoMatchState.class));
+
+        // When
+        service.receiveAuthnResponseFromIdp(sessionId, samlAuthnResponseContainerDto);
     }
 
     @Test

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromIdpServiceTest.java
@@ -100,7 +100,7 @@ public class AuthnResponseFromIdpServiceTest {
                 null,
                 null
         );
-        when(sessionRepository.getUnknownStateController(sessionId)).thenReturn(controller);
+        when(sessionRepository.getStateControllerRegardlessOfCurrentState(sessionId)).thenReturn(controller);
 
         // When
         service.receiveAuthnResponseFromIdp(sessionId, samlAuthnResponseContainerDto);


### PR DESCRIPTION
Where the session state is one that includes information on the IDP, decrypt the request and record the request details in the error created. Add tests for new function, and check that the old behaviour still works. Raises new exception whose message will get passed through to the frontend.

See https://trello.com/c/GVzYvzsG/104-understand-and-fix-invalidstate-errors