### PR TITLE
l4zBlwLF: Give test more time

### DIFF
--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/S3ConfigSourceTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/S3ConfigSourceTest.java
@@ -164,7 +164,7 @@ public class S3ConfigSourceTest {
         testSource.getRemoteConfig();
 
         try {
-            Thread.sleep(5);
+            Thread.sleep(10);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Test is failing because the async thread is taking to long in CI. Temporarily increasing sleep time. Will rethink the testing if this.