### PR TITLE
AUTO-112: Update Wiremock library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ subprojects {
         def test_deps_deps = [
                 'org.json:json:20170516',
                 'com.jayway.awaitility:awaitility:1.6.0',
-                'com.github.tomakehurst:wiremock:2.16.0',
+                'com.github.tomakehurst:wiremock-standalone:2.23.2',
                 "uk.gov.ida:saml-test:$dependencyVersions.saml_lib",
                 'org.assertj:assertj-core:3.9.1',
                 'io.dropwizard:dropwizard-testing:' + dependencyVersions.dropwizard]


### PR DESCRIPTION
This change changes from wiremock to wiremock-standalone to avoid Jetty incompatible issues encountered in Verify Test RP's integration tests. Please see https://github.com/tomakehurst/wiremock/issues/551 for further details. This change also upgrades wiremock-standalone to the latest version for consistency (verify-saml-libs has this library).

I ran pre-commit script and it passed all unit tests and integration tests.

Author: @adityapahuja