### PR TITLE
BAU: use Java 11 in IntelliJ

### DIFF
--- a/idea.gradle
+++ b/idea.gradle
@@ -24,8 +24,8 @@ subprojects {
 
 idea {
     project {
-        jdkName = '1.8'
-        languageLevel = '1.8'
+        jdkName = '11'
+        languageLevel = '11'
     }
 
     workspace {


### PR DESCRIPTION
Pre-requisite for starting to use Java 9+ features