### PR TITLE
OGD-138: Integrate verify-event-emitter library updated with SQS.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-66"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-67"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'359',
+            ida_utils:'364',
             dropwizard:"$dropwizard_version",
             dropwizard_infinispan:"$dropwizard_version-48",
             pact:'3.5.6',
@@ -101,6 +101,7 @@ subprojects {
         redis
         redis_test
         splunk
+        awssdk
     }
 
     dependencies {
@@ -122,7 +123,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-60"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-66"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",
@@ -177,6 +178,8 @@ subprojects {
         redis_test('com.github.kstyrc:embedded-redis:0.6')
 
         splunk('uk.gov.ida:splunk-library-javalogging:1.1.0')
+
+        awssdk 'com.amazonaws:aws-java-sdk-s3:1.11.563'
     }
 }
 

--- a/hub/config/build.gradle
+++ b/hub/config/build.gradle
@@ -7,7 +7,8 @@ dependencies {
             configurations.config,
             configurations.dropwizard,
             configurations.common,
-            configurations.prometheus
+            configurations.prometheus,
+            configurations.awssdk
 }
 
 apply plugin: 'application'

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/EventEmitterConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/EventEmitterConfiguration.java
@@ -33,6 +33,10 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private URI apiGatewayUrl;
 
+    @Valid
+    @JsonProperty
+    private String sourceQueueName;
+
     private EventEmitterConfiguration() { }
 
     @Override
@@ -60,5 +64,8 @@ public class EventEmitterConfiguration implements Configuration {
 
     @Override
     public URI getApiGatewayUrl() { return apiGatewayUrl; }
+
+    @Override
+    public String getSourceQueueName() { return sourceQueueName; }
 }
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/EventEmitterConfiguration.java
@@ -35,6 +35,10 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private URI apiGatewayUrl;
 
+    @Valid
+    @JsonProperty
+    private String sourceQueueName;
+
     private EventEmitterConfiguration() { }
 
     @Override
@@ -62,5 +66,8 @@ public class EventEmitterConfiguration implements Configuration {
 
     @Override
     public URI getApiGatewayUrl() { return apiGatewayUrl; }
+
+    @Override
+    public String getSourceQueueName() { return sourceQueueName; }
 }
 

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/EventEmitterConfiguration.java
@@ -33,6 +33,10 @@ public class EventEmitterConfiguration implements Configuration {
     @JsonProperty
     private URI apiGatewayUrl;
 
+    @Valid
+    @JsonProperty
+    private String sourceQueueName;
+
     private EventEmitterConfiguration() { }
 
     @Override
@@ -60,4 +64,7 @@ public class EventEmitterConfiguration implements Configuration {
 
     @Override
     public URI getApiGatewayUrl() { return apiGatewayUrl; }
+
+    @Override
+    public String getSourceQueueName() { return sourceQueueName; }
 }


### PR DESCRIPTION
- The latest version of verify-event-emitter includes the ability to send audit messages directly to an SQS queue for DCS.
- The only impact on hub is the need to add a SourceQueueName property to the Event Emitter config.  This is an optional field and will be blank for hub which uses the API Gateway Event Emitter.
- aws-java-sdk-s3 was provided transitively via verify-event-emitter.  As S3 is not used in this library it has been removed from the list of jars.  The library is now included as a direct verify-hub dependency instead.
- SQS code lives in a separate EventEmitterSQSModule.
