### PR TITLE
EID-1362: Use hashed PID for eIDAS logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'java'
 apply plugin: 'com.github.ben-manes.versions'
 
 ext {
-    opensaml_version = '3.4.0'
+    opensaml_version = '3.4.2'
     dropwizard_version = '1.3.9'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
@@ -37,7 +37,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-37',
-            saml_libs:"$opensaml_version-181",
+            saml_lib:"$opensaml_version-184",
         ]
 
 subprojects {
@@ -89,7 +89,7 @@ subprojects {
         ida_utils
         ida_test_utils
         dev_pki
-        saml_libs
+        saml_lib
         prometheus
         redis
         redis_test
@@ -134,13 +134,11 @@ subprojects {
         prometheus 'engineering.gds-reliability:gds-metrics-dropwizard:0.1.0'
 
         saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
-             "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_libs",
              project(":hub-saml")
 
-        saml_test "uk.gov.ida:saml-test-utils:$dependencyVersions.saml_libs"
+        saml_lib "uk.gov.ida:saml-lib:$dependencyVersions.saml_lib"
 
-        saml_libs "uk.gov.ida:saml-utils:$dependencyVersions.saml_libs",
-                "uk.gov.ida:saml-extensions:$dependencyVersions.saml_libs"
+        saml_test "uk.gov.ida:saml-test:$dependencyVersions.saml_lib"
 
         pact_test "au.com.dius:pact-jvm-consumer-junit_2.11:$dependencyVersions.pact",
                 "au.com.dius:pact-jvm-consumer_2.11:$dependencyVersions.pact",
@@ -158,7 +156,7 @@ subprojects {
                 'org.json:json:20170516',
                 'com.jayway.awaitility:awaitility:1.6.0',
                 'com.github.tomakehurst:wiremock:2.16.0',
-                "uk.gov.ida:saml-metadata-bindings-test:$dependencyVersions.saml_libs",
+                "uk.gov.ida:saml-test:$dependencyVersions.saml_lib",
                 'io.dropwizard:dropwizard-testing:' + dependencyVersions.dropwizard]
 
         test_deps_deps.each { dep ->

--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -39,7 +39,7 @@ bintray {
 dependencies {
     compile configurations.common,
             configurations.test_deps_compile,
-            configurations.saml_libs,
+            configurations.saml_lib,
             configurations.saml_test,
             project(':hub-saml')
 }

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -38,7 +38,7 @@ bintray {
 
 dependencies {
     compile configurations.common,
-            configurations.saml_libs,
+            configurations.saml_lib,
             configurations.ida_utils
 
     testCompile configurations.test_deps_compile,

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSigner.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/decorators/SamlAttributeQueryAssertionSignatureSigner.java
@@ -10,7 +10,6 @@ import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
-import uk.gov.ida.saml.hub.HubConstants;
 import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
 
 import static org.opensaml.xmlsec.signature.support.Signer.signObject;

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -846,12 +846,6 @@ public class SamlEngineModule extends AbstractModule {
         return new IdpAssertionMetricsCollector(environment.metrics());
     }
 
-    @Provides
-    @Named("EidasAttributesLogger")
-    private EidasAttributesLogger getEidasAttributesLogger() {
-        return new EidasAttributesLogger(EidasResponseAttributesHashLogger::instance);
-    }
-
     public enum KeyPosition {
         PRIMARY,
         SECONDARY

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/IdpAuthnResponseTranslatorServiceTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/IdpAuthnResponseTranslatorServiceTest.java
@@ -50,6 +50,7 @@ import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -89,8 +90,6 @@ public class IdpAuthnResponseTranslatorServiceTest {
     private IdpAssertionMetricsCollector idpAssertionMetricsCollector;
     @Mock
     private PassthroughAssertion passThroughAssertion;
-    @Mock
-    private EidasAttributesLogger eidasAttributesLogger;
     @Mock
     private TransactionsConfigProxy transactionsConfigProxy;
 
@@ -170,7 +169,6 @@ public class IdpAuthnResponseTranslatorServiceTest {
                 samlResponseToIdaResponseIssuedByIdpTransformer,
                 inboundResponseFromIdpDataGenerator,
                 idpAssertionMetricsCollector,
-                eidasAttributesLogger,
                 transactionsConfigProxy);
     }
 
@@ -261,7 +259,7 @@ public class IdpAuthnResponseTranslatorServiceTest {
         when(responseContainer.getMatchingServiceEntityId()).thenReturn("a proxy node entity id");
         when(transactionsConfigProxy.isProxyNodeEntityId("a proxy node entity id")).thenReturn(true);
         translateAndCheckCommonFields();
-        verify(samlResponseToIdaResponseIssuedByIdpTransformer).setEidasAttributesLogger(eidasAttributesLogger);
+        verify(samlResponseToIdaResponseIssuedByIdpTransformer).setEidasAttributesLogger(isA(EidasAttributesLogger.class));
     }
 
     @Test
@@ -269,7 +267,7 @@ public class IdpAuthnResponseTranslatorServiceTest {
         when(responseContainer.getMatchingServiceEntityId()).thenReturn("a proxy node entity id");
         when(transactionsConfigProxy.isProxyNodeEntityId("a proxy node entity id")).thenReturn(false);
         translateAndCheckCommonFields();
-        verify(samlResponseToIdaResponseIssuedByIdpTransformer, never()).setEidasAttributesLogger(eidasAttributesLogger);
+        verify(samlResponseToIdaResponseIssuedByIdpTransformer, never()).setEidasAttributesLogger(isA(EidasAttributesLogger.class));
     }
 
     private void checkAlwaysPresentFields(InboundResponseFromIdpDto result) {


### PR DESCRIPTION
The hash of user attributes logged by saml engine gets compared with a
hash of user attributes in the proxy node. The PID used to produce this
hash in the proxy node has already itself been hashed by the VSP so we
need to replicate this behaviour in the EidasAttributesLogger.

Note: this also updates the hub to the latest and greatest singular Verify SAML library.