### PR TITLE
EID-1517: Only log user attributes in a Proxy Node journey when matching dataset is present

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer.java
@@ -54,7 +54,8 @@ public class DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer implements
         this.idpResponseValidator.validate(response);
         ValidatedResponse validatedResponse = this.idpResponseValidator.getValidatedResponse();
         ValidatedAssertions validatedAssertions = this.idpResponseValidator.getValidatedAssertions();
-        eidasAttributesLogger.ifPresent(l -> l.logEidasAttributesAsHash(validatedAssertions.getMatchingDatasetAssertion().get(), response));
+        eidasAttributesLogger.ifPresent(logger -> validatedAssertions.getMatchingDatasetAssertion()
+                .ifPresent(assertion -> logger.logEidasAttributesAsHash(assertion, response)));
         return idaResponseUnmarshaller.fromSaml(validatedResponse, validatedAssertions);
     }
 


### PR DESCRIPTION
If a user is on a **Proxy Node** journey through the Hub, and via the IDP, lands up in one of these states:
- No Authn Context Event
- Authn Failure
- Submit Requester Error
- Submit Fraud Event

then they are presently shown a frontend "_Sorry, something went wrong_" page.

If the user was **not** on a Proxy Node journey then the above scenario would result in the user seeing the "{IDP} couldn’t sign you in" page.

Users in a Proxy Node journey through the Hub **should not** see a different error page for the error events above.

The **Proxy Node** journey through the Hub additionally logs a hash of eidas user attributes, and this evaluation is causing an error in `saml-engine`, and the "_Sorry, something went wrong_" page is then shown.

This PR updates the logic used to decide whether to log a hash of eidas user attributes, specifically to check if the matching dataset assertions are present.

This is part one of addressing [EID-1517](https://govukverify.atlassian.net/browse/EID-1517), part two will be acceptance tests for Proxy Node journeys.