### PR TITLE
xHGobHw4: Use enabled flag in TrustStore Config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
 }
 
 def dependencyVersions = [
-            ida_utils:'367',
+            ida_utils:'370',
             dropwizard:"$dropwizard_version",
             dropwizard_infinispan:"$dropwizard_version-48",
             pact:'3.5.6',

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStore.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStore.java
@@ -13,6 +13,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import static java.text.MessageFormat.format;
 
@@ -42,8 +43,10 @@ public class ConfigServiceKeyStore {
         for (CertificateDto keyFromConfig : certificates) {
             String base64EncodedCertificateValue = keyFromConfig.getCertificate();
             final X509Certificate certificate = x509CertificateFactory.createCertificate(base64EncodedCertificateValue);
-            KeyStore trustStore = trustStoreForCertificateProvider.getTrustStoreFor(keyFromConfig.getFederationEntityType());
-            validate(certificate, trustStore);
+            Optional<KeyStore> trustStore = trustStoreForCertificateProvider.getTrustStoreFor(keyFromConfig.getFederationEntityType());
+            if (trustStore.isPresent()){
+                validate(certificate, trustStore.get());
+            }
             publicKeys.add(certificate.getPublicKey());
         }
 
@@ -54,9 +57,10 @@ public class ConfigServiceKeyStore {
         CertificateDto certificateDto = certificatesConfigProxy.getEncryptionCertificate(entityId);
         String base64EncodedCertificateValue = certificateDto.getCertificate();
         final X509Certificate certificate = x509CertificateFactory.createCertificate(base64EncodedCertificateValue);
-        KeyStore trustStore = trustStoreForCertificateProvider.getTrustStoreFor(certificateDto.getFederationEntityType());
-        validate(certificate, trustStore);
-
+        Optional<KeyStore> trustStore = trustStoreForCertificateProvider.getTrustStoreFor(certificateDto.getFederationEntityType());
+        if (trustStore.isPresent()){
+            validate(certificate, trustStore.get());
+        }
         return certificate.getPublicKey();
     }
 

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/TrustStoreForCertificateProvider.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/TrustStoreForCertificateProvider.java
@@ -7,6 +7,7 @@ import uk.gov.ida.truststore.TrustStoreConfiguration;
 
 import javax.inject.Inject;
 import java.security.KeyStore;
+import java.util.Optional;
 
 import static java.text.MessageFormat.format;
 
@@ -21,9 +22,12 @@ public class TrustStoreForCertificateProvider {
         this.keyStoreCache = keyStoreCache;
     }
 
-    public KeyStore getTrustStoreFor(FederationEntityType federationEntityType) {
+    public Optional<KeyStore> getTrustStoreFor(FederationEntityType federationEntityType) {
         ClientTrustStoreConfiguration configuration = getAppropriateTrustStoreConfig(federationEntityType);
-        return keyStoreCache.get(configuration);
+        if (configuration.isEnabled()){
+            return Optional.of(keyStoreCache.get(configuration));
+        }
+        return Optional.empty();
     }
 
     private ClientTrustStoreConfiguration getAppropriateTrustStoreConfig(final FederationEntityType federationEntityType) {

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStoreTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStoreTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.hub.samlengine.config;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,16 +15,13 @@ import uk.gov.ida.hub.samlengine.domain.CertificateDto;
 import uk.gov.ida.hub.samlengine.domain.FederationEntityType;
 import uk.gov.ida.saml.core.test.TestEntityIds;
 
-import java.io.IOException;
 import java.security.KeyStore;
 import java.security.PublicKey;
 import java.security.cert.CertPathValidatorException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.collect.ImmutableList.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -38,8 +36,9 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.PUBLIC_SIGNING_CE
 @RunWith(MockitoJUnitRunner.class)
 public class ConfigServiceKeyStoreTest {
 
-    public static final String IDP_ENTITY_ID = TestEntityIds.STUB_IDP_ONE;
-    public static final String SECOND_IDP_ENTITY_ID = TestEntityIds.STUB_IDP_TWO;
+    private static final String IDP_ENTITY_ID = TestEntityIds.STUB_IDP_ONE;
+    private static final String RP_ENTITY_ID = TestEntityIds.TEST_RP;
+    private static final String SECOND_IDP_ENTITY_ID = TestEntityIds.STUB_IDP_TWO;
 
     @Mock
     private CertificatesConfigProxy certificatesConfigProxy;
@@ -58,7 +57,7 @@ public class ConfigServiceKeyStoreTest {
     private ConfigServiceKeyStore configServiceKeyStore;
 
     @Before
-    public void setup() throws CertificateException {
+    public void setUp() {
         issuerId = "issuer-id";
         configServiceKeyStore = new ConfigServiceKeyStore(
                 certificatesConfigProxy,
@@ -68,17 +67,19 @@ public class ConfigServiceKeyStoreTest {
     }
 
     @Test
-    public void getVerifyingKeysForEntity_shouldGetVerifyingKeysFromConfigCertificateProxy() throws Exception {
+    public void getVerifyingKeysForEntity_shouldGetVerifyingKeysFromConfigCertificateProxy() {
         configServiceKeyStore.getVerifyingKeysForEntity(issuerId);
 
         verify(certificatesConfigProxy).getSignatureVerificationCertificates(issuerId);
     }
 
+
+
     @Test
-    public void getVerifyingKeysForEntity_shouldReturnAllKeysReturnedByConfig() throws Exception {
+    public void getVerifyingKeysForEntity_shouldReturnAllKeysReturnedByConfig() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         final CertificateDto certTwoDto = getX509Certificate(SECOND_IDP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -90,10 +91,10 @@ public class ConfigServiceKeyStoreTest {
     }
 
     @Test
-    public void getVerifyingKeysForEntity_shouldValidateEachKeyReturnedByConfig() throws Exception {
+    public void getVerifyingKeysForEntity_shouldValidateEachKeyReturnedByConfig() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         final CertificateDto certTwoDto = getX509Certificate(SECOND_IDP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -105,9 +106,9 @@ public class ConfigServiceKeyStoreTest {
     }
 
     @Test
-    public void getVerificationKeyForEntity_shouldThrowExceptionIfCertificateIsInvalid() throws Exception {
+    public void getVerificationKeyForEntity_shouldThrowExceptionIfCertificateIsInvalid() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(of(certOneDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         CertPathValidatorException underlyingException = new CertPathValidatorException("Invalid Certificate");
@@ -122,7 +123,17 @@ public class ConfigServiceKeyStoreTest {
     }
 
     @Test
-    public void getEncryptionKeyForEntity_shouldGetEncryptionKeysFromConfigCertificateProxy() throws Exception {
+    public void getVerificationKeyForEntity_shouldNotValidateWhenTrustStoreDisabled() {
+        final CertificateDto certOneDto = getX509Certificate(RP_ENTITY_ID);
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
+        when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.empty());
+        configServiceKeyStore.getVerifyingKeysForEntity(issuerId);
+        verify(certificateChainValidator, times(0)).validate(x509Certificate, trustStore);
+    }
+
+    @Test
+    public void getEncryptionKeyForEntity_shouldGetEncryptionKeysFromConfigCertificateProxy() {
         when(certificatesConfigProxy.getEncryptionCertificate(anyString())).thenReturn(aCertificateDto().build());
         when(x509CertificateFactory.createCertificate(anyString())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -134,7 +145,7 @@ public class ConfigServiceKeyStoreTest {
     }
 
     @Test
-    public void getEncryptionKeyForEntity_shouldValidateTheKeyReturnedByConfig() throws Exception {
+    public void getEncryptionKeyForEntity_shouldValidateTheKeyReturnedByConfig() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         when(certificatesConfigProxy.getEncryptionCertificate(issuerId)).thenReturn(certOneDto);
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
@@ -147,7 +158,7 @@ public class ConfigServiceKeyStoreTest {
     }
 
     @Test
-    public void getEncryptionKeyForEntity_shouldThrowExceptionIfCertificateIsInvalid() throws Exception {
+    public void getEncryptionKeyForEntity_shouldThrowExceptionIfCertificateIsInvalid() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         when(certificatesConfigProxy.getEncryptionCertificate(issuerId)).thenReturn(certOneDto);
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
@@ -163,7 +174,17 @@ public class ConfigServiceKeyStoreTest {
         }
     }
 
-    private static CertificateDto getX509Certificate(String entityId) throws IOException {
+    @Test
+    public void getEncryptionKeyForEntity_shouldNotValidateWhenTrustStoreDisabled() {
+        final CertificateDto certOneDto = getX509Certificate(RP_ENTITY_ID);
+        when(certificatesConfigProxy.getEncryptionCertificate(issuerId)).thenReturn(certOneDto);
+        when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.empty());
+        configServiceKeyStore.getEncryptionKeyForEntity(issuerId);
+        verify(certificateChainValidator, times(0)).validate(x509Certificate, trustStore);
+    }
+
+    private static CertificateDto getX509Certificate(String entityId) {
         return new CertificateDtoBuilder().withIssuerId(entityId).withCertificate(PUBLIC_SIGNING_CERTS.get(entityId)).build();
     }
 }

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStoreTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStoreTest.java
@@ -21,6 +21,7 @@ import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,7 +81,7 @@ public class ConfigServiceKeyStoreTest {
         when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
-        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(trustStore);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         when(certificateChainValidator.validate(x509Certificate, trustStore)).thenReturn(valid());
 
         List<PublicKey> keys = configServiceKeyStore.getVerifyingKeysForEntity(issuerId);
@@ -95,7 +96,7 @@ public class ConfigServiceKeyStoreTest {
         when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
-        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(trustStore);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         when(certificateChainValidator.validate(x509Certificate, trustStore)).thenReturn(valid());
 
         configServiceKeyStore.getVerifyingKeysForEntity(issuerId);
@@ -108,7 +109,7 @@ public class ConfigServiceKeyStoreTest {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
-        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(trustStore);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         CertPathValidatorException underlyingException = new CertPathValidatorException("Invalid Certificate");
         when(certificateChainValidator.validate(x509Certificate, trustStore)).thenReturn(invalid(underlyingException));
         try {
@@ -124,7 +125,7 @@ public class ConfigServiceKeyStoreTest {
     public void getEncryptionKeyForEntity_shouldGetEncryptionKeysFromConfigCertificateProxy() throws Exception {
         when(certificatesConfigProxy.getEncryptionCertificate(anyString())).thenReturn(aCertificateDto().build());
         when(x509CertificateFactory.createCertificate(anyString())).thenReturn(x509Certificate);
-        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(trustStore);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         when(certificateChainValidator.validate(x509Certificate, trustStore)).thenReturn(valid());
 
         configServiceKeyStore.getEncryptionKeyForEntity(issuerId);
@@ -137,7 +138,7 @@ public class ConfigServiceKeyStoreTest {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         when(certificatesConfigProxy.getEncryptionCertificate(issuerId)).thenReturn(certOneDto);
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
-        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(trustStore);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         when(certificateChainValidator.validate(x509Certificate, trustStore)).thenReturn(valid());
 
         configServiceKeyStore.getEncryptionKeyForEntity(issuerId);
@@ -150,7 +151,7 @@ public class ConfigServiceKeyStoreTest {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         when(certificatesConfigProxy.getEncryptionCertificate(issuerId)).thenReturn(certOneDto);
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
-        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(trustStore);
+        when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         CertPathValidatorException underlyingException = new CertPathValidatorException("Invalid Certificate");
         when(certificateChainValidator.validate(x509Certificate, trustStore)).thenReturn(invalid(underlyingException));
         try {


### PR DESCRIPTION
We want to be able to turn off validating certificate chains with our
root trust store for RPs (and their MSAs). We have previously added an
`enabled` flag to the `ClientTrustStoreConfiguration` in
`verify-utils-libs`.

This commit:

Updates `TrustStoreForCertificateProvider` to return `Optional<KeyStore>`
from `getTrustStoreFor`.

Uses the new `enabled` flag in `ClientTrustStoreConfiguration` to
determine whether or not to return the configured trust store.

Updates `ConfigServiceKeyStore` to validate using the trust store only
if it is present. i.e. the Optional returned from `getTrustStoreFor` is
not empty.

co-authored-by: Alan Carter <alan.carter@digital.cabinet-office.gov>