### PR TITLE
EID-1504 Allow unsigned eIDAS assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-37',
-            saml_lib:"$opensaml_version-192",
+            saml_lib:"$opensaml_version-193",
         ]
 
 subprojects {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/EidasValidatorFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/EidasValidatorFactory.java
@@ -33,7 +33,7 @@ public class EidasValidatorFactory {
 
     public void getValidatedAssertion(ValidatedResponse validatedResponse, List<Assertion> decryptedAssertions) {
         SamlAssertionsSignatureValidator samlAssertionsSignatureValidator = new SamlAssertionsSignatureValidator(getSamlMessageSignatureValidator(validatedResponse.getIssuer().getValue()));
-        samlAssertionsSignatureValidator.validate(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        samlAssertionsSignatureValidator.validateEidas(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     private SamlMessageSignatureValidator getSamlMessageSignatureValidator(String entityId) {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidator.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidator.java
@@ -33,7 +33,11 @@ public class ResponseAssertionsFromCountryValidator {
 
     public void validate(ValidatedResponse validatedResponse, Assertion validatedIdentityAssertion) {
 
-        assertionValidator.validate(validatedIdentityAssertion, validatedResponse.getInResponseTo(), expectedRecipientId);
+        assertionValidator.validateEidas(
+            validatedIdentityAssertion,
+            validatedResponse.getInResponseTo(),
+            expectedRecipientId
+        );
 
         if (validatedResponse.isSuccess()) {
 

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
@@ -59,7 +59,7 @@ public class ResponseAssertionsFromCountryValidatorTest {
     public void shouldValidateAssertion() {
         validator.validate(validatedResponse, assertion);
 
-        verify(assertionValidator).validate(assertion, validatedResponse.getInResponseTo(), EXPECTED_RECIPIENT_ID);
+        verify(assertionValidator).validateEidas(assertion, validatedResponse.getInResponseTo(), EXPECTED_RECIPIENT_ID);
         verify(authnStatementAssertionValidator).validate(assertion);
         verify(eidasAttributeStatementAssertionValidator).validate(assertion);
     }


### PR DESCRIPTION
This pulls in build 193 of saml-lib. The new version allows unsigned
assertions from eIDAS countries. The eIDAS SAML profile allows this,
whereas the Verify profile does not.