### PR TITLE
BAU: Initialise S3 client with region

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/ConfigApplication.java
@@ -81,7 +81,7 @@ public class ConfigApplication extends Application<ConfigConfiguration> {
                 if (selfServiceConfig.isEnabled()){
                     return new S3ConfigSource(
                             selfServiceConfig,
-                            AmazonS3ClientBuilder.defaultClient(),
+                            AmazonS3ClientBuilder.standard().withRegion("eu-west-2").build(),
                             objectMapper);
                 }
                 return new S3ConfigSource();


### PR DESCRIPTION
Trying to work out why we can't connect to S3. Trying with an explicity
set region when building he client. If this works we will move this into
self service config.