### PR TITLE
EID-1422 Hard code splunk config

### DIFF
--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -57,8 +57,8 @@ logging:
           url: ${SPLUNK_URL}
           token: ${SPLUNK_TOKEN}
           source: ${SPLUNK_SOURCE}
-          sourceType: ${SPLUNK_SOURCE_TYPE}
-          index: ${SPLUNK_INDEX}
+          sourceType: verify-hub_saml-engine
+          index: verify_eidas_notification_saml
   level: INFO
   appenders:
     - type: logstash-console


### PR DESCRIPTION
The splunk sourceType and index are remaining static across all the
environments, which means we can just add them to the config rather than
inject them in as env variables.

This also changes the sourceType we're using as they can only contain
[a-z0-9_]. This one is provided by cyber.