### PR TITLE
Make better use of the Streams API

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
@@ -1,10 +1,7 @@
 package uk.gov.ida.saml.hub.domain;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-
 import java.io.Serializable;
+import java.util.List;
 
 public enum UserAccountCreationAttribute implements Serializable {
     FIRST_NAME("firstname"),
@@ -31,12 +28,11 @@ public enum UserAccountCreationAttribute implements Serializable {
     }
 
     public static UserAccountCreationAttribute getUserAccountCreationAttribute(final String name){
-        return Iterables.find(ImmutableList.copyOf(values()), new Predicate<>() {
-            @Override
-            public boolean apply(final UserAccountCreationAttribute input) {
-                return input.getAttributeName().equals(name);
-            }
-        });
+        return List.of(values())
+                .stream()
+                .filter(input -> input.getAttributeName().equals(name))
+                .findFirst()
+                .orElseThrow();
     }
 }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/SamlEngineStubRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/SamlEngineStubRule.java
@@ -18,7 +18,6 @@ import uk.gov.ida.hub.policy.domain.InboundResponseFromCountry;
 import uk.gov.ida.hub.policy.domain.InboundResponseFromIdpDto;
 
 import javax.ws.rs.core.Response;
-import java.util.List;
 import java.util.UUID;
 
 public class SamlEngineStubRule extends HttpStubRule {
@@ -78,12 +77,15 @@ public class SamlEngineStubRule extends HttpStubRule {
         register(Urls.SamlEngineUrls.GENERATE_RP_ERROR_RESPONSE_RESOURCE, Response.Status.BAD_REQUEST.getStatusCode(), ErrorStatusDto.createAuditedErrorStatus(UUID.randomUUID(), ExceptionType.INVALID_INPUT));
     }
 
+    private RecordedRequest getRecordedTranslateRequest() {
+        return getRecordedRequest()
+                .stream()
+                .filter(request -> request.getPath().equals(Urls.SamlEngineUrls.TRANSLATE_IDP_AUTHN_RESPONSE_RESOURCE))
+                .findFirst()
+                .orElseThrow();
+    }
+
     public SamlAuthnResponseTranslatorDto getSamlAuthnResponseTranslatorDto(ObjectMapper objectMapper) throws java.io.IOException {
-        List<RecordedRequest> recordedRequest = getRecordedRequest();
-        RecordedRequest recordedTranslateRequest = recordedRequest.stream().filter(request -> {
-                    return request.getPath().equals(Urls.SamlEngineUrls.TRANSLATE_IDP_AUTHN_RESPONSE_RESOURCE);
-                }
-        ).findFirst().get();
-        return objectMapper.readValue(new String(recordedTranslateRequest.getEntityBytes()), SamlAuthnResponseTranslatorDto.class);
+        return objectMapper.readValue(new String(getRecordedTranslateRequest().getEntityBytes()), SamlAuthnResponseTranslatorDto.class);
     }
 }


### PR DESCRIPTION
We can remove the use of guava in `UserAccountCreationAttribute` by using `Stream`s more effectively.
By adding a helper method to `SamlEngineStubRule` we can make the `Stream`s invocation a bit neater