### PR TITLE
Eid 1422 Send saml engine hash attribute logs to splunk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ subprojects {
         }
         else {
           maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+          maven { url 'http://splunk.jfrog.io/splunk/ext-releases-local' }
         }
     }
 
@@ -101,6 +102,7 @@ subprojects {
         prometheus
         redis
         redis_test
+        splunk
     }
 
     dependencies {
@@ -176,6 +178,8 @@ subprojects {
 
         redis('io.lettuce:lettuce-core:5.1.4.RELEASE')
         redis_test('com.github.kstyrc:embedded-redis:0.6')
+
+        splunk('com.splunk.logging:splunk-library-javalogging:1.6.2')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,11 +60,11 @@ subprojects {
           maven { url 'https://dl.bintray.com/alphagov/maven' } // For dropwizard-logstash
           maven { url 'https://dl.bintray.com/alphagov/maven-test' } // For other public verify binaries
           maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
+          maven { url 'https://splunk.jfrog.io/splunk/ext-releases-local' }
           jcenter()
         }
         else {
           maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
-          maven { url 'http://splunk.jfrog.io/splunk/ext-releases-local' }
         }
     }
 

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -58,6 +58,7 @@ logging:
           token: ${SPLUNK_TOKEN}
           source: ${SPLUNK_SOURCE}
           sourceType: ${SPLUNK_SOURCE_TYPE}
+          index: ${SPLUNK_INDEX}
   level: INFO
   appenders:
     - type: logstash-console

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -48,6 +48,16 @@ rpTrustStoreConfiguration:
   path: /tmp/truststores/${DEPLOYMENT}/rp_ca_certs.ts
   password: puppet
 logging:
+  loggers:
+    uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger:
+      level: INFO
+      additive: true
+      appenders:
+        - type: splunk
+          url: ${SPLUNK_URL}
+          token: ${SPLUNK_TOKEN}
+          source: ${SPLUNK_SOURCE}
+          sourceType: ${SPLUNK_SOURCE_TYPE}
   level: INFO
   appenders:
     - type: logstash-console

--- a/hub/saml-engine/build.gradle
+++ b/hub/saml-engine/build.gradle
@@ -13,7 +13,8 @@ dependencies {
             configurations.common,
             configurations.ida_utils,
             configurations.redis,
-            configurations.prometheus
+            configurations.prometheus,
+            configurations.splunk
 }
 
 apply plugin: 'application'

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerTest.java
@@ -18,9 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SplunkLoggerTest {
 
-    private static final String SOURCE_TYPE = "IntegrationTest";
     private static final String TOKEN = "SomeToken";
     private static final String SOURCE = "SplunkLoggerTest";
+    private static final String SOURCE_TYPE = "IntegrationTest";
+    private static final String INDEX = "SplunkIndex";
 
     private static HttpStubRule splunkStub = new HttpStubRule();
     public static SamlEngineAppRule samlEngineAppRule = new SamlEngineAppRule(
@@ -28,7 +29,8 @@ public class SplunkLoggerTest {
             config("logging.appenders[0].url", () -> String.valueOf(splunkStub.baseUri())),
             config("logging.appenders[0].token", TOKEN),
             config("logging.appenders[0].source", SOURCE),
-            config("logging.appenders[0].sourceType", SOURCE_TYPE)
+            config("logging.appenders[0].sourceType", SOURCE_TYPE),
+            config("logging.appenders[0].index", INDEX)
     );
 
     @ClassRule
@@ -46,5 +48,6 @@ public class SplunkLoggerTest {
         JsonNode requestBody = new ObjectMapper().readTree(lastRequest.getEntityBytes());
         assertThat(requestBody.get("source").asText()).isEqualTo(SOURCE);
         assertThat(requestBody.get("sourcetype").asText()).isEqualTo(SOURCE_TYPE);
+        assertThat(requestBody.get("index").asText()).isEqualTo(INDEX);
     }
 }

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerTest.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.integrationtest.hub.samlengine.apprule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import httpstub.HttpStubRule;
+import httpstub.RecordedRequest;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule;
+
+import java.io.IOException;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SplunkLoggerTest {
+
+    private static final String SOURCE_TYPE = "IntegrationTest";
+    private static final String TOKEN = "SomeToken";
+    private static final String SOURCE = "SplunkLoggerTest";
+
+    private static HttpStubRule splunkStub = new HttpStubRule();
+    public static SamlEngineAppRule samlEngineAppRule = new SamlEngineAppRule(
+            config("logging.appenders[0].type", "splunk"),
+            config("logging.appenders[0].url", () -> String.valueOf(splunkStub.baseUri())),
+            config("logging.appenders[0].token", TOKEN),
+            config("logging.appenders[0].source", SOURCE),
+            config("logging.appenders[0].sourceType", SOURCE_TYPE)
+    );
+
+    @ClassRule
+    public static RuleChain rules = RuleChain.outerRule(splunkStub).around(samlEngineAppRule);
+
+    @Before
+    public void setUp() {
+        splunkStub.register("/services/collector/event/1.0", OK.getStatusCode());
+    }
+
+    @Test
+    public void shouldSendLogsToSplunkWithCorrectContent() throws IOException {
+        RecordedRequest lastRequest = splunkStub.getLastRequest();
+        assertThat(lastRequest.getHeader("Authorization")).contains(TOKEN);
+        JsonNode requestBody = new ObjectMapper().readTree(lastRequest.getEntityBytes());
+        assertThat(requestBody.get("source").asText()).isEqualTo(SOURCE);
+        assertThat(requestBody.get("sourcetype").asText()).isEqualTo(SOURCE_TYPE);
+    }
+}

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
@@ -22,6 +22,7 @@ import uk.gov.ida.common.shared.security.TrustStoreMetrics;
 import uk.gov.ida.hub.samlengine.exceptions.IdaJsonProcessingExceptionMapperBundle;
 import uk.gov.ida.hub.samlengine.exceptions.SamlEngineExceptionMapper;
 import uk.gov.ida.hub.samlengine.filters.SessionIdQueryParamLoggingFilter;
+import uk.gov.ida.hub.samlengine.logging.SplunkAppenderFactory;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryAuthnRequestGeneratorResource;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryAuthnResponseTranslatorResource;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryMatchingServiceRequestGeneratorResource;
@@ -71,6 +72,7 @@ public class SamlEngineApplication extends Application<SamlEngineConfiguration> 
                         new EnvironmentVariableSubstitutor(false)
                 )
         );
+        bootstrap.getObjectMapper().registerSubtypes(SplunkAppenderFactory.class);
 
         MDC.clear();
         bootstrap.addBundle(new ServiceStatusBundle());

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineApplication.java
@@ -22,7 +22,6 @@ import uk.gov.ida.common.shared.security.TrustStoreMetrics;
 import uk.gov.ida.hub.samlengine.exceptions.IdaJsonProcessingExceptionMapperBundle;
 import uk.gov.ida.hub.samlengine.exceptions.SamlEngineExceptionMapper;
 import uk.gov.ida.hub.samlengine.filters.SessionIdQueryParamLoggingFilter;
-import uk.gov.ida.hub.samlengine.logging.SplunkAppenderFactory;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryAuthnRequestGeneratorResource;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryAuthnResponseTranslatorResource;
 import uk.gov.ida.hub.samlengine.resources.translators.CountryMatchingServiceRequestGeneratorResource;
@@ -72,7 +71,6 @@ public class SamlEngineApplication extends Application<SamlEngineConfiguration> 
                         new EnvironmentVariableSubstitutor(false)
                 )
         );
-        bootstrap.getObjectMapper().registerSubtypes(SplunkAppenderFactory.class);
 
         MDC.clear();
         bootstrap.addBundle(new ServiceStatusBundle());

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
@@ -34,6 +34,10 @@ public class SplunkAppenderFactory extends AbstractAppenderFactory<ILoggingEvent
     private String sourceType;
 
     @JsonProperty
+    @NotNull
+    private String index;
+
+    @JsonProperty
     private Long batchSizeCount = 10L;
 
     @Override
@@ -45,6 +49,7 @@ public class SplunkAppenderFactory extends AbstractAppenderFactory<ILoggingEvent
         appender.setToken(token);
         appender.setSource(source);
         appender.setSourcetype(sourceType);
+        appender.setIndex(index);
         appender.setbatch_size_count(batchSizeCount.toString());
         appender.setLayout(buildLayout(context, layoutFactory));
 

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
@@ -1,0 +1,56 @@
+package uk.gov.ida.hub.samlengine.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.splunk.logging.HttpEventCollectorLogbackAppender;
+import io.dropwizard.logging.AbstractAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+
+import javax.validation.constraints.NotNull;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@JsonTypeName("splunk")
+public class SplunkAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> {
+    @JsonProperty
+    @NotNull
+    private String url;
+
+    @JsonProperty
+    @NotNull
+    private String token;
+
+    @JsonProperty
+    @NotNull
+    private String source;
+
+    @JsonProperty
+    @NotNull
+    private String sourceType;
+
+    @JsonProperty
+    private Long batchSizeCount = 10L;
+
+    @Override
+    public Appender<ILoggingEvent> build(LoggerContext context, String applicationName, LayoutFactory<ILoggingEvent> layoutFactory, LevelFilterFactory<ILoggingEvent> levelFilterFactory, AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory) {
+        HttpEventCollectorLogbackAppender<ILoggingEvent> appender = new HttpEventCollectorLogbackAppender<ILoggingEvent>();
+        checkNotNull(context);
+
+        appender.setUrl(url);
+        appender.setToken(token);
+        appender.setSource(source);
+        appender.setSourcetype(sourceType);
+        appender.setbatch_size_count(batchSizeCount.toString());
+        appender.setLayout(buildLayout(context, layoutFactory));
+
+        appender.addFilter(levelFilterFactory.build(threshold));
+        appender.start();
+
+        return wrapAsync(appender, asyncAppenderFactory, context);
+    }
+}

--- a/hub/saml-engine/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/hub/saml-engine/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,0 +1,1 @@
+uk.gov.ida.hub.samlengine.logging.SplunkAppenderFactory

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactoryTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactoryTest.java
@@ -1,0 +1,73 @@
+package uk.gov.ida.hub.samlengine.logging;
+
+import ch.qos.logback.classic.AsyncAppender;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.logging.async.AsyncLoggingEventAppenderFactory;
+import io.dropwizard.logging.filter.ThresholdLevelFilterFactory;
+import io.dropwizard.logging.layout.DropwizardLayoutFactory;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SplunkAppenderFactoryTest {
+
+    private static ObjectMapper mapper = new ObjectMapper();
+    private static JSONObject jsonSplunkFactory;
+
+    @Before
+    public void setup() {
+        jsonSplunkFactory = new JSONObject();
+        jsonSplunkFactory.put("type", "splunk");
+        jsonSplunkFactory.put("url", "http://example.com");
+        jsonSplunkFactory.put("token", "myToken");
+        jsonSplunkFactory.put("source", "mySource");
+        jsonSplunkFactory.put("sourceType", "mySourceType");
+    }
+
+    @Test
+    public void canBeInstantiatedFromJson() throws Exception {
+        mapper.readValue(jsonSplunkFactory.toString(), SplunkAppenderFactory.class);
+    }
+
+    @Test
+    public void isNotValidWithoutRequiredFields() throws Exception {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        String[] requiredFields = {"url", "token", "source", "sourceType"};
+
+        for (String field : requiredFields) {
+            JSONObject jsonWithMissingField = new JSONObject(jsonSplunkFactory, JSONObject.getNames(jsonSplunkFactory));
+            jsonWithMissingField.put(field, JSONObject.NULL);
+
+            SplunkAppenderFactory appenderFactory = mapper.readValue(jsonWithMissingField.toString(), SplunkAppenderFactory.class);
+            Set<ConstraintViolation<SplunkAppenderFactory>> violations = validator.validate(appenderFactory);
+
+            assertThat(violations.size()).isEqualTo(1);
+            assertThat(violations.iterator().next().getMessage()).isEqualTo("may not be null");
+        }
+    }
+
+    @Test
+    public void buildReturnsAnAsyncAppender() throws Exception {
+        SplunkAppenderFactory splunkAppenderFactory = mapper.readValue(jsonSplunkFactory.toString(), SplunkAppenderFactory.class);
+        Appender<ILoggingEvent> appender = splunkAppenderFactory.build(
+            new LoggerContext(),
+            "appName",
+            new DropwizardLayoutFactory(),
+            new ThresholdLevelFilterFactory(),
+            new AsyncLoggingEventAppenderFactory()
+        );
+
+        assertThat(appender).isExactlyInstanceOf(AsyncAppender.class);
+    }
+}

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactoryTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactoryTest.java
@@ -33,6 +33,7 @@ public class SplunkAppenderFactoryTest {
         jsonSplunkFactory.put("token", "myToken");
         jsonSplunkFactory.put("source", "mySource");
         jsonSplunkFactory.put("sourceType", "mySourceType");
+        jsonSplunkFactory.put("index", "myIndex");
     }
 
     @Test
@@ -43,7 +44,7 @@ public class SplunkAppenderFactoryTest {
     @Test
     public void isNotValidWithoutRequiredFields() throws Exception {
         Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-        String[] requiredFields = {"url", "token", "source", "sourceType"};
+        String[] requiredFields = {"url", "token", "source", "sourceType", "index"};
 
         for (String field : requiredFields) {
             JSONObject jsonWithMissingField = new JSONObject(jsonSplunkFactory, JSONObject.getNames(jsonSplunkFactory));

--- a/hub/saml-engine/src/test/resources/saml-engine.yml
+++ b/hub/saml-engine/src/test/resources/saml-engine.yml
@@ -28,14 +28,6 @@ metrics:
 logging:
   level: INFO
   appenders:
-    - type: file
-      currentLogFilename: apps-home/saml-engine.log
-      archivedLogFilenamePattern: apps-home/saml-engine.log.%d.gz
-      logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
-    - type: logstash-file
-      currentLogFilename: apps-home/logstash/saml-engine.log
-      archivedLogFilenamePattern: apps-home/logstash/saml-engine.log.%d.gz
-      archivedFileCount: 7
     - type: console
       logFormat: '%-5p [%d{ISO8601,UTC}] %c: %X{logPrefix}%m%n%xEx'
 


### PR DESCRIPTION
**Not to be merged until urls, tokens, sources and sourceTypes are received from cyber, and made available from parameter store.**

This is based on @andy-paine's PR to add the SplunkAppenderFactory

It adds the splunk appender to the `EidasResponseAttributesHashLogger` logger so that the logs are send to splunk. From there cyber can compare them to the hashed attribute logs that they're already receiving from the proxy-node.

Closes #249 