### PR TITLE
AUTO-340: Update keepAlive on remaining applications for consistency

### DIFF
--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -21,7 +21,7 @@ httpClient:
   timeout: 60s
   timeToLive: 10m
   connectionTimeout: 4s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   tls:
@@ -33,7 +33,7 @@ samlSoapProxyClient:
   timeout: 60s
   timeToLive: 10m
   connectionTimeout: 4s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   tls:

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -26,7 +26,7 @@ httpClient:
   timeout: 60s
   timeToLive: 10m
   connectionTimeout: 4s
-  keepAlive: 60s
+  keepAlive: 10s
   gzipEnabled: false
   gzipEnabledForRequests: false
   chunkedEncodingEnabled: false

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -15,7 +15,7 @@ httpClient:
   timeToLive: 10m
   connectionTimeout: 4s
   retries: 3
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   tls:

--- a/hub/policy/src/test/resources/policy-with-redis.yml
+++ b/hub/policy/src/test/resources/policy-with-redis.yml
@@ -48,7 +48,7 @@ httpClient:
   timeToLive: 10m
   cookiesEnabled: false
   connectionTimeout: 1s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   gzipEnabledForRequests: false
@@ -58,7 +58,7 @@ samlSoapProxyClient:
   timeToLive: 10m
   cookiesEnabled: false
   connectionTimeout: 1s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
 

--- a/hub/policy/src/test/resources/policy.yml
+++ b/hub/policy/src/test/resources/policy.yml
@@ -53,7 +53,7 @@ httpClient:
   timeToLive: 10m
   cookiesEnabled: false
   connectionTimeout: 1s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
   gzipEnabledForRequests: false
@@ -63,7 +63,7 @@ samlSoapProxyClient:
   timeToLive: 10m
   cookiesEnabled: false
   connectionTimeout: 1s
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
 

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -48,7 +48,7 @@ httpClient:
   timeToLive: 10m
   cookiesEnabled: false
   connectionTimeout: 1s
-  keepAlive: 60s
+  keepAlive: 10s
   gzipEnabled: false
   gzipEnabledForRequests: false
   chunkedEncodingEnabled: false

--- a/hub/saml-proxy/src/test/resources/saml-proxy.yml
+++ b/hub/saml-proxy/src/test/resources/saml-proxy.yml
@@ -41,7 +41,7 @@ httpClient:
   cookiesEnabled: false
   connectionTimeout: 1s
   retries: 3
-  keepAlive: 60s
+  keepAlive: 10s
   chunkedEncodingEnabled: false
   validateAfterInactivityPeriod: 5s
 


### PR DESCRIPTION
The keepAlive value determines how long a persistent connection is kept open on the client side without being used (between two http requests). This value must be set less than the server side idleTimeout (defaults to 30 seconds in Dropwizard server) otherwise the connection can be closed on the server’s end resulting a org.apache.http.NoHttpResponseException when the client tries to reuse the connection.

SAML SOAP Proxy HTTP client, SAML SOAP Proxy MSA client and SAML SOAP Proxy MSA HealthCheck client had keepAlive set to 60 seconds. SAML Engine server's and MSA server's idleTimeout defaulted to 30 seconds. The clients' keepAlive were greater than the servers' idleTimeout. There were 5,422 org.apache.http.NoHttpResponseException in SAML SOAP Proxy log file in production over the last 7 days via Kibana. I changed keepAlive to 10 seconds instead of 60 seconds so that it was less than the server's idleTimeout. As a result of this change, the number of org.apache.http.NoHttpResponseException stopped appearing in SAML SOAP Proxy log file.

<img width="1362" alt="SAMLSOAPProxyLogFile" src="https://user-images.githubusercontent.com/19972046/55385930-2b97d600-5526-11e9-8089-6bf27532f7af.png">

SAML Engine, SAML Proxy and Policy have the same issue. This commit updates remaining applications (SAML Engine, SAML Proxy and Policy) to have http client keep alive set to 10 seconds instead of 60 seconds. This will stop them from throwing org.apache.http.NoHttpResponseException.

Author: @adityapahuja