### PR TITLE
Parse Self Service enabled config

### DIFF
--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -31,3 +31,8 @@ certificateExpiryDateCheckServiceConfiguration:
   enable: true
 certificateOcspRevocationStatusCheckServiceConfiguration:
   enable: true
+selfServiceConfiguration:
+  enabled: ${SELF_SERVICE_ENABLED:-false}
+  s3BucketName: ${SERVICES_METADATA_BUCKET:-}
+  s3ObjectKey: ${METADATA_OBJECT_KEY:-}
+  cacheExpiry: 30s

--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -31,7 +31,7 @@ certificateExpiryDateCheckServiceConfiguration:
   enable: true
 certificateOcspRevocationStatusCheckServiceConfiguration:
   enable: true
-selfServiceConfiguration:
+selfService:
   enabled: ${SELF_SERVICE_ENABLED:-false}
   s3BucketName: ${SERVICES_METADATA_BUCKET:-}
   s3ObjectKey: ${METADATA_OBJECT_KEY:-}


### PR DESCRIPTION
Set the other required configuration for the config service to read the new metadata bucket.

Corresponding PRs:
https://github.com/alphagov/verify-infrastructure-config/pull/158
https://github.com/alphagov/verify-infrastructure/pull/244

https://trello.com/c/glz5vLuk/485-update-the-config-in-hub-to-enable-the-e2e-journey