### PR TITLE
BAU: Bump event emitter to 0.0.1-59

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-58"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-59"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",


### PR DESCRIPTION
This bumps the event emitter's dropwizard-logstash dependency to 1.3.9-71.

This was committed earlier this month but didn't get deployed.  We want to deploy a new version of the event emitter now, so we'd like to see this older one deployed first.