### PR TITLE
AUTO-112: Pubish libraries to Artifactory externally

### DIFF
--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -6,7 +6,11 @@ apply plugin: 'java'
 publishing {
     repositories {
         maven {
-            url "/srv/maven" // change to point to your repo, e.g. http://my.org/repo
+            credentials {
+                username "${System.env.ARTIUSER}"
+                password "${System.env.ARTIPASSWORD}"
+            }
+            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
         }
     }
 

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -6,7 +6,11 @@ apply plugin: 'java'
 publishing {
     repositories {
         maven {
-            url "/srv/maven" // change to point to your repo, e.g. http://my.org/repo
+            credentials {
+                username "${System.env.ARTIUSER}"
+                password "${System.env.ARTIPASSWORD}"
+            }
+            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
         }
     }
 


### PR DESCRIPTION
This change updates Gradle files to publish hub-saml and hub-saml-test-urils libraries to Artifactory externally instead of locally. This change is needed for jobs in Concourse to publish the libraries to Artifactory externally.

Author: @adityapahuja