### PR TITLE
Bump event emitter to 0.0.1-60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-59"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-60"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",


### PR DESCRIPTION
https://trello.com/c/y8ieTzSO/14-adjust-event-emitter-to-log-encrypted-event