### PR TITLE
Trello: PwUqib5x: Increase MSA SOAP response error log level

### DIFF
--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
@@ -74,7 +74,7 @@ public class AttributeQueryRequestClient {
         } catch (SOAPRequestError e) {
             if(e.getEntity().isPresent()) {
                 final String stackTrace = e.getEntity().get();
-                LOG.info(format("Stack trace received from MSA with URI {0} following HTTP response {1}:\n{2}", matchingServiceUri, e.getResponseStatus(), stackTrace));
+                LOG.error(format("Stack trace received from MSA with URI {0} following HTTP response {1}:\n{2}", matchingServiceUri, e.getResponseStatus(), stackTrace));
             }
             throw new MatchingServiceException(format("Matching Service response from {0} was status {1}",
                     matchingServiceUri, e.getResponseStatus()), e);


### PR DESCRIPTION
MSA errors should come back with stack traces. By logging them at an `info` level, they are not being surfaced clearly in monitoring tools. The errors that are thrown as a result don't have the MSA stack trace so it is not always clear what the problem was. This should help.

[Trello card](https://trello.com/c/PwUqib5x/85-improve-hub-re-logging-of-msa-errors)