### PR TITLE
ZD-3570817 matching dataset duplication error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-37',
-            saml_lib:"$opensaml_version-193",
+            saml_lib:"$opensaml_version-200"
         ]
 
 subprojects {


### PR DESCRIPTION
verify-saml-libs were altered so that a duplicate assertion is logged as a warning instead of an error.

Alter build.gradle so that the updated verify-saml-libs are used by the hub.