### PR TITLE
BAU: Investigate why Codacy test reporting is failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ cache:
     - "$HOME/.gradle/wrapper/"
 after_success:
   - "./gradlew jacocoRootReport"
-  - curl -Ls -o codacy-coverage-reporter-assembly.jar $(curl -Ls https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url')
+  - curl -LSs -o codacy-coverage-reporter-assembly.jar $(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url')
   - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml


### PR DESCRIPTION
Codacy test reporting has been failing since 3 May. Added the `-S` flag to `curl` so it will show error messages in Travis build logs

From `man curl`: `-s` silences progress bar and error messages. `-S` re-enables error messages.