### PR TITLE
Integrate snyk with hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,17 @@ env:
 jdk:
   - openjdk11
 
-before_install: npm install -g snyk
+before_install: npm install -g snyk@1.146.0
 
 script:
   - ./gradlew check
   - snyk/test.sh
 
-after_success: snyk/monitor.sh
+after_success:
+  - snyk/monitor.sh
+  - ./gradlew jacocoRootReport
+  - curl -LSs -o codacy-coverage-reporter-assembly.jar $(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url')
+  - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -23,7 +27,4 @@ cache:
   directories:
     - "$HOME/.gradle/caches/"
     - "$HOME/.gradle/wrapper/"
-after_success:
-  - "./gradlew jacocoRootReport"
-  - curl -LSs -o codacy-coverage-reporter-assembly.jar $(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url')
-  - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,19 @@ env:
   global:
     - VERIFY_USE_PUBLIC_BINARIES=true
     - secure: qtjlAyHNvF//hsfZMGxHdkss3vo/y69eOeopn7zkoITVZJlBhBXQ4+jVEeExghIxXyV36zQPUWCyxhqyo5haRDbG/tRnapSdTMY+i6Awdm9TqxYw1KlUTwoevXGzbqK2lxnchp8ZE7+ebEorQkAfII+FX496IqWEjzx5UbmAem+xCNdv76t9LWcW+gXLTei+i0U/s1Vr5M5aIseb8hfriE6zqood0s7S9zbydZbyhR2ky3mknVjsgMT8a8bkWN3xq9Eg3odmepXb8OZxgjmYa8rBDrS2Qz+KZOeWE3Ap1Sqo5OSA6X6ysIrbbY3zIy1oNZdsu1xHXFmVJAFSyp0c8SNIVhfIuycPw8vKQQuQELvrFoGBN2m9fL3aeuedZ4c6dc/Ok9Lrr5RE2sBaaXTUTsntO9mcYOuVCScIFpLqboZJ9minNVgvk/bv8+AkbEToBIu2RA9SmnH4szuaB3SsPGmj5ukMXuT3LO6Kpr7yYzxsNlzg5e0+C9smJ4a5ZeCRedazqwUSvZ/bWvAfMNlstlGbG5u6o4WDfQeyztZjuwUeNjHY85Iu1/SzKp8kPKPNGeAMoFWNmFiUEhjji4SeF8240dcV/u68E3LnlJV0DSL2a0vwMJTfgML3Z5gYfQWAP7OqTQglNy3oVs5GQ9zvsso1qm4n9fxhF7YbQIf3zAo=
+    - secure: "hIW2/4kos6DNDizuv+ZQm1ROaG+5b+lLjZbxTPZHDap0LcuCLn2S9LMnDvg+ok7KGrzJmMGGexYW2MCAEptBEIM+TcuAqzn4PktYojqcspcrXrhrZ8HR9VJtU8NfOEmwVtYun6f0Nqb32s/+T6xGBY+DemCd+XD36H/PCX+rSZ55orshykulhwvaWLaP50L9Zb8g6atX98fChOd6HRW7O43nI+uto1c4uaC5xiOC6F+MUYG3f2v1VmOge9f0iQYn4irUlFzRIemgoMyTKISoi8kMHXWu5zZu7sGob7kG9mw/btM72XtZ75u/uaDZimTOyaiumEg72DbLsTgd8TpYbzFQTgSmAFKPYDimAEMEhch3JrSVgpX/OrfLDpNheBBfK7z0m/wOPOqzxADMUshMzLW8frlEwQ2z9iMarBsXmchNy/7YWvA6yqpVCZLx0KnWe/M/AEPnOZlYeEpoIpj/gGv8Pfkw+JdsXhgmk9JMYXP/FmA5WTCEm8fW5PuR3tBVNEQEXdc5p9J/ZWEA3LcSrFoE5BxQiZiGS7NYYID/SAlsllrEAwqnxX5B3VBvC096BHEXPg+ZwG1eDW80sK84flrVa68A/mdC20AomM6hwMDbHBLSp6nQIsm9xT9iKexSZRQ2MJwoSkFa7UIrd/LOy/YpCqaQz1H/OtvF/Q2wU4o="
+
 jdk:
   - openjdk11
+
+before_install: npm install -g snyk
+
+script:
+  - ./gradlew check
+  - snyk/test.sh
+
+after_success: snyk/monitor.sh
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,8 @@ subprojects {
                     'org.glassfish.hk2:hk2-api:2.4.0-b31',
                     'org.glassfish.hk2:hk2-locator:2.4.0-b31',
                     'org.glassfish.hk2.external:javax.inject:2.4.0-b31',
-                    'com.hubspot.dropwizard:dropwizard-guicier:0.9.1.0'
+                    'com.hubspot.dropwizard:dropwizard-guicier:0.9.1.0',
+                    'org.bouncycastle:bcprov-jdk15on:1.61'
         }
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
     }
@@ -146,9 +147,6 @@ subprojects {
 
         saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
              project(":hub-saml")
-        saml("org.bouncycastle:bcprov-jdk15on:1.61") {
-            force = true
-        }
 
         saml_lib "uk.gov.ida:saml-lib:$dependencyVersions.saml_lib"
 

--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,9 @@ subprojects {
 
         saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
              project(":hub-saml")
+        saml("org.bouncycastle:bcprov-jdk15on:1.61") {
+            force = true
+        }
 
         saml_lib "uk.gov.ida:saml-lib:$dependencyVersions.saml_lib"
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,8 @@ subprojects {
     dependencies {
 
         common 'joda-time:joda-time:2.3',
-                'com.google.inject:guice:4.0',
+                'com.google.inject:guice:4.2.2',
+                "com.google.guava:guava:25.1-jre",
                 "javax.xml.bind:jaxb-api:2.3.1",
                 "com.sun.xml.bind:jaxb-core:2.3.0.1",
                 "com.sun.xml.bind:jaxb-impl:2.3.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,6 @@ subprojects {
         all*.exclude group: 'org.mockito', module: 'mockito-all'
         common
         dropwizard
-        msa
         saml
         saml_test
         pact_test

--- a/build.gradle
+++ b/build.gradle
@@ -33,19 +33,19 @@ repositories {
 
 ext {
     opensaml_version = '3.4.2'
-    dropwizard_version = '1.3.9'
+    dropwizard_version = '1.3.12'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
 def dependencyVersions = [
-            ida_utils:'359',
+            ida_utils:'361',
             dropwizard:"$dropwizard_version",
-            dropwizard_infinispan:"$dropwizard_version-48",
+            dropwizard_infinispan:"$dropwizard_version-49",
             pact:'3.5.6',
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-37',
-            saml_lib:"$opensaml_version-193",
+            saml_lib:"$opensaml_version-195",
         ]
 
 subprojects {
@@ -79,10 +79,12 @@ subprojects {
                     'org.bouncycastle:bcprov-jdk15on:1.61'
         }
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+
+        exclude group: 'commons-beanutils', module: 'commons-beanutils'
+        exclude group: 'org.mockito', module: 'mockito-all'
     }
 
     configurations {
-        all*.exclude group: 'org.mockito', module: 'mockito-all'
         common
         dropwizard
         saml
@@ -125,7 +127,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-60"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-61"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/snyk/configurations.sh
+++ b/snyk/configurations.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# This is to allow the snyk_test and snyk_monitor scripts to both use the same list of configurations and stay in sync.
+# Any new gradle configurations to be tested should be added here.
+
+# shellcheck disable=SC2034
+CONFIGURATIONS="common dropwizard msa saml soap config verify_event_emitter ida_utils saml_lib prometheus redis"

--- a/snyk/configurations.sh
+++ b/snyk/configurations.sh
@@ -4,4 +4,4 @@
 # Any new gradle configurations to be tested should be added here.
 
 # shellcheck disable=SC2034
-CONFIGURATIONS="common dropwizard msa saml soap config verify_event_emitter ida_utils saml_lib prometheus redis"
+CONFIGURATIONS="common dropwizard saml soap config verify_event_emitter ida_utils saml_lib prometheus redis"

--- a/snyk/configurations.sh
+++ b/snyk/configurations.sh
@@ -4,4 +4,4 @@
 # Any new gradle configurations to be tested should be added here.
 
 # shellcheck disable=SC2034
-CONFIGURATIONS="common dropwizard saml soap config verify_event_emitter ida_utils saml_lib prometheus redis"
+CONFIGURATIONS="common dropwizard saml soap config verify_event_emitter ida_utils saml_lib prometheus redis splunk"

--- a/snyk/monitor.sh
+++ b/snyk/monitor.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# If a new configuration is added it will need adding to `snyk_configurations.sh`.
+# This script is intended to be used by a CI server.
+
+# Travis builds run on Trusty which requires a different definition for sub-project
+[[ $TRAVIS = "true" ]] && sub_project="config" || sub_project=":hub:config"
+
+function print_banner() {
+    echo "######################################################################"
+    echo "### Monitoring dependencies for $1 gradle configuration"
+    echo "######################################################################"
+}
+
+function monitor_configuration() {
+    local config=$1;
+    print_banner "$config"
+    # The sub-project specified here is irrelevant. The configuration will still be tested regardless of if the
+    # sub-project actually uses it.
+    snyk monitor --gradle-sub-project="$sub_project" --project-name="$config"-config --org=verify-hub -- --configuration="$config"
+}
+
+source snyk/configurations.sh
+
+for configuration in $CONFIGURATIONS; do
+    monitor_configuration $configuration
+done;

--- a/snyk/test.sh
+++ b/snyk/test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# If a new configuration is added it will need adding to `snyk_configurations.sh`.
+# This script is intended to be used by a CI server.
+
+# Travis builds run on Trusty which requires a different definition for sub-project
+[[ $TRAVIS = "true" ]] && sub_project="config" || sub_project=":hub:config"
+exit_code=0
+
+function print_banner() {
+    echo "######################################################################"
+    echo "### Testing dependencies for $1 gradle configuration"
+    echo "######################################################################"
+}
+
+function test_configuration() {
+    local config=$1;
+    print_banner "$config"
+    # The sub-project specified here is irrelevant. The configuration will still be tested regardless of if the
+    # sub-project actually uses it.
+    snyk test --gradle-sub-project="$sub_project" -- --configuration="$config"
+    if [[ $? -gt 0 ]]; then
+        exit_code=1
+    fi
+}
+
+source snyk/configurations.sh
+
+mv Gemfile tmp-Gemfile
+mv Gemfile.lock tmp-Gemfile.lock
+trap "{ mv tmp-Gemfile Gemfile ; mv tmp-Gemfile.lock Gemfile.lock; }" EXIT
+
+for configuration in $CONFIGURATIONS; do
+   test_configuration $configuration
+done
+
+exit $exit_code


### PR DESCRIPTION
This PR integrates [snyk](https://snyk.io/) with the hub. The hubs dependencies are tested as part of the Travis build. The build will fail if snyk finds a vulnerability with any of the hubs dependencies. At this point you can go and fix the issues, or if there is no solution the issue can be ignored via the [snyk console](https://app.snyk.io/org/verify-hub).

This set up is very similar to that used in the proxy-node. Here's a link to a document describing the set up in more detail: https://docs.google.com/document/d/1MB_N9A-lYRG-r_Ngo6bmF9uiaDlRekmVHwZo9TbU8W8/edit?usp=sharing

When reviewing please look at the list of configurations being tested and check that it's not missing any that should be tested.

## Commits
### BAU Create snyk scripts  …
These are almost directly copied from the scripts used in the
proxy-node.

The main difference is the names of the configurations to test. Also
changed is the gradle sub project being used.

The scripts now also move the Gemfile and Gemfile.lock in the root of
the project to a different namespace while the tests run. Without this
snyk will just test the dependencies in there rather than the gradle
dependencies.

### BAU Bump Guice version in common config  …
This fixes CVE-2018-10237, a medium severity vulnerability.

Guice 4.0 was pulling in version 16.0 of Guava which was vulnerable.

Unfortunately from Guice 4.2.1, Guice pulls in Guava 25.1-android which
is incompatible with our stuff. Guava release two variants `*-android`
and `*-jre`. The recommendation is to explicitly declare a dependency on
the `-jre` variant of equal or greater version number. See (here for a
pretty good explanation.)[google/guice#1207]
This has been done.

### BAU Bump Guice version in common config  …
This fixes CVE-2018-10237, a medium severity vulnerability.

Guice 4.0 was pulling in version 16.0 of Guava which was vulnerable.

Unfortunately from Guice 4.2.1, Guice pulls in Guava 25.1-android which
is incompatible with our stuff. Guava release two variants `*-android`
and `*-jre`. The recommendation is to explicitly declare a dependency on
the `-jre` variant of equal or greater version number. See (here for a
pretty good explanation.)[google/guice#1207]
This has been done.

### BAU Bump verify_event_emitter to 0.0.1-59  …
This version depends on dropwizard-logstash 1.3.9-71 which in turn pull
in dropwizard-core 1.3.9 which fixes a bunch of vulnerabilities.

Namely:

[CVE-2018-19361](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72884)
[CVE-2018-19360](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72883)
[CVE-2018-19362](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72882)
[CVE-2018-14721](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72451)
[CVE-2018-14720](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72449)
[CVE-2018-14719](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72450)
[CVE-2018-14718](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72448)
[CVE-2018-1000873](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATATYPE-173759)
[CVE-2018-12545](https://app.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174011)
[CVE-2018-10237](https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236)

### BAU Bump saml_lib to 3.4.2-185  …
185 bumps it's dropwizard version from 1.3.5 to 1.3.9 which fixes a
bunch of vulnerabilities with the saml_lib configuration.

The issues fixed are:

[CVE-2018-14718](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72448)
[CVE-2018-19361](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72884)
[CVE-2018-19362](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72882)
[CVE-2018-14719](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72450)
[CVE-2018-14721](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72451)
[CVE-2018-19360](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72883)
[CVE-2018-14720](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72449)
[CVE-2018-1000873](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATATYPE-173759)
[CVE-2018-12545](https://app.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174011)

This also pins the version of BouncyCastle to 1.61 for all
configurations as there were vulnerabilities in the saml_lib
configuration as well as others. The vulnerabilities this fixes are:

[CVE-2018-1000180](https://app.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-32369)
[CVE-2018-1000613](https://app.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-32412)

### BAU Update travis.yml to run snyk scripts  …
This adds the SNYK_TOKEN env variable as an encrypted variable. The
token used is my token.

It installs the CLI before the projects dependencies are installed in
the "before_install" block.

It runs test.sh after running the default check task, as before.

It runs monitor.sh if the "script" block was successful.




