### PR TITLE
EID-1583 Revert eIDAS insigned assertions handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 ext {
-    opensaml_version = '3.4.2'
+    opensaml_version = '3.4.3'
     dropwizard_version = '1.3.9'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
@@ -45,7 +45,7 @@ def dependencyVersions = [
             ida_test_utils:"2.0.0-46",
             opensaml:"$opensaml_version",
             dev_pki: '1.1.0-37',
-            saml_lib:"$opensaml_version-206"
+            saml_lib:"$opensaml_version-209"
         ]
 
 subprojects {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/EidasValidatorFactory.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/factories/EidasValidatorFactory.java
@@ -33,7 +33,7 @@ public class EidasValidatorFactory {
 
     public void getValidatedAssertion(ValidatedResponse validatedResponse, List<Assertion> decryptedAssertions) {
         SamlAssertionsSignatureValidator samlAssertionsSignatureValidator = new SamlAssertionsSignatureValidator(getSamlMessageSignatureValidator(validatedResponse.getIssuer().getValue()));
-        samlAssertionsSignatureValidator.validateEidas(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        samlAssertionsSignatureValidator.validate(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
 
     private SamlMessageSignatureValidator getSamlMessageSignatureValidator(String entityId) {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidator.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidator.java
@@ -33,7 +33,7 @@ public class ResponseAssertionsFromCountryValidator {
 
     public void validate(ValidatedResponse validatedResponse, Assertion validatedIdentityAssertion) {
 
-        assertionValidator.validateEidas(
+        assertionValidator.validate(
             validatedIdentityAssertion,
             validatedResponse.getInResponseTo(),
             expectedRecipientId

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
@@ -59,7 +59,7 @@ public class ResponseAssertionsFromCountryValidatorTest {
     public void shouldValidateAssertion() {
         validator.validate(validatedResponse, assertion);
 
-        verify(assertionValidator).validateEidas(assertion, validatedResponse.getInResponseTo(), EXPECTED_RECIPIENT_ID);
+        verify(assertionValidator).validate(assertion, validatedResponse.getInResponseTo(), EXPECTED_RECIPIENT_ID);
         verify(authnStatementAssertionValidator).validate(assertion);
         verify(eidasAttributeStatementAssertionValidator).validate(assertion);
     }


### PR DESCRIPTION
There was an issue with how this was implemented and it needs rolling
back. This reverts the code and pulls in an updated version of saml-libs
that no longer contains the issue.

This feature will be reimplemented in future with a different approach.