### PR TITLE
EID-1422 Use Verify's fork of Splunk logging library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ subprojects {
         redis('io.lettuce:lettuce-core:5.1.4.RELEASE')
         redis_test('com.github.kstyrc:embedded-redis:0.6')
 
-        splunk('com.splunk.logging:splunk-library-javalogging:1.6.2')
+        splunk('uk.gov.ida:splunk-library-javalogging:1.1.0')
     }
 }
 

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerProxyTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/SplunkLoggerProxyTest.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.integrationtest.hub.samlengine.apprule;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import httpstub.HttpStubRule;
+import httpstub.RecordedRequest;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.integrationtest.hub.samlengine.apprule.support.SamlEngineAppRule;
+
+import java.io.IOException;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SplunkLoggerProxyTest {
+
+    private static final String TOKEN = "SomeToken";
+    private static final String SOURCE = "SplunkLoggerTest";
+    private static final String SOURCE_TYPE = "IntegrationTest";
+    private static final String INDEX = "SplunkIndex";
+    private static final String SPLUNK_URL = "http://splunk.example.com";
+    private static final String SPLUNK_EVENT_ENDPOINT = "/services/collector/event/1.0";
+
+    @ClassRule
+    public static HttpStubRule proxyStub = new HttpStubRule();
+
+    @ClassRule
+    public static SamlEngineAppRule samlEngineAppRule = new SamlEngineAppRule(
+        proxyStub.baseUri().build().getHost(),
+        Integer.toString(proxyStub.getPort()),
+        config("logging.appenders[0].type", "splunk"),
+        config("logging.appenders[0].url", SPLUNK_URL),
+        config("logging.appenders[0].token", TOKEN),
+        config("logging.appenders[0].source", SOURCE),
+        config("logging.appenders[0].sourceType", SOURCE_TYPE),
+        config("logging.appenders[0].index", INDEX)
+    );
+
+    @AfterClass
+    public static void clearSystemProxyProperties() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+    }
+
+    @Test
+    public void shouldSendLogsViaProxyIfConfigured() throws IOException {
+        RecordedRequest lastRequest = proxyStub.getLastRequest();
+        JsonNode requestBody = new ObjectMapper().readTree(lastRequest.getEntityBytes());
+
+        assertThat(lastRequest.getUrl()).isEqualTo(SPLUNK_URL + SPLUNK_EVENT_ENDPOINT);
+        assertThat(lastRequest.getHeader("Authorization")).contains(TOKEN);
+        assertThat(requestBody.get("source").asText()).isEqualTo(SOURCE);
+        assertThat(requestBody.get("sourcetype").asText()).isEqualTo(SOURCE_TYPE);
+        assertThat(requestBody.get("index").asText()).isEqualTo(INDEX);
+    }
+}

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -49,13 +49,10 @@ import static com.google.common.base.Throwables.propagate;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_PRIVATE_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.TestEntityIds.HUB_ENTITY_ID;
 import static uk.gov.ida.saml.metadata.ResourceEncoder.entityIdAsResource;
 
@@ -85,12 +82,24 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
     public SamlEngineAppRule(boolean isCountryEnabled, ConfigOverride... configOverrides) {
         super(SamlEngineIntegrationApplication.class,
                 ResourceHelpers.resourceFilePath("saml-engine.yml"),
-                withDefaultOverrides(isCountryEnabled, configOverrides)
+                withDefaultOverrides(isCountryEnabled, null, null, configOverrides)
         );
         BootstrapUtils.reset();
     }
 
-    public static ConfigOverride[] withDefaultOverrides(boolean isCountryEnabled, ConfigOverride ... configOverrides) {
+    public SamlEngineAppRule(String proxyHost, String proxyPort, ConfigOverride... configOverrides) {
+        super(SamlEngineIntegrationApplication.class,
+            ResourceHelpers.resourceFilePath("saml-engine.yml"),
+            withDefaultOverrides(true, proxyHost, proxyPort, configOverrides)
+        );
+        BootstrapUtils.reset();
+    }
+
+    public static ConfigOverride[] withDefaultOverrides(boolean isCountryEnabled, String proxyHost, String proxyPort, ConfigOverride ... configOverrides) {
+        if (proxyHost != null && proxyPort != null) {
+            System.setProperty("http.proxyHost", proxyHost);
+            System.setProperty("http.proxyPort", proxyPort);
+        }
         List<ConfigOverride> overrides = Stream.of(
                 config("saml.entityId", HUB_ENTITY_ID),
                 config("saml.expectedDestination", "http://localhost"),

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/SplunkAppenderFactory.java
@@ -53,8 +53,14 @@ public class SplunkAppenderFactory extends AbstractAppenderFactory<ILoggingEvent
         appender.setbatch_size_count(batchSizeCount.toString());
         appender.setLayout(buildLayout(context, layoutFactory));
         appender.addFilter(levelFilterFactory.build(threshold));
+        appender.setHttpProxyHost(System.getProperty("http.proxyHost"));
+        appender.setHttpProxyPort(getProxyPortIntFromSystem());
         appender.start();
 
         return wrapAsync(appender, asyncAppenderFactory, context);
+    }
+
+    private int getProxyPortIntFromSystem() {
+        return (System.getProperty("http.proxyPort") != null) ? Integer.parseInt(System.getProperty("http.proxyPort")) : 0;
     }
 }


### PR DESCRIPTION
We've forked Splunk's java logging library so that we can add the
ability to configure the proxy to use. The library uses an Apache http
client under the hood, and it doesn't use the java system properties by
default like the Jersey clients the apps use. The library offers no way
to configure the proxy; this is what was added by our fork. Hopefully we
can get the changes merged upstream.