### PR TITLE
BAU: remove misleading reference to stack trace

### DIFF
--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
@@ -73,8 +73,8 @@ public class AttributeQueryRequestClient {
             }
         } catch (SOAPRequestError e) {
             if(e.getEntity().isPresent()) {
-                final String stackTrace = e.getEntity().get();
-                LOG.info(format("Stack trace received from MSA with URI {0} following HTTP response {1}:\n{2}", matchingServiceUri, e.getResponseStatus(), stackTrace));
+                final String responseBody = e.getEntity().get();
+                LOG.info(format("Error received from MSA (URI '{0}') following HTTP response {1}; response body:\n{2}", matchingServiceUri, e.getResponseStatus(), responseBody));
             }
             throw new MatchingServiceException(format("Matching Service response from {0} was status {1}",
                     matchingServiceUri, e.getResponseStatus()), e);


### PR DESCRIPTION
The variable named "stack trace" can be anything: it is the body of the response from the MSA. So the logs shouldn't explicitly name it as a stack trace as this can be misleading.