### PR TITLE
l4zBlwLF: Add config options for self SelfServiceConfig

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigConfiguration.java
@@ -8,6 +8,7 @@ import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.hub.config.configuration.PrometheusClientServiceConfiguration;
+import uk.gov.ida.hub.config.configuration.SelfServiceConfig;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.TrustStoreConfiguration;
 
@@ -51,6 +52,10 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @NotNull
     @JsonProperty
     protected Duration certificateWarningPeriod = Duration.days(30);
+
+    @Valid
+    @JsonProperty
+    protected SelfServiceConfig selfService;
 
     @Valid
     @JsonProperty
@@ -100,6 +105,10 @@ public class ConfigConfiguration extends Configuration implements TrustStoreConf
     @Override
     public boolean isPrometheusEnabled() {
         return true;
+    }
+
+    public SelfServiceConfig getSelfService() {
+        return selfService;
     }
 
     public PrometheusClientServiceConfiguration getCertificateExpiryDateCheckServiceConfiguration() {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/configuration/SelfServiceConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/configuration/SelfServiceConfig.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.hub.config.configuration;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SelfServiceConfig {
+
+    @Valid
+    @JsonProperty
+    private boolean enabled = false;
+
+    @Valid
+    @JsonProperty
+    private URI source;
+
+    @SuppressWarnings("unused")
+    public SelfServiceConfig() { }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public URI getSource() {
+        return source;
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfig.java
@@ -112,6 +112,11 @@ public class TransactionConfig implements EntityIdentifiable, CertificateConfigu
     @JsonProperty
     protected boolean eidasProxyNode;
 
+    @Valid
+    @JsonProperty
+    protected boolean selfService = false;
+
+
     @SuppressWarnings("unused") // needed to prevent guice injection
     protected TransactionConfig() {
     }
@@ -243,4 +248,9 @@ public class TransactionConfig implements EntityIdentifiable, CertificateConfigu
     public boolean isEidasProxyNode() {
         return eidasProxyNode;
     }
+
+    public boolean isSelfService() {
+        return selfService;
+    }
+
 }


### PR DESCRIPTION
* Added self service section to the configuration of the config service
  itself to configure enabling self service globaly and provide the source
  URL that the self service data will be availible from.

* Added selfService option to the transaction config, so enable self
  service for that service.