### PR TITLE
l4zBlwLF: Refactor CertificateService for clarity

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateExpiryDateCheckService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateExpiryDateCheckService.java
@@ -27,7 +27,7 @@ public class CertificateExpiryDateCheckService implements Runnable {
     @Override
     public void run() {
         try {
-            final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+            final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificateDetails();
             final double timestamp = DateTime.now(DateTimeZone.UTC).getMillis();
             certificateDetailsSet.forEach(certificateDetails -> {
                 try {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
@@ -21,9 +21,8 @@ import java.util.stream.Stream;
 
 public class CertificateService <T extends EntityIdentifiable & CertificateConfigurable> {
 
-    private final List<ConfigRepository<T>> configRepositories =new ArrayList<>();
+    private final List<ConfigRepository<T>> configRepositories = new ArrayList<>();
     private CertificateValidityChecker certificateValidityChecker;
-//    private static final Logger LOG = LoggerFactory.getLogger(CertificateService.class);
 
     @Inject
     public CertificateService(

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
@@ -1,119 +1,107 @@
 package uk.gov.ida.hub.config.application;
 
 import com.google.inject.Inject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.gov.ida.hub.config.domain.CertificateConfigurable;
-import uk.gov.ida.hub.config.domain.EntityIdentifiable;
 import uk.gov.ida.hub.config.data.ConfigRepository;
+import uk.gov.ida.hub.config.domain.Certificate;
+import uk.gov.ida.hub.config.domain.CertificateConfigurable;
 import uk.gov.ida.hub.config.domain.CertificateDetails;
 import uk.gov.ida.hub.config.domain.CertificateValidityChecker;
+import uk.gov.ida.hub.config.domain.EntityIdentifiable;
 import uk.gov.ida.hub.config.domain.MatchingServiceConfig;
 import uk.gov.ida.hub.config.domain.TransactionConfig;
 import uk.gov.ida.hub.config.dto.FederationEntityType;
 import uk.gov.ida.hub.config.exceptions.CertificateDisabledException;
 import uk.gov.ida.hub.config.exceptions.NoCertificateFoundException;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toList;
+public class CertificateService <T extends EntityIdentifiable & CertificateConfigurable> {
 
-public class CertificateService {
-
-    private static final List<CertificateDetails> EMPTY = null;
-    private final ConfigRepository<TransactionConfig> transactionDataSource;
-    private final ConfigRepository<MatchingServiceConfig> matchingServiceDataSource;
-    private CertificateValidityChecker certificateValidityChecker = null;
-
-    private final Function<String, Optional<CertificateDetails>> getTransactionEncryptionCert;
-    private final Function<String, Optional<CertificateDetails>> getMatchingServiceEncryptionCert;
-    private final Function<String, Optional<List<CertificateDetails>>> getTransactionSignatureCert;
-    private final Function<String, Optional<List<CertificateDetails>>> getMatchingServiceSignatureCert;
-
-    private static final Logger LOG = LoggerFactory.getLogger(CertificateService.class);
+    private final List<ConfigRepository<T>> configRepositories =new ArrayList<>();
+    private CertificateValidityChecker certificateValidityChecker;
+//    private static final Logger LOG = LoggerFactory.getLogger(CertificateService.class);
 
     @Inject
     public CertificateService(
-            ConfigRepository<TransactionConfig> transactionDataSource,
-            ConfigRepository<MatchingServiceConfig> matchingServiceDataSource,
+            ConfigRepository<TransactionConfig> transactionConfigRepository,
+            ConfigRepository<MatchingServiceConfig> matchingServiceConfigRepository,
             CertificateValidityChecker certificateValidityChecker) {
-        this.transactionDataSource = transactionDataSource;
-        this.matchingServiceDataSource = matchingServiceDataSource;
+        this.configRepositories.add((ConfigRepository<T>)transactionConfigRepository);
+        this.configRepositories.add((ConfigRepository<T>)matchingServiceConfigRepository);
         this.certificateValidityChecker = certificateValidityChecker;
-
-        getTransactionEncryptionCert = encryptiondataSource.apply(transactionDataSource, FederationEntityType.RP);
-        getMatchingServiceEncryptionCert = encryptiondataSource.apply(matchingServiceDataSource, FederationEntityType.MS);
-        getTransactionSignatureCert = signatureDataSource.apply(transactionDataSource, FederationEntityType.RP);
-        getMatchingServiceSignatureCert = signatureDataSource.apply(matchingServiceDataSource, FederationEntityType.MS);
     }
 
-    public CertificateDetails encryptionCertificateFor(String entityId) {
-        CertificateDetails certificateDetails = getTransactionEncryptionCert.apply(entityId)
-                .orElseGet(() -> getMatchingServiceEncryptionCert.apply(entityId)
-                .orElseThrow(() -> new NoCertificateFoundException()));
+    public Set<CertificateDetails> getAllCertificateDetails() {
+        return configRepositories.stream()
+                .flatMap(this::getAllCertificateDetails)
+                .collect(Collectors.toSet());
+    }
 
-        if (certificateDetails.isNotEnabled()) {
+    public  CertificateDetails encryptionCertificateFor(String entityId) {
+        T config = getConfig(entityId);
+        CertificateDetails certDetails = createCertificateDetails(config, config.getEncryptionCertificate());
+        if (!certificateValidityChecker.isValid(certDetails)){
+            throw new NoCertificateFoundException();
+        }
+        if (certDetails.isNotEnabled()){
             throw new CertificateDisabledException();
         }
-
-        return certificateDetails;
+        return certDetails;
     }
 
-    public Set<CertificateDetails> getAllCertificatesDetails() {
-        Set<CertificateDetails> certificateDetailsSet = new HashSet<>();
-        certificateDetailsSet.addAll(getCertificatesDetailsSet(transactionDataSource, FederationEntityType.RP));
-        certificateDetailsSet.addAll(getCertificatesDetailsSet(matchingServiceDataSource, FederationEntityType.MS));
-        return certificateDetailsSet;
+    public List<CertificateDetails> signatureVerificationCertificatesFor(String entityId) {
+        T config = getConfig(entityId);
+        return config.getSignatureVerificationCertificates()
+                .stream()
+                .map(cert -> createCertificateDetails(config, cert))
+                .filter(cd -> certificateValidityChecker.isValid(cd))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), this::throwIfEmpty));
     }
 
-    private <T extends EntityIdentifiable & CertificateConfigurable> Set<CertificateDetails> getCertificatesDetailsSet(final ConfigRepository<T> configRepository,
-                                                                                                                       final FederationEntityType federationEntityType) {
-        Set<CertificateDetails> certificateDetailsSet = new HashSet<>();
-        final Set<T> configs = configRepository.getAllData();
-        configs.forEach(
-            config -> {
-                config.getSignatureVerificationCertificates()
-                      .forEach(certificate -> certificateDetailsSet.add(new CertificateDetails(
-                          config.getEntityId(),
-                          certificate,
-                          federationEntityType,
-                          config.isEnabled())));
-                certificateDetailsSet.add(new CertificateDetails(
-                    config.getEntityId(),
-                    config.getEncryptionCertificate(),
-                    federationEntityType,
-                    config.isEnabled()));
-            });
-        return certificateDetailsSet;
+    private List<CertificateDetails> throwIfEmpty(List<CertificateDetails> list){
+        if (list.isEmpty()){
+            throw new NoCertificateFoundException();
+        }
+        return list;
     }
 
-    public List<CertificateDetails> signatureVerificatonCertificatesFor(String entityId) {
-        return getTransactionSignatureCert.apply(entityId)
-                .orElseGet(() -> getMatchingServiceSignatureCert.apply(entityId)
-                .orElseThrow(() -> new NoCertificateFoundException()));
+    private Stream<CertificateDetails> getAllCertificateDetails(ConfigRepository<T> configRepository) {
+        return configRepository.getAllData()
+                .stream()
+                .flatMap(this::getAllCertificateDetails);
     }
 
-    private BiFunction<ConfigRepository<? extends CertificateConfigurable>, FederationEntityType,
-            Function<String, Optional<CertificateDetails>>> encryptiondataSource =
-            (certEntityRepo, fedType) -> entityId ->
-                    certEntityRepo.getData(entityId)
-                    .map(cert -> new CertificateDetails(entityId, cert.getEncryptionCertificate(), fedType, cert.isEnabled()))
-                    .filter(cert -> certificateValidityChecker.isValid(cert));
+    private Stream<CertificateDetails> getAllCertificateDetails(T config){
+        List<CertificateDetails> certDetails = config.getSignatureVerificationCertificates()
+                .stream()
+                .map(cert -> createCertificateDetails(config, cert))
+                .collect(Collectors.toList());
+        certDetails.add(createCertificateDetails(config, config.getEncryptionCertificate()));
+        return certDetails.stream();
+    }
 
-    private BiFunction<ConfigRepository<? extends CertificateConfigurable>, FederationEntityType,
-            Function<String, Optional<List<CertificateDetails>>>> signatureDataSource =
-            (certEntityRepo, fedType) -> entityId ->
-                certEntityRepo.getData(entityId)
-                .map(cert -> cert.getSignatureVerificationCertificates())
-                .map(sigCerts -> sigCerts.stream()
-                        .map(cert -> new CertificateDetails(entityId, cert, fedType))
-                        .filter(certDetail -> certificateValidityChecker.isValid(certDetail))
-                        .collect(collectingAndThen(toList(), certDetailsList -> certDetailsList.isEmpty() ? EMPTY : certDetailsList)));
+    private CertificateDetails createCertificateDetails(T config, Certificate certificate){
+        return new CertificateDetails(
+                config.getEntityId(),
+                certificate,
+                getType(config),
+                config.isEnabled());
+    }
+
+    private T getConfig(String entityId){
+        return configRepositories.stream()
+                .filter(repo -> repo.containsKey(entityId))
+                .findFirst()
+                .orElseThrow(NoCertificateFoundException::new)
+                .getData(entityId)
+                .get();
+    }
+
+    private FederationEntityType getType(T config) {
+        return config instanceof TransactionConfig ? FederationEntityType.RP : FederationEntityType.MS;
+    }
 }
-

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationService.java
@@ -33,7 +33,7 @@ public class OcspCertificateChainValidationService implements Runnable {
     @Override
     public void run() {
         try {
-            final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificatesDetails();
+            final Set<CertificateDetails> certificateDetailsSet = certificateService.getAllCertificateDetails();
             final double timestamp = DateTime.now(DateTimeZone.UTC).getMillis();
             certificateDetailsSet.forEach(certificateDetails -> {
                 try {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigRepository.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigRepository.java
@@ -18,6 +18,10 @@ public class ConfigRepository<T extends EntityIdentifiable> {
     public ConfigRepository() {
     }
 
+    public boolean containsKey(String entityId){
+        return dataMap.containsKey(entityId);
+    }
+
     public Optional<T> getData(String entityId) {
         return Optional.ofNullable(dataMap.get(entityId));
     }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CertificatesResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CertificatesResource.java
@@ -91,7 +91,7 @@ public class CertificatesResource {
     public Collection<CertificateDto> getSignatureVerificationCertificates(
             @PathParam(Urls.SharedUrls.ENTITY_ID_PARAM) String entityId) {
         try {
-            List<CertificateDetails> certificateDetails = certificateService.signatureVerificatonCertificatesFor(entityId);
+            List<CertificateDetails> certificateDetails = certificateService.signatureVerificationCertificatesFor(entityId);
             return certificateDetails.stream()
                     .map(details -> aCertificateDto(
                             entityId,

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
@@ -64,6 +64,7 @@ public class CertificateServiceTest {
                 .withEnabled(true)
                 .build();
 
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(transactionConfig));
         when(certificateValidityChecker.isValid(any(CertificateDetails.class))).thenReturn(true);
 
@@ -80,7 +81,7 @@ public class CertificateServiceTest {
                 .withEnabled(true)
                 .build();
 
-        when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(transactionConfig));
         when(certificateValidityChecker.isValid(any(CertificateDetails.class))).thenReturn(false);
 
@@ -93,7 +94,8 @@ public class CertificateServiceTest {
                 .withEntityId(RP_ONE_ENTITY_ID)
                 .build();
 
-        when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
+        when(matchingServiceDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(matchingServiceConfig));
         when(certificateValidityChecker.isValid(any(CertificateDetails.class))).thenReturn(true);
 
@@ -109,7 +111,8 @@ public class CertificateServiceTest {
                 .withEntityId(RP_ONE_ENTITY_ID)
                 .build();
 
-        when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
+        when(matchingServiceDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(matchingServiceConfig));
         when(certificateValidityChecker.isValid(any(CertificateDetails.class))).thenReturn(false);
 
@@ -119,8 +122,8 @@ public class CertificateServiceTest {
 
     @Test(expected = NoCertificateFoundException.class)
     public void throwsNotFoundException_WhenNoEncryptionCertificateExists() {
-        when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
-        when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
+        when(matchingServiceDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
 
         certificateService.encryptionCertificateFor(RP_ONE_ENTITY_ID);
     }
@@ -132,6 +135,7 @@ public class CertificateServiceTest {
                 .withEnabled(false)
                 .build();
 
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(transactionConfig));
         when(certificateValidityChecker.isValid(any(CertificateDetails.class))).thenReturn(true);
 
@@ -149,10 +153,11 @@ public class CertificateServiceTest {
                 .addSignatureVerificationCertificate(sigCert2)
                 .build();
 
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(transactionConfig));
         when(certificateValidityChecker.isValid(any(CertificateDetails.class))).thenReturn(true);
 
-        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificatonCertificatesFor(RP_ONE_ENTITY_ID);
+        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificationCertificatesFor(RP_ONE_ENTITY_ID);
 
         assertThat(certificateDetailsFound.size()).isEqualTo(2);
         assertThat(certificateDetailsFound).contains(aCertifcateDetail(RP_ONE_ENTITY_ID, sigCert1, FederationEntityType.RP),
@@ -173,11 +178,12 @@ public class CertificateServiceTest {
         CertificateDetails validCertificate = aCertifcateDetail(RP_ONE_ENTITY_ID, validCert, FederationEntityType.RP);
         CertificateDetails invalidCertificate = aCertifcateDetail(RP_ONE_ENTITY_ID, invalidCert, FederationEntityType.RP);
 
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(transactionConfig));
         when(certificateValidityChecker.isValid(invalidCertificate)).thenReturn(false);
         when(certificateValidityChecker.isValid(validCertificate)).thenReturn(true);
 
-        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificatonCertificatesFor(RP_ONE_ENTITY_ID);
+        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificationCertificatesFor(RP_ONE_ENTITY_ID);
 
         assertThat(certificateDetailsFound.size()).isEqualTo(1);
         assertThat(certificateDetailsFound.get(0)).isEqualTo(validCertificate);
@@ -194,11 +200,12 @@ public class CertificateServiceTest {
                 .addSignatureVerificationCertificate(sigCert2)
                 .build();
 
-        when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
+        when(matchingServiceDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(matchingServiceConfig));
         when(certificateValidityChecker.isValid(any(CertificateDetails.class))).thenReturn(true);
 
-        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificatonCertificatesFor(RP_ONE_ENTITY_ID);
+        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificationCertificatesFor(RP_ONE_ENTITY_ID);
 
         assertThat(certificateDetailsFound.size()).isEqualTo(2);
         assertThat(certificateDetailsFound).contains(aCertifcateDetail(RP_ONE_ENTITY_ID, sigCert1, FederationEntityType.MS),
@@ -219,12 +226,13 @@ public class CertificateServiceTest {
         CertificateDetails validCertificate = new CertificateDetails(RP_ONE_ENTITY_ID, validSigCert, FederationEntityType.MS);
         CertificateDetails invalidCertificate = new CertificateDetails(RP_ONE_ENTITY_ID, invalidSigCert, FederationEntityType.MS);
 
-        when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
+        when(matchingServiceDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(matchingServiceConfig));
         when(certificateValidityChecker.isValid(invalidCertificate)).thenReturn(false);
         when(certificateValidityChecker.isValid(validCertificate)).thenReturn(true);
 
-        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificatonCertificatesFor(RP_ONE_ENTITY_ID);
+        List<CertificateDetails> certificateDetailsFound = certificateService.signatureVerificationCertificatesFor(RP_ONE_ENTITY_ID);
 
         assertThat(certificateDetailsFound.size()).isEqualTo(1);
         assertThat(certificateDetailsFound.get(0)).isEqualTo(validCertificate);
@@ -241,19 +249,20 @@ public class CertificateServiceTest {
 
         CertificateDetails invalidCertificate = new CertificateDetails(RP_ONE_ENTITY_ID, invalidSigCert, FederationEntityType.MS);
 
-        when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
+        when(matchingServiceDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(true);
         when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.of(matchingServiceConfig));
         when(certificateValidityChecker.isValid(invalidCertificate)).thenReturn(false);
 
-        certificateService.signatureVerificatonCertificatesFor(RP_ONE_ENTITY_ID);
+        certificateService.signatureVerificationCertificatesFor(RP_ONE_ENTITY_ID);
     }
 
     @Test(expected = NoCertificateFoundException.class)
     public void throwsNoCertificateFoundException_WhenMatchingSignatureCertificatesDoNotExist() {
-        when(transactionDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
-        when(matchingServiceDataSource.getData(RP_ONE_ENTITY_ID)).thenReturn(Optional.empty());
+        when(transactionDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
+        when(matchingServiceDataSource.containsKey(RP_ONE_ENTITY_ID)).thenReturn(false);
 
-        certificateService.signatureVerificatonCertificatesFor(RP_ONE_ENTITY_ID);
+        certificateService.signatureVerificationCertificatesFor(RP_ONE_ENTITY_ID);
     }
 
     @Test
@@ -279,7 +288,7 @@ public class CertificateServiceTest {
         when(transactionDataSource.getAllData()).thenReturn(transactionConfigs);
         when(matchingServiceDataSource.getAllData()).thenReturn(matchingServiceConfigs);
 
-        final Set<CertificateDetails> actualCertificateDetailsSet = certificateService.getAllCertificatesDetails();
+        final Set<CertificateDetails> actualCertificateDetailsSet = certificateService.getAllCertificateDetails();
 
         assertThat(actualCertificateDetailsSet.size()).isEqualTo(6);
         assertThat(actualCertificateDetailsSet).containsAll(expectedCertificateDetailsSet);


### PR DESCRIPTION
The existing CertificateService was difficult to understand. This refactor simplifies the code so we can build out the functionality to retrieve certificates from remote repositories.