### PR TITLE
bau - dont build using travis with java8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: java
 env:
   - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
-  - oraclejdk8
-  - openjdk8
   - openjdk11
 matrix:
 before_cache:


### PR DESCRIPTION
- We run Java11 in prod, so there's no reason we need to be backwards compatible
- This will save time with the travis builds