### PR TITLE
Make S3ConfigSource simpler

### DIFF
--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/S3ConfigSourceTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/S3ConfigSourceTest.java
@@ -97,7 +97,7 @@ public class S3ConfigSourceTest {
      */
     public void getRemoteConfigReturnsRemoteConfigCollection() throws Exception {
         SelfServiceConfig selfServiceConfig = objectMapper.readValue(selfServiceConfigEnabledJson, SelfServiceConfig.class);
-        when(s3Client.getObject(BUCKET_NAME, OBJECT_KEY)).thenReturn(s3Object);
+        when(s3Client.getObject(new GetObjectRequest(BUCKET_NAME, OBJECT_KEY))).thenReturn(s3Object);
         when(s3Object.getObjectContent()).thenReturn(getObjectStream("/remote-test-config.json"));
         when(s3Object.getObjectMetadata()).thenReturn(objectMetadata);
         when(objectMetadata.getLastModified()).thenReturn(new Date());
@@ -135,7 +135,7 @@ public class S3ConfigSourceTest {
     @Test
     public void getRemoteConfigReturnsCachedConfigWhenRepeatedlyCalled() throws IOException {
         SelfServiceConfig selfServiceConfig = objectMapper.readValue(selfServiceConfigEnabledJson, SelfServiceConfig.class);
-        when(s3Client.getObject(BUCKET_NAME, OBJECT_KEY)).thenReturn(s3Object);
+        when(s3Client.getObject(new GetObjectRequest(BUCKET_NAME, OBJECT_KEY))).thenReturn(s3Object);
         when(s3Object.getObjectContent()).thenReturn(getObjectStream("/remote-test-config.json"));
         when(s3Object.getObjectMetadata()).thenReturn(objectMetadata);
         when(objectMetadata.getLastModified()).thenReturn(new Date());
@@ -150,7 +150,7 @@ public class S3ConfigSourceTest {
     @Test
     public void getRemoteConfigOnlyRetrievesNewContentWhenLastModifiedChanges() throws Exception {
         SelfServiceConfig selfServiceConfig = objectMapper.readValue(selfServiceConfigShortCacheJson, SelfServiceConfig.class);
-        when(s3Client.getObject(BUCKET_NAME, OBJECT_KEY)).thenReturn(s3Object);
+        when(s3Client.getObject(new GetObjectRequest(BUCKET_NAME, OBJECT_KEY))).thenReturn(s3Object);
         when(s3Object.getObjectContent()).thenReturn(getObjectStream("/remote-test-config.json"));
         when(s3Object.getObjectMetadata()).thenReturn(objectMetadata);
         when(objectMetadata.getLastModified()).thenReturn(Date.from(Instant.now().minusMillis(10000)));


### PR DESCRIPTION
This class can be simpler.

* We don't need the whole of `SelfServiceConfig`, just the key name for the object in S3
* Merge both copies of the code for pulling objects from S3