### PR TITLE
N7edPMiO: Improve MSA Logging

### DIFF
--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
@@ -78,7 +78,7 @@ public class AttributeQueryRequestClient {
 
                 // The MSA sometimes returns 500s with a singularly unhelpful body. Special case handling to get Sentry
                 // to split out these errors. See https://trello.com/c/N7edPMiO/
-                if (responseBody.equals("uk.gov.ida.exceptions.ApplicationException")) {
+                if (responseBody.startsWith("uk.gov.ida.exceptions.ApplicationException") || responseBody.startsWith("uk.gov.ida.matchingserviceadapter.exceptions.LocalMatchingServiceException")) {
                     throw new MatchingServiceException(format("Unknown internal Matching Service error from {0} with status {1} ",
                             matchingServiceUri, e.getResponseStatus()), e);
                 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/AttributeQueryRequestClient.java
@@ -78,7 +78,7 @@ public class AttributeQueryRequestClient {
 
                 // The MSA sometimes returns 500s with a singularly unhelpful body. Special case handling to get Sentry
                 // to split out these errors. See https://trello.com/c/N7edPMiO/
-                if (responseBody.startsWith("uk.gov.ida.exceptions.ApplicationException") || responseBody.startsWith("uk.gov.ida.matchingserviceadapter.exceptions.LocalMatchingServiceException")) {
+                if (responseBody.startsWith("uk.gov.ida.exceptions.ApplicationException")) {
                     throw new MatchingServiceException(format("Unknown internal Matching Service error from {0} with status {1} ",
                             matchingServiceUri, e.getResponseStatus()), e);
                 }


### PR DESCRIPTION
## What

MSA logs don't contain a lot of useful information. It's hard to use them to identify what a problem is.

We should implement error logging changes to the MSA so that the full stacktrace is returned to the Verify Hub when an HTTP 500 error happens in the MSA.

There is some further background in Anshul's [investigation into MSA 500 errors](https://docs.google.com/document/d/10-oAqzKiPXu4nzwD9GL7knABwKxOLNY4oUlo6gC4uRA/edit#).

Original Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/3651026

## How
Change special exception handling to look for exception name at start of message, as message will potentially now contain full stack trace rather than just contain the exception name.

## Related

https://github.com/alphagov/verify-matching-service-adapter/pull/122