### PR TITLE
Clean out old healthcheck version mechanism

### DIFF
--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceHealthCheckIntegrationTests.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceHealthCheckIntegrationTests.java
@@ -117,7 +117,8 @@ public class MatchingServiceHealthCheckIntegrationTests {
     @Test
     public void healthCheck_shouldRespondWith200WhenAllMatchingServicesHealthy() throws Exception {
         configStub.setUpStubForMatchingServiceHealthCheckRequest(msaStubRule1.getAttributeQueryRequestUri(), msaEntityId2);
-        msaStubRule1.prepareForHealthCheckRequest(aHealthyHealthCheckResponse(msaEntityId2), msaVersion2);
+        String healthCheckResponse = aHealthyHealthCheckResponse(msaEntityId2, msaVersion2);
+        msaStubRule1.prepareForHealthCheckRequest(healthCheckResponse);
         samlEngineStub.prepareForHealthCheckSamlGeneration();
         samlEngineStub.setupStubForAttributeResponseTranslate(anInboundResponseFromMatchingServiceDto()
                 .withIssuer(msaEntityId2)
@@ -151,13 +152,13 @@ public class MatchingServiceHealthCheckIntegrationTests {
     public void healthCheck_shouldRespondWith500WhenAllMatchingServicesAreNotHealthy() throws Exception {
         configStub.setUpStubForTwoMatchingServiceHealthCheckRequests(msaStubRule1.getAttributeQueryRequestUri(), msaEntityId,
                 msaStubRule2.getAttributeQueryRequestUri(), msaEntityId2);
-
-        msaStubRule1.prepareForHealthCheckRequest(anUnhealthyHealthCheckResponse(msaEntityId), msaVersion);
+        
+        msaStubRule1.prepareForHealthCheckRequest(anUnhealthyHealthCheckResponse(msaEntityId, msaVersion));
         samlEngineStub.prepareForHealthCheckSamlGeneration();
         samlEngineStub.setupStubForAttributeResponseTranslateReturningError(ErrorStatusDto.createAuditedErrorStatus(UUID.randomUUID(),
                 ExceptionType.INVALID_SAML));
 
-        msaStubRule2.prepareForHealthCheckRequest(aHealthyHealthCheckResponse(msaEntityId2), msaVersion2);
+        msaStubRule2.prepareForHealthCheckRequest(aHealthyHealthCheckResponse(msaEntityId2, msaVersion2));
         samlEngineStub.prepareForHealthCheckSamlGeneration();
         samlEngineStub.setupStubForAttributeResponseTranslateReturningError(ErrorStatusDto.createAuditedErrorStatus(UUID.randomUUID(),
                 ExceptionType.INVALID_SAML));
@@ -182,12 +183,12 @@ public class MatchingServiceHealthCheckIntegrationTests {
         configStub.setUpStubForTwoMatchingServiceHealthCheckRequests(msaStubRule1.getAttributeQueryRequestUri(), msaEntityId,
                 msaStubRule2.getAttributeQueryRequestUri(), msaEntityId2);
 
-        msaStubRule1.prepareForHealthCheckRequest(anUnhealthyHealthCheckResponse(msaEntityId), msaVersion);
+        msaStubRule1.prepareForHealthCheckRequest(anUnhealthyHealthCheckResponse(msaEntityId, msaVersion));
         samlEngineStub.prepareForHealthCheckSamlGeneration();
         samlEngineStub.setupStubForAttributeResponseTranslateReturningError(ErrorStatusDto.createAuditedErrorStatus(UUID.randomUUID(),
                 ExceptionType.INVALID_SAML));
 
-        msaStubRule2.prepareForHealthCheckRequest(aHealthyHealthCheckResponse(msaEntityId2), msaVersion2);
+        msaStubRule2.prepareForHealthCheckRequest(aHealthyHealthCheckResponse(msaEntityId2, msaVersion2));
         samlEngineStub.prepareForHealthCheckSamlGeneration();
         samlEngineStub.setupStubForAttributeResponseTranslate(anInboundResponseFromMatchingServiceDto()
                 .withIssuer(msaEntityId2)
@@ -208,7 +209,7 @@ public class MatchingServiceHealthCheckIntegrationTests {
 
     }
 
-    private String anUnhealthyHealthCheckResponse(String msaEntityId) throws Base64DecodingException {
+    private String anUnhealthyHealthCheckResponse(String msaEntityId, String msaVersion) throws Base64DecodingException {
         Function<HealthCheckResponseFromMatchingService, Element> transformer = new MsaTransformersFactory().getHealthcheckResponseFromMatchingServiceToElementTransformer(
                 null,
                 getKeyStore(),
@@ -217,6 +218,7 @@ public class MatchingServiceHealthCheckIntegrationTests {
                 DIGEST_ALGORITHM
         );
         final HealthCheckResponseFromMatchingService healthCheckResponse = new HealthCheckResponseFromMatchingService(
+                "response-id-123-version-"+msaVersion,
                 msaEntityId,
                 "request-id"
         );
@@ -224,7 +226,7 @@ public class MatchingServiceHealthCheckIntegrationTests {
         return XmlUtils.writeToString(soapMessageManager.wrapWithSoapEnvelope(healthyResponse));
     }
 
-    private String aHealthyHealthCheckResponse(String msaEntityId) throws Base64DecodingException {
+    private String aHealthyHealthCheckResponse(String msaEntityId, String msaVersion) throws Base64DecodingException {
         Function<uk.gov.ida.saml.msa.test.outbound.HealthCheckResponseFromMatchingService, Element> transformer = new MsaTransformersFactory().getHealthcheckResponseFromMatchingServiceToElementTransformer(
                 null,
                 getKeyStore(),
@@ -233,6 +235,7 @@ public class MatchingServiceHealthCheckIntegrationTests {
                 DIGEST_ALGORITHM
         );
         final HealthCheckResponseFromMatchingService healthCheckResponse = new HealthCheckResponseFromMatchingService(
+                "response-id-123-version-"+msaVersion,
                 msaEntityId,
                 "request-id"
         );

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
@@ -159,9 +159,9 @@ public class PrometheusMetricsIntegrationTest {
         final MatchingServiceDetails msaFourDetails = new MatchingServiceDetails(
             msaStubFour.getAttributeQueryRequestUri(), MSA_FOUR_ENTITY_ID, RP_FOUR_ENTITY_ID);
         Set<MatchingServiceDetails> msaDetailsSet = new HashSet<>(Sets.newHashSet(msaOneDetails, msaTwoDetails, msaThreeDetails, msaFourDetails));
-        final Element msaOneResponse = aHealthyHealthCheckResponse(MSA_ONE_ENTITY_ID, MSA_ONE_RESPONSE_ID);
-        final Element msaTwoResponse = aHealthyHealthCheckResponse(MSA_TWO_ENTITY_ID, MSA_TWO_RESPONSE_ID);
-        final Element msaFourResponse = aHealthyHealthCheckResponse(MSA_FOUR_ENTITY_ID, MSA_FOUR_RESPONSE_ID);
+        final Element msaOneResponse = aHealthyHealthCheckResponse(MSA_ONE_ENTITY_ID, MSA_ONE_RESPONSE_ID, MSA_ONE_VERSION);
+        final Element msaTwoResponse = aHealthyHealthCheckResponse(MSA_TWO_ENTITY_ID, MSA_TWO_RESPONSE_ID, MSA_TWO_VERSION);
+        final Element msaFourResponse = aHealthyHealthCheckResponse(MSA_FOUR_ENTITY_ID, MSA_FOUR_RESPONSE_ID, MSA_FOUR_VERSION);
         final SamlMessageDto msaOneSamlMessage = new SamlMessageDto(encodeAsString(XmlUtils.writeToString(msaOneResponse)));
         final SamlMessageDto msaTwoSamlMessage = new SamlMessageDto(encodeAsString(XmlUtils.writeToString(msaTwoResponse)));
         final SamlMessageDto msaFourSamlMessage = new SamlMessageDto(encodeAsString(XmlUtils.writeToString(msaFourResponse)));
@@ -176,11 +176,11 @@ public class PrometheusMetricsIntegrationTest {
         configStub.setupStubForCertificates(MSA_TWO_ENTITY_ID, TEST_RP_MS_PUBLIC_SIGNING_CERT, TEST_RP_MS_PUBLIC_ENCRYPTION_CERT);
         configStub.setupStubForCertificates(MSA_FOUR_ENTITY_ID, TEST_RP_MS_PUBLIC_SIGNING_CERT, TEST_RP_MS_PUBLIC_ENCRYPTION_CERT);
         msaStubOne.prepareForHealthCheckRequest(
-            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaOneResponse)), MSA_ONE_VERSION);
+            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaOneResponse)));
         msaStubTwo.prepareForHealthCheckRequest(
-            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaTwoResponse)), MSA_TWO_VERSION);
+            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaTwoResponse)));
         msaStubFour.prepareForHealthCheckRequest(
-            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaFourResponse)), MSA_FOUR_VERSION);
+            XmlUtils.writeToString(SOAP_MESSAGE_MANAGER.wrapWithSoapEnvelope(msaFourResponse)));
         samlEngineStub.prepareForHealthCheckSamlGeneration(msaOneHealthCheckerRequest);
         samlEngineStub.prepareForHealthCheckSamlGeneration(msaTwoHealthCheckerRequest);
         samlEngineStub.prepareForHealthCheckSamlGeneration(msaThreeHealthCheckerRequest);
@@ -288,7 +288,7 @@ public class PrometheusMetricsIntegrationTest {
     }
 
     private static Element aHealthyHealthCheckResponse(final String msaEntityId,
-                                                       final String responseId) {
+                                                       final String responseId, String msaVersion) {
         Function<HealthCheckResponseFromMatchingService, Element> transformer = new MsaTransformersFactory().getHealthcheckResponseFromMatchingServiceToElementTransformer(
             null,
             getKeyStore(),
@@ -298,7 +298,7 @@ public class PrometheusMetricsIntegrationTest {
         final HealthCheckResponseFromMatchingService healthCheckResponse = new HealthCheckResponseFromMatchingService(
             responseId,
             msaEntityId,
-            "request-id"
+            "request-id-"+msaVersion
         );
         return transformer.apply(healthCheckResponse);
     }

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/MsaStubRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/MsaStubRule.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
 import httpstub.AbstractHttpStub;
 import httpstub.HttpStub;
 import httpstub.HttpStubRule;
@@ -33,12 +32,11 @@ public class MsaStubRule extends HttpStubRule {
         register(ATTRIBUTE_QUERY_RESOURCE, Response.Status.OK.getStatusCode(), response);
     }
 
-    public void prepareForHealthCheckRequest(String response, String msaVersion) {
+    public void prepareForHealthCheckRequest(String response) {
         RegisteredResponse registeredResponse = aRegisteredResponse()
                 .withStatus(Response.Status.OK.getStatusCode())
                 .withContentType(MediaType.TEXT_XML_TYPE.toString())
                 .withBody(response)
-                .withHeaders(ImmutableMap.of("ida-msa-version", msaVersion))
                 .build();
         register(ATTRIBUTE_QUERY_RESOURCE, registeredResponse);
     }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/HealthCheckSoapRequestClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/HealthCheckSoapRequestClient.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlsoapproxy.client;
 
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -20,7 +19,6 @@ import java.util.UUID;
 
 public class HealthCheckSoapRequestClient extends SoapRequestClient {
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckSoapRequestClient.class);
-    private static final String MSA_VERSION_HTTP_HEADER = "ida-msa-version";
 
     @Inject
     public HealthCheckSoapRequestClient(SoapMessageManager soapMessageManager, @Named("HealthCheckClient") Client client) {
@@ -30,17 +28,14 @@ public class HealthCheckSoapRequestClient extends SoapRequestClient {
     public HealthCheckResponse makeSoapRequestForHealthCheck(Element requestElement, URI uri) {
         LOG.info(MessageFormat.format("Making SOAP request to: {0}", uri));
 
-        SoapResponse response;
         try {
-            response = makePost(uri, requestElement);
+            SoapResponse response = makePost(uri, requestElement);
+            return new HealthCheckResponse(response.getBody());
         } catch(ProcessingException e) {
             throw ApplicationException.createUnauditedException(ExceptionType.NETWORK_ERROR, UUID.randomUUID(), e);
         } catch (SOAPRequestError e) {
-            throw ApplicationException.createUnauditedException(ExceptionType.REMOTE_SERVER_ERROR, UUID.randomUUID(),
-                    e);
+            throw ApplicationException.createUnauditedException(ExceptionType.REMOTE_SERVER_ERROR, UUID.randomUUID(), e);
         }
-
-        return new HealthCheckResponse(response.getBody(), Optional.ofNullable(response.getHeaders().getFirst(MSA_VERSION_HTTP_HEADER)));
     }
 
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/MatchingServiceHealthCheckClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/MatchingServiceHealthCheckClient.java
@@ -2,7 +2,6 @@ package uk.gov.ida.hub.samlsoapproxy.client;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -14,6 +13,7 @@ import uk.gov.ida.shared.utils.xml.XmlUtils;
 import javax.inject.Inject;
 import java.net.URI;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 public class MatchingServiceHealthCheckClient {
 
@@ -42,13 +42,12 @@ public class MatchingServiceHealthCheckClient {
         } catch(ApplicationException ex) {
             final String errorMessage = MessageFormat.format("Failed to complete matching service health check to {0}.", matchingServiceUri);
             LOG.warn(errorMessage, ex);
-            return new MatchingServiceHealthCheckResponseDto(Optional.<String>empty(), Optional.<String>empty());
+            return new MatchingServiceHealthCheckResponseDto(Optional.<String>empty());
         } finally {
             context.stop();
         }
 
         return new MatchingServiceHealthCheckResponseDto(
-                    Optional.of(XmlUtils.writeToString(healthCheckResponse.getResponseElement())),
-                    healthCheckResponse.getVersionNumber());
+                    Optional.of(XmlUtils.writeToString(healthCheckResponse.getResponseElement())));
     }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/domain/MatchingServiceHealthCheckResponseDto.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/domain/MatchingServiceHealthCheckResponseDto.java
@@ -5,22 +5,17 @@ import java.util.Optional;
 public class MatchingServiceHealthCheckResponseDto {
 
     private Optional<String> response;
-    private Optional<String> versionNumber;
 
     @SuppressWarnings("unused") //Needed for JAXB
     private MatchingServiceHealthCheckResponseDto() {
     }
 
-    public MatchingServiceHealthCheckResponseDto(Optional<String> response, Optional<String> versionNumber) {
+    public MatchingServiceHealthCheckResponseDto(Optional<String> response) {
         this.response = response;
-        this.versionNumber = versionNumber;
     }
 
     public Optional<String> getResponse() {
         return response;
     }
 
-    public Optional<String> getVersionNumber() {
-        return versionNumber;
-    }
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/rest/HealthCheckResponse.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/rest/HealthCheckResponse.java
@@ -1,22 +1,16 @@
 package uk.gov.ida.hub.samlsoapproxy.rest;
 
-import java.util.Optional;
 import org.w3c.dom.Element;
 
 public class HealthCheckResponse {
     private final Element responseElement;
-    private final Optional<String> versionNumber;
 
-    public HealthCheckResponse(Element responseElement, Optional<String> versionNumber) {
+    public HealthCheckResponse(Element responseElement) {
         this.responseElement = responseElement;
-        this.versionNumber = versionNumber;
     }
 
     public Element getResponseElement() {
         return responseElement;
     }
 
-    public Optional<String> getVersionNumber() {
-        return versionNumber;
-    }
 }

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/builders/HealthCheckResponseBuilder.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/builders/HealthCheckResponseBuilder.java
@@ -1,29 +1,22 @@
 package uk.gov.ida.hub.samlsoapproxy.builders;
 
-import java.util.Optional;
 import org.w3c.dom.Element;
 import uk.gov.ida.hub.samlsoapproxy.rest.HealthCheckResponse;
 
 public class HealthCheckResponseBuilder {
 
     private Element element;
-    private Optional<String> versionNumber = Optional.empty();
 
     public static HealthCheckResponseBuilder aHealthCheckResponse(){
         return new HealthCheckResponseBuilder();
     }
 
     public HealthCheckResponse build(){
-        return new HealthCheckResponse(element, versionNumber);
+        return new HealthCheckResponse(element);
     }
 
     public HealthCheckResponseBuilder withElement(Element element) {
         this.element = element;
-        return this;
-    }
-
-    public HealthCheckResponseBuilder withVersionNumber(String versionNumber) {
-        this.versionNumber = Optional.ofNullable(versionNumber);
         return this;
     }
 }

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/builders/MatchingServiceHealthCheckerResponseDtoBuilder.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/builders/MatchingServiceHealthCheckerResponseDtoBuilder.java
@@ -37,7 +37,7 @@ public class MatchingServiceHealthCheckerResponseDtoBuilder {
         return this;
     }
 
-    public MatchingServiceHealthCheckerResponseDtoBuilder withId() {
+    public MatchingServiceHealthCheckerResponseDtoBuilder withId(String id) {
         this.id = id;
         return this;
     }

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/client/MatchingServiceHealthCheckClientTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/client/MatchingServiceHealthCheckClientTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.samlsoapproxy.client;
 
 import com.codahale.metrics.MetricRegistry;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,6 +15,7 @@ import uk.gov.ida.hub.samlsoapproxy.rest.HealthCheckResponse;
 import uk.gov.ida.shared.utils.xml.XmlUtils;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,22 +54,6 @@ public class MatchingServiceHealthCheckClientTest {
                 matchingServiceHealthCheckClient.sendHealthCheckRequest(healthCheckRequest, healthCheckUri);
 
         assertThat(matchingServiceHealthCheckResponseDto.getResponse()).isEqualTo(Optional.of(XmlUtils.writeToString(healthCheckResponseElement)));
-    }
-
-    @Test
-    public void sendHealthCheckRequest_shouldReturnSuccessResponseWithVersionNumber() {
-        String expectedVersion = "someVersion";
-        HealthCheckResponse responseMessageThatHasAVersion = aHealthCheckResponse()
-                .withElement(healthCheckResponseElement)
-                .withVersionNumber(expectedVersion)
-                .build();
-
-        when(soapRequestClient.makeSoapRequestForHealthCheck(healthCheckRequest, healthCheckUri)).thenReturn(responseMessageThatHasAVersion);
-
-        final MatchingServiceHealthCheckResponseDto matchingServiceHealthCheckResponseDto =
-                matchingServiceHealthCheckClient.sendHealthCheckRequest(healthCheckRequest, healthCheckUri);
-
-        assertThat(matchingServiceHealthCheckResponseDto.getVersionNumber()).isEqualTo(Optional.of(expectedVersion));
     }
 
     @Test


### PR DESCRIPTION
All live MSAs report their version and other information through the `responseId` mechanism. The code to look for the version number in the HTTP headers is now redundant and has been cleaned out.