### PR TITLE
L4zBlwLF:  S3 integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,15 +56,15 @@ subprojects {
 
     repositories {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
-          logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
-          maven { url 'https://dl.bintray.com/alphagov/maven' } // For dropwizard-logstash
-          maven { url 'https://dl.bintray.com/alphagov/maven-test' } // For other public verify binaries
-          maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
-          maven { url 'https://splunk.jfrog.io/splunk/ext-releases-local' }
-          jcenter()
+            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+            maven { url 'https://dl.bintray.com/alphagov/maven' } // For dropwizard-logstash
+            maven { url 'https://dl.bintray.com/alphagov/maven-test' } // For other public verify binaries
+            maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
+            maven { url 'https://splunk.jfrog.io/splunk/ext-releases-local' }
+            jcenter()
         }
         else {
-          maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+            maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
         }
     }
 
@@ -102,6 +102,7 @@ subprojects {
         redis_test
         splunk
         awssdk
+        s3mock
     }
 
     dependencies {
@@ -180,6 +181,8 @@ subprojects {
         splunk('uk.gov.ida:splunk-library-javalogging:1.1.0')
 
         awssdk 'com.amazonaws:aws-java-sdk-s3:1.11.563'
+
+        s3mock 'com.adobe.testing:s3mock:2.1.9', 'com.adobe.testing:s3mock-junit4:2.1.9'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ subprojects {
 
         awssdk 'com.amazonaws:aws-java-sdk-s3:1.11.563'
 
-        s3mock 'com.adobe.testing:s3mock:2.1.9', 'com.adobe.testing:s3mock-junit4:2.1.9'
+        s3mock 'com.adobe.testing:s3mock:1.1.6'
     }
 }
 

--- a/hub/config/build.gradle
+++ b/hub/config/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
     testCompile configurations.test_deps_compile,
             configurations.ida_test_utils,
-            configurations.dev_pki
+            configurations.dev_pki,
+            configurations.s3mock
 
     compile configurations.ida_utils,
             configurations.config,

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/SelfServiceIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/SelfServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.integrationtest.hub.config.apprule;
 
-import com.adobe.testing.s3mock.junit4.S3MockRule;
+import com.adobe.testing.s3mock.S3MockRule;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -10,6 +10,7 @@ import io.dropwizard.util.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import uk.gov.ida.hub.config.Urls;
 import uk.gov.ida.hub.config.dto.MatchingServiceConfigDto;
 import uk.gov.ida.integrationtest.hub.config.apprule.support.ConfigAppRule;
@@ -34,10 +35,14 @@ public class SelfServiceIntegrationTest {
     private static final String BUCKET_NAME = "s3Bucket";
     private static final String OBJECT_KEY = "src/test/resources/remote-test-config.json";
 
-    @ClassRule(order = 1)
-    public static S3MockRule s3MockRule = S3MockRule.builder().silent().build();
 
-    @ClassRule(order = 2)
+    public static S3MockRule s3MockRule = new S3MockRule();
+
+
+
+
+
+    @ClassRule
     public static ConfigAppRule configAppRule = new ConfigAppRule(s3MockRule::createS3Client, getSelfServiceOverrides())
             .addTransaction(aTransactionConfigData()
                     .withEntityId("rp-entity-id")
@@ -56,6 +61,7 @@ public class SelfServiceIntegrationTest {
                     .withOnboarding(asList("rp-entity-id"))
                     .build());
 
+
     private static ConfigOverride[] getSelfServiceOverrides() {
         ConfigOverride[] overrides = {
                 ConfigOverride.config("selfService.enabled", "true"),
@@ -66,6 +72,9 @@ public class SelfServiceIntegrationTest {
         return overrides;
     }
 
+    @ClassRule
+    public static RuleChain ruleChain = RuleChain.outerRule(s3MockRule)
+            .around(configAppRule);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/SelfServiceIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/SelfServiceIntegrationTest.java
@@ -1,0 +1,103 @@
+package uk.gov.ida.integrationtest.hub.config.apprule;
+
+import com.adobe.testing.s3mock.junit4.S3MockRule;
+import helpers.JerseyClientConfigurationBuilder;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.jersey.errors.ErrorMessage;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.util.Duration;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import uk.gov.ida.hub.config.Urls;
+import uk.gov.ida.hub.config.dto.MatchingServiceConfigDto;
+import uk.gov.ida.integrationtest.hub.config.apprule.support.ConfigAppRule;
+import uk.gov.ida.shared.utils.string.StringEncoding;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
+import static uk.gov.ida.hub.config.domain.builders.MatchingServiceConfigBuilder.aMatchingServiceConfig;
+import static uk.gov.ida.hub.config.domain.builders.TransactionConfigBuilder.aTransactionConfigData;
+
+public class SelfServiceIntegrationTest {
+
+    public static Client client;
+    private static final String ENTITY_ID = "test-ms-entity-id";
+    private static final String MATCHING_URI = "http://foo.bar/matching-service-uri";
+    private static final String BUCKET_NAME = "s3Bucket";
+    private static final String OBJECT_KEY = "src/test/resources/remote-test-config.json";
+
+    @ClassRule(order = 1)
+    public static S3MockRule s3MockRule = S3MockRule.builder().silent().build();
+
+    @ClassRule(order = 2)
+    public static ConfigAppRule configAppRule = new ConfigAppRule(s3MockRule::createS3Client, getSelfServiceOverrides())
+            .addTransaction(aTransactionConfigData()
+                    .withEntityId("rp-entity-id")
+                    .withMatchingServiceEntityId(ENTITY_ID)
+                    .build())
+            .addTransaction(aTransactionConfigData()
+                    .withEntityId("rp-entity-id-no-matching")
+                    .withUsingMatching(false)
+                    .build())
+            .addMatchingService(aMatchingServiceConfig()
+                    .withEntityId(ENTITY_ID)
+                    .withUri(URI.create(MATCHING_URI))
+                    .build())
+            .addIdp(anIdentityProviderConfigData()
+                    .withEntityId("idp-entity-id")
+                    .withOnboarding(asList("rp-entity-id"))
+                    .build());
+
+    private static ConfigOverride[] getSelfServiceOverrides() {
+        ConfigOverride[] overrides = {
+                ConfigOverride.config("selfService.enabled", "true"),
+                ConfigOverride.config("selfService.s3BucketName", BUCKET_NAME),
+                ConfigOverride.config("selfService.s3ObjectKey", OBJECT_KEY),
+                ConfigOverride.config("selfService.cacheExpiry", "5s")
+        };
+        return overrides;
+    }
+
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        JerseyClientConfiguration jerseyClientConfiguration = JerseyClientConfigurationBuilder.aJerseyClientConfiguration().withTimeout(Duration.seconds(10)).build();
+        client = new JerseyClientBuilder(configAppRule.getEnvironment()).using(jerseyClientConfiguration).build(SelfServiceIntegrationTest.class.getSimpleName());
+    }
+
+    @Test
+    public void getMatchingServices_returnsOkAndListOfMatchingServices(){
+        Response response = client.target(configAppRule.getUri(Urls.ConfigUrls.MATCHING_SERVICE_ROOT).build()).request().get();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        assertThat(response.readEntity(Collection.class).size()).isEqualTo(1);
+    }
+
+    @Test
+    public void getMatchingService_returnsMatchingServiceForEntityId(){
+        String entityId = ENTITY_ID;
+        URI uri = configAppRule.getUri(Urls.ConfigUrls.MATCHING_SERVICE_RESOURCE).buildFromEncoded(StringEncoding.urlEncode(entityId).replace("+", "%20"));
+
+        Response response = client.target(uri.toASCIIString()).request().get();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        MatchingServiceConfigDto ms = response.readEntity(MatchingServiceConfigDto.class);
+        assertThat(ms.getEntityId()).isEqualTo(entityId);
+        assertThat(ms.getUri().toString()).isEqualTo(MATCHING_URI);
+    }
+
+    @Test
+    public void getMatchingService_returnsInternalServerError(){
+        String entityId = "not-found";
+        URI uri = configAppRule.getUri(Urls.ConfigUrls.MATCHING_SERVICE_RESOURCE).buildFromEncoded(StringEncoding.urlEncode(entityId).replace("+", "%20"));
+        Response response = client.target(uri.toASCIIString()).request().get();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("There was an error processing your request.");
+    }
+}

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.integrationtest.hub.config.apprule.support;
 
 import certificates.values.CACertificates;
+import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
@@ -25,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static io.dropwizard.testing.ConfigOverride.config;
@@ -49,6 +51,14 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
     private List<MatchingServiceConfig> matchingServices = new ArrayList<>();
     private List<IdentityProviderConfig> idps = new ArrayList<>();
     private List<CountryConfig> countries = new ArrayList<>();
+
+    public ConfigAppRule(Supplier<AmazonS3> s3ClientSupplier, ConfigOverride... configOverrides) {
+        super(ConfigIntegrationApplication.class,
+                ResourceHelpers.resourceFilePath("config.yml"),
+                withDefaultOverrides(configOverrides)
+        );
+        ConfigIntegrationApplication.setS3ClientSupplier(s3ClientSupplier);
+    }
 
     public ConfigAppRule(ConfigOverride... configOverrides) {
         super(ConfigApplication.class,

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigIntegrationApplication.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigIntegrationApplication.java
@@ -1,0 +1,54 @@
+package uk.gov.ida.integrationtest.hub.config.apprule.support;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.dropwizard.setup.Bootstrap;
+import uk.gov.ida.hub.config.ConfigApplication;
+import uk.gov.ida.hub.config.ConfigConfiguration;
+import uk.gov.ida.hub.config.configuration.SelfServiceConfig;
+import uk.gov.ida.hub.config.data.S3ConfigSource;
+
+import javax.inject.Singleton;
+import java.util.function.Supplier;
+
+public class ConfigIntegrationApplication extends ConfigApplication {
+
+    private static Supplier<AmazonS3> s3ClientSupplier;
+
+    public static void setS3ClientSupplier(Supplier<AmazonS3> s3ClientSupplier) {
+        ConfigIntegrationApplication.s3ClientSupplier = s3ClientSupplier;
+    }
+
+    @Override
+    public void initialize(Bootstrap<ConfigConfiguration> bootstrap) {
+        super.initialize(bootstrap);
+    }
+
+    @Override
+    protected Module bindS3ConfigSource() {
+        return new AbstractModule() {
+            @Override
+            protected void configure() {
+            }
+
+            @Provides
+            @Singleton
+            @SuppressWarnings("unused")
+            private S3ConfigSource getS3ConfigSource(ConfigConfiguration configConfiguration, ObjectMapper objectMapper){
+                SelfServiceConfig selfServiceConfig = configConfiguration.getSelfService();
+                if (selfServiceConfig.isEnabled()){
+                    AmazonS3 amazonS3 = s3ClientSupplier != null ? s3ClientSupplier.get() : AmazonS3ClientBuilder.defaultClient();
+                    return new S3ConfigSource(
+                            selfServiceConfig,
+                            amazonS3,
+                            objectMapper);
+                }
+                return new S3ConfigSource();
+            }
+        };
+    }
+}

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.config;
 
-import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
@@ -37,7 +36,6 @@ import java.util.EnumSet;
 public class ConfigApplication extends Application<ConfigConfiguration> {
 
     private GuiceBundle<ConfigConfiguration> guiceBundle;
-    private AmazonS3 testAmazonS3 = null;
 
     public static void main(String[] args) throws Exception {
         new ConfigApplication().run(args);

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
@@ -1,6 +1,12 @@
 package uk.gov.ida.hub.config;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.Provides;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
@@ -12,6 +18,8 @@ import uk.gov.ida.bundles.LoggingBundle;
 import uk.gov.ida.bundles.MonitoringBundle;
 import uk.gov.ida.bundles.ServiceStatusBundle;
 import uk.gov.ida.common.shared.security.TrustStoreMetrics;
+import uk.gov.ida.hub.config.configuration.SelfServiceConfig;
+import uk.gov.ida.hub.config.data.S3ConfigSource;
 import uk.gov.ida.hub.config.filters.SessionIdQueryParamLoggingFilter;
 import uk.gov.ida.hub.config.resources.CertificatesResource;
 import uk.gov.ida.hub.config.resources.CountriesResource;
@@ -21,6 +29,7 @@ import uk.gov.ida.hub.config.resources.TransactionsResource;
 import uk.gov.ida.truststore.ClientTrustStoreConfiguration;
 import uk.gov.ida.truststore.KeyStoreLoader;
 
+import javax.inject.Singleton;
 import javax.servlet.DispatcherType;
 import java.security.KeyStore;
 import java.util.EnumSet;
@@ -28,6 +37,7 @@ import java.util.EnumSet;
 public class ConfigApplication extends Application<ConfigConfiguration> {
 
     private GuiceBundle<ConfigConfiguration> guiceBundle;
+    private AmazonS3 testAmazonS3 = null;
 
     public static void main(String[] args) throws Exception {
         new ConfigApplication().run(args);
@@ -49,6 +59,7 @@ public class ConfigApplication extends Application<ConfigConfiguration> {
 
         guiceBundle = GuiceBundle.defaultBuilder(ConfigConfiguration.class)
                 .modules(new ConfigModule())
+                .modules(bindS3ConfigSource())
                 .build();
         bootstrap.addBundle(guiceBundle);
         bootstrap.addBundle(new ServiceStatusBundle());
@@ -56,6 +67,28 @@ public class ConfigApplication extends Application<ConfigConfiguration> {
         bootstrap.addBundle(new LoggingBundle());
         bootstrap.addBundle(new PrometheusBundle());
         bootstrap.addCommand(new ConfigValidCommand());
+    }
+
+    protected Module bindS3ConfigSource() {
+        return new AbstractModule() {
+            @Override
+            protected void configure() {
+            }
+
+            @Provides
+            @Singleton
+            @SuppressWarnings("unused")
+            private S3ConfigSource getS3ConfigSource(ConfigConfiguration configConfiguration, ObjectMapper objectMapper){
+                SelfServiceConfig selfServiceConfig = configConfiguration.getSelfService();
+                if (selfServiceConfig.isEnabled()){
+                    return new S3ConfigSource(
+                            selfServiceConfig,
+                            AmazonS3ClientBuilder.defaultClient(),
+                            objectMapper);
+                }
+                return new S3ConfigSource();
+            }
+        };
     }
 
     @Override

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigModule.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.hub.config;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -15,6 +17,7 @@ import uk.gov.ida.common.shared.security.verification.PKIXParametersProvider;
 import uk.gov.ida.hub.config.annotations.CertificateConfigValidator;
 import uk.gov.ida.hub.config.application.CertificateService;
 import uk.gov.ida.hub.config.application.PrometheusClientService;
+import uk.gov.ida.hub.config.configuration.SelfServiceConfig;
 import uk.gov.ida.hub.config.data.ConfigDataBootstrap;
 import uk.gov.ida.hub.config.data.ConfigDataSource;
 import uk.gov.ida.hub.config.data.FileBackedCountryConfigDataSource;
@@ -93,8 +96,17 @@ public class ConfigModule extends AbstractModule {
         bind(CertificateService.class);
     }
 
+    private AmazonS3 getAmazonS3Client(SelfServiceConfig selfServiceConfig) {
+        if (!selfServiceConfig.isEnabled()){
+            return null;
+        }
+
+        return AmazonS3ClientBuilder.defaultClient();
+    }
+
     @Provides
     @Singleton
+    @SuppressWarnings("unused")
     private PrometheusClientService getPrometheusClientService(
         Environment environment,
         ConfigConfiguration configConfiguration,
@@ -119,6 +131,7 @@ public class ConfigModule extends AbstractModule {
     }
 
     @Provides
+    @SuppressWarnings("unused")
     public CertificateValidityChecker validityChecker(TrustStoreForCertificateProvider trustStoreForCertificateProvider, CertificateChainValidator certificateChainValidator) {
         return CertificateValidityChecker.createNonOCSPCheckingCertificateValidityChecker(trustStoreForCertificateProvider, certificateChainValidator);
     }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/configuration/SelfServiceConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/configuration/SelfServiceConfig.java
@@ -25,6 +25,14 @@ public class SelfServiceConfig {
     @JsonProperty
     private Duration cacheExpiry;
 
+    @Valid
+    @JsonProperty
+    private String s3Endpoint;
+
+    @Valid
+    @JsonProperty
+    private String s3Region;
+
     @SuppressWarnings("unused")
     public SelfServiceConfig() { }
 
@@ -46,5 +54,13 @@ public class SelfServiceConfig {
 
     public Duration getCacheExpiry() {
         return cacheExpiry;
+    }
+
+    public String getS3Endpoint() {
+        return s3Endpoint;
+    }
+
+    public String getS3Region() {
+        return s3Region;
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/S3ConfigSource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/S3ConfigSource.java
@@ -49,7 +49,7 @@ public class S3ConfigSource {
         this.selfServiceConfig = selfServiceConfig;
         this.enabled = selfServiceConfig.isEnabled();
         this.bucket = selfServiceConfig.getS3BucketName();
-        if (selfServiceConfig.isEnabled() && s3Client != null){
+        if (enabled && s3Client != null){
             this.s3Client = s3Client;
             this.objectMapper = objectMapper;
             this.cacheLoader = new S3ConfigCacheLoader();

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/S3ConfigSource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/S3ConfigSource.java
@@ -33,6 +33,7 @@ public class S3ConfigSource {
     public static final Map<String, RemoteMatchingServiceConfig> EMPTY_MATCHING_SERVICE_CONFIG_MAP = Collections.emptyMap();
     public static final List<RemoteServiceProviderConfig> EMPTY_SERVICE_PROVIDER_CONFIG_LIST = Collections.emptyList();
     public static final RemoteConfigCollection EMPTY_COLLECTION = new RemoteConfigCollection(null, null, EMPTY_CONNECTED_SERVICE_CONFIG_MAP, EMPTY_MATCHING_SERVICE_CONFIG_MAP, EMPTY_SERVICE_PROVIDER_CONFIG_LIST);
+    private boolean enabled = false;
     private String bucket;
     private SelfServiceConfig selfServiceConfig;
     private AmazonS3 s3Client;
@@ -40,14 +41,15 @@ public class S3ConfigSource {
     private LoadingCache<String, RemoteConfigCollection> cache;
     private ObjectMapper objectMapper;
 
-    public CacheLoader<String, RemoteConfigCollection> getCacheLoader() {
-        return cacheLoader;
+
+    public S3ConfigSource() {
     }
 
     public S3ConfigSource(SelfServiceConfig selfServiceConfig, AmazonS3 s3Client, ObjectMapper objectMapper) {
         this.selfServiceConfig = selfServiceConfig;
+        this.enabled = selfServiceConfig.isEnabled();
         this.bucket = selfServiceConfig.getS3BucketName();
-        if (selfServiceConfig.isEnabled()){
+        if (selfServiceConfig.isEnabled() && s3Client != null){
             this.s3Client = s3Client;
             this.objectMapper = objectMapper;
             this.cacheLoader = new S3ConfigCacheLoader();
@@ -58,7 +60,7 @@ public class S3ConfigSource {
     }
 
     public RemoteConfigCollection getRemoteConfig(){
-        if (!selfServiceConfig.isEnabled()){
+        if (!enabled){
             return EMPTY_COLLECTION;
         }
         try {
@@ -78,6 +80,10 @@ public class S3ConfigSource {
         } finally {
             inputStream.close();
         }
+    }
+
+    public CacheLoader<String, RemoteConfigCollection> getCacheLoader() {
+        return cacheLoader;
     }
 
     public class S3ConfigCacheLoader extends CacheLoader<String, RemoteConfigCollection> {


### PR DESCRIPTION
This commit adds and and wires up Adobe's S3Mock for integration tests.
At this stage the `SelfServiceIntegrationTest` does not exercise code
that performs S3Integration, just wires up the mock AmazonS3 client
object so that it is availible. The next step is to add the code that
merges local and remote config and extend the integration test to
exercise that.