### PR TITLE
BAU: Bump saml-lib version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-37',
-            saml_lib:"$opensaml_version-200"
+            saml_lib:"$opensaml_version-206"
         ]
 
 subprojects {

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatterTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ProtectiveMonitoringLogFormatterTest.java
@@ -22,6 +22,8 @@ import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.builders.AuthnRequestBuilder.anAuthnRequest;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.DEFAULT_REQUEST_ID;
+import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.DEFAULT_RESPONSE_ID;
 import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
 
 @RunWith(OpenSAMLRunner.class)
@@ -62,8 +64,8 @@ public class ProtectiveMonitoringLogFormatterTest {
         String logString = new ProtectiveMonitoringLogFormatter().formatAuthnResponse(response, Direction.INBOUND, SignatureStatus.VALID_SIGNATURE);
 
         String expectedLogMessage = "Protective Monitoring – Authn Response Event – " +
-                "{responseId: default-response-id, " +
-                "inResponseTo: default-request-id, " +
+                "{responseId: " + DEFAULT_RESPONSE_ID + ", " +
+                "inResponseTo: " + DEFAULT_REQUEST_ID + ", " +
                 "direction: INBOUND, " +
                 "destination: http://destination.com, " +
                 "issuerId: a-test-entity, " +


### PR DESCRIPTION
Bump the version of libs from verify-saml-libs that we use.

Fix a test that was dependent on a string value from the bumped libs.