### PR TITLE
eidas logging: use inResponseTo from IDP as hub request id

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/EidasAttributesLogger.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/EidasAttributesLogger.java
@@ -62,7 +62,7 @@ public class EidasAttributesLogger {
             }
         }
 
-        hashLogger.logHashFor(response.getID(), response.getDestination());
+        hashLogger.logHashFor(response.getInResponseTo(), response.getDestination());
     }
 
     private void logFirstVerified(Attribute attribute, Consumer<XMLObject> xmlObjectConsumer) {

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/domain/EidasAttributesLoggerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/domain/EidasAttributesLoggerTest.java
@@ -62,9 +62,29 @@ public class EidasAttributesLoggerTest {
         when(issuer.getValue()).thenReturn("issuer");
         when(subject.getNameID()).thenReturn(nameID);
         when(nameID.getValue()).thenReturn("pid");
-        when(response.getID()).thenReturn("request id");
+        when(response.getInResponseTo()).thenReturn("request id");
         when(response.getDestination()).thenReturn("destination");
     }
+
+    @Test
+    public void testInResponseToOnIDPResponseIsUsedAsHubRequestIdInEDIASHashLogging() {
+        EidasAttributesLogger eidasAttributesLogger = new EidasAttributesLogger(() -> hashLogger, entityId);
+        PersonName attributeValue = mock(PersonName.class);
+        when(attributeValue.getVerified()).thenReturn(true);
+        Element element = mock(Element.class);
+        when(element.getTextContent()).thenReturn("Paul");
+        when(attributeValue.getDOM()).thenReturn(element);
+        Attribute attribute = mock(Attribute.class);
+        when(attribute.getName()).thenReturn(IdaConstants.Attributes_1_1.Firstname.NAME);
+        when(attribute.getAttributeValues()).thenReturn(Lists.newArrayList(attributeValue));
+        when(assertion.getAttributeStatements()).thenReturn(Lists.newArrayList(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(Lists.newArrayList(attribute));
+        eidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
+        verify(response).getInResponseTo();
+        verify(response).getDestination();
+        verifyNoMoreInteractions(response);
+    }
+
 
     @Test
     public void testOnlyFirstValidFirstNameIsHashed() {


### PR DESCRIPTION
We need to log a hash of user attributes in both the Hub and Proxy Node for security reasons.

In order to compare these hashes, we need to join two log events on some key, in this case a hub request id.

Proxy Node uses the request id generated by the `VSP` as its "hub request id".
When processing the SAML Response from the IDP, the equivalent id is the "inResponseTo" attribute value sent back by the IDP.

This PR will update the key to use the "inResponseTo" attribute value.

Note that this logging is only activated on a Hub journey originating from our eIDAS Proxy Node. 