### PR TITLE
ZD3679369: record unhealthy MSA info

### DIFF
--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
@@ -249,7 +249,7 @@ public class PrometheusMetricsIntegrationTest {
             MSA_HEALTH_METRICS_TEMPLATE, VERIFY_SAML_SOAP_PROXY_MSA_HEALTH_STATUS_LAST_UPDATED,
             msa.getAttributeQueryRequestUri(),
             (double) DateTime.now(DateTimeZone.UTC).getMillis()));
-        assertThat(entity).doesNotContain(String.format(VERIFY_SAML_SOAP_PROXY_MSA_INFO + "{matchingService=\"%s\",", msa.getAttributeQueryRequestUri()));
+        assertThat(entity).contains(String.format(VERIFY_SAML_SOAP_PROXY_MSA_INFO + "{matchingService=\"%s\",", msa.getAttributeQueryRequestUri()));
     }
 
     private void assertThatAHealthyMsaHasBothCorrectHealthAndInfoMetrics(final String entity,

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckTask.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckTask.java
@@ -38,18 +38,11 @@ public class MatchingServiceHealthCheckTask implements Callable<String> {
         try {
             final MatchingServiceHealthCheckResult matchingServiceHealthCheckResult = matchingServiceHealthChecker.performHealthCheck(matchingServiceConfig);
             final double timestamp = DateTime.now(DateTimeZone.UTC).getMillis();
-            if (matchingServiceHealthCheckResult.isHealthy()) {
-                infoMetric.recordDetails(matchingServiceHealthCheckResult.getDetails());
-                healthStatusGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
-                                 .set(HEALTHY);
-                healthStatusLastUpdatedGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
-                                            .set(timestamp);
-            } else {
-                healthStatusGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
-                                 .set(UNHEALTHY);
-                healthStatusLastUpdatedGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
-                                            .set(timestamp);
-            }
+            infoMetric.recordDetails(matchingServiceHealthCheckResult.getDetails());
+            healthStatusGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
+                    .set(matchingServiceHealthCheckResult.isHealthy() ? HEALTHY : UNHEALTHY);
+            healthStatusLastUpdatedGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
+                    .set(timestamp);
         } catch (Exception e) {
             LOG.warn(e.getMessage());
         }


### PR DESCRIPTION
Ensure that MSAs that have been unhealthy for a long time still appear on the Grafana dashboard. Some info fields will be empty (e.g. version), but that's probably better than nothing.

See https://govuk.zendesk.com/agent/tickets/3679369