### PR TITLE
l4zBlwLF: Simplify generics for CertificateService

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
@@ -6,7 +6,6 @@ import uk.gov.ida.hub.config.domain.Certificate;
 import uk.gov.ida.hub.config.domain.CertificateConfigurable;
 import uk.gov.ida.hub.config.domain.CertificateDetails;
 import uk.gov.ida.hub.config.domain.CertificateValidityChecker;
-import uk.gov.ida.hub.config.domain.EntityIdentifiable;
 import uk.gov.ida.hub.config.domain.MatchingServiceConfig;
 import uk.gov.ida.hub.config.domain.TransactionConfig;
 import uk.gov.ida.hub.config.dto.FederationEntityType;
@@ -19,7 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class CertificateService <T extends EntityIdentifiable & CertificateConfigurable> {
+public class CertificateService <T extends CertificateConfigurable> {
 
     private final List<LocalConfigRepository<T>> configRepositories = new ArrayList<>();
     private CertificateValidityChecker certificateValidityChecker;

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateConfigurable.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/CertificateConfigurable.java
@@ -2,7 +2,7 @@ package uk.gov.ida.hub.config.domain;
 
 import java.util.Collection;
 
-public interface CertificateConfigurable {
+public interface CertificateConfigurable extends EntityIdentifiable {
 
     EncryptionCertificate getEncryptionCertificate();
 

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/MatchingServiceConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/MatchingServiceConfig.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MatchingServiceConfig implements EntityIdentifiable, CertificateConfigurable {
+public class MatchingServiceConfig implements CertificateConfigurable {
 
     @SuppressWarnings("unused") // needed to prevent guice injection
     protected MatchingServiceConfig() {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfig.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import static java.util.Optional.ofNullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TransactionConfig implements EntityIdentifiable, CertificateConfigurable {
+public class TransactionConfig implements CertificateConfigurable {
 
     @Valid
     @NotNull


### PR DESCRIPTION
Everything that implements `CertificateConfigurable` also implements
`EntityIdentifiable`. In `CertificateService` we had a generic type
definition that required both implementations. We can simplify this by
having `CertificateConfigurable` extend `EntityIdentifiable`.