### PR TITLE
use latest verify-saml-libs compiled with java 8 compile target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-37',
-            saml_lib:"$opensaml_version-190",
+            saml_lib:"$opensaml_version-192",
         ]
 
 subprojects {


### PR DESCRIPTION
The latest (`192`) build of `verify-saml-libs` is compiled using OpenJDK-11, but with a java 8 compile target.

This makes the library compatible with dependents like `verify-matching-service-adapter`, which might be compiled with Java 8.

Although `Hub` is now compiled against Java 11, this PR bumps the version of `verify-saml-libs` to track the latest release of `verify-saml-libs`.

This PR follow on from alphagov/verify-saml-libs#63