### PR TITLE
Simplify lambda usages

### DIFF
--- a/hub-saml/src/test/java/uk/gov/ida/saml/core/security/RelayStateValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/core/security/RelayStateValidatorTest.java
@@ -23,12 +23,7 @@ public class RelayStateValidatorTest {
         final String aStringMoreThanEightyCharacters = "a".repeat(82);
 
         SamlTransformationErrorManagerTestHelper.validateFail(
-                new SamlTransformationErrorManagerTestHelper.Action() {
-                    @Override
-                    public void execute() {
-                        relayStateValidator.validate(aStringMoreThanEightyCharacters);
-                    }
-                },
+                () -> relayStateValidator.validate(aStringMoreThanEightyCharacters),
                 SamlTransformationErrorFactory.invalidRelayState(aStringMoreThanEightyCharacters)
         );
 
@@ -48,12 +43,7 @@ public class RelayStateValidatorTest {
         for (final String i : asList(">", "<", "'", "\"", "%", "&", ";")) {
 
             SamlTransformationErrorManagerTestHelper.validateFail(
-                    new SamlTransformationErrorManagerTestHelper.Action() {
-                        @Override
-                        public void execute() {
-                            relayStateValidator.validate(aString + i);
-                        }
-                    },
+                    () -> relayStateValidator.validate(aString + i),
                     SamlTransformationErrorFactory.relayStateContainsInvalidCharacter(i, aString + i)
             );
         }

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestFromTransactionValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestFromTransactionValidatorTest.java
@@ -38,18 +38,8 @@ public class AuthnRequestFromTransactionValidatorTest {
 
     @Before
     public void setup() {
-        SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration = new SamlDuplicateRequestValidationConfiguration() {
-            @Override
-            public Duration getAuthnRequestIdExpirationDuration() {
-                return Duration.hours(2);
-            }
-        };
-        SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration = new SamlAuthnRequestValidityDurationConfiguration() {
-            @Override
-            public Duration getAuthnRequestValidityDuration() {
-                return Duration.minutes(5);
-            }
-        };
+        SamlDuplicateRequestValidationConfiguration samlDuplicateRequestValidationConfiguration = () -> Duration.hours(2);
+        SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration = () -> Duration.minutes(5);
         IdExpirationCache idExpirationCache = new ConcurrentMapIdExpirationCache(new ConcurrentHashMap<>());
         validator = new AuthnRequestFromTransactionValidator(
                 new IssuerValidator(),

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIssueInstantValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/AuthnRequestIssueInstantValidatorTest.java
@@ -17,12 +17,7 @@ public class AuthnRequestIssueInstantValidatorTest {
 
     @Before
     public void setup() {
-        SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration = new SamlAuthnRequestValidityDurationConfiguration() {
-            @Override
-            public Duration getAuthnRequestValidityDuration() {
-                return Duration.minutes(AUTHN_REQUEST_VALIDITY_MINS);
-            }
-        };
+        SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration = () -> Duration.minutes(AUTHN_REQUEST_VALIDITY_MINS);
 
         authnRequestIssueInstantValidator = new AuthnRequestIssueInstantValidator(samlAuthnRequestValidityDurationConfiguration);
     }

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/authnrequest/DuplicateAuthnRequestValidatorTest.java
@@ -23,12 +23,7 @@ public class DuplicateAuthnRequestValidatorTest {
 
     @Before
     public void initialiseTestSubject() {
-        SamlDuplicateRequestValidationConfiguration samlEngineConfiguration = new SamlDuplicateRequestValidationConfiguration() {
-            @Override
-            public Duration getAuthnRequestIdExpirationDuration() {
-                return Duration.hours(EXPIRATION_HOURS);
-            }
-        };
+        SamlDuplicateRequestValidationConfiguration samlEngineConfiguration = () -> Duration.hours(EXPIRATION_HOURS);
         ConcurrentMap<AuthnRequestIdKey, DateTime> duplicateIds = new ConcurrentHashMap<>();
         IdExpirationCache idExpirationCache = new ConcurrentMapIdExpirationCache(duplicateIds);
         duplicateAuthnRequestValidator = new DuplicateAuthnRequestValidator(idExpirationCache, samlEngineConfiguration);

--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/transformers/decorators/SamlEntityDescriptorValidatorTest.java
@@ -107,12 +107,7 @@ public class SamlEntityDescriptorValidatorTest {
     public void assertExceptionMessage(final EntityDescriptor entityDescriptor, SamlValidationSpecificationFailure failure) {
 
         SamlTransformationErrorManagerTestHelper.validateFail(
-                new SamlTransformationErrorManagerTestHelper.Action() {
-                    @Override
-                    public void execute() {
-                        validator.validate(entityDescriptor);
-                    }
-                },
+                () -> validator.validate(entityDescriptor),
                 failure
         );
 

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
@@ -130,7 +130,7 @@ public class PrometheusMetricsIntegrationTest {
         assertThat(entity).contains(String.format(GAUGE_TYPE_TEMPLATE, VERIFY_CONFIG_CERTIFICATE_OCSP_LAST_SUCCESS_TIMESTAMP));
 
         getExpectedCertificatesMetrics().stream()
-                                        .filter(expectedMessage -> expectedMessage.isPresent())
+                                        .filter(Message::isPresent)
                                         .forEach(expectedMessage -> assertThat(entity).contains(expectedMessage.getMessage()));
         getExpectedCertificatesMetrics().stream()
                                         .filter(expectedMessage -> !expectedMessage.isPresent())
@@ -154,14 +154,14 @@ public class PrometheusMetricsIntegrationTest {
                         .forEach(
                             certificate -> {
                                 getExpectedCertificateExpiryDateMetrics(configEntityData.getEntityId(), certificate).ifPresent(
-                                    expectedCertificateExpiryMetrics -> expectedCertificatesMetrics.add(expectedCertificateExpiryMetrics));
+                                        expectedCertificatesMetrics::add);
                                 getExpectedCertificateOcspRevocationStatusMetrics(configEntityData.getEntityId(), certificate).ifPresent(
-                                    expectedCertificateOcspRevocationStatusMetrics -> expectedCertificatesMetrics.addAll(expectedCertificateOcspRevocationStatusMetrics));
+                                        expectedCertificatesMetrics::addAll);
                             });
         getExpectedCertificateExpiryDateMetrics(configEntityData.getEntityId(), configEntityData.getEncryptionCertificate()).ifPresent(
-            expectedCertificateExpiryMetrics -> expectedCertificatesMetrics.add(expectedCertificateExpiryMetrics));
+                expectedCertificatesMetrics::add);
         getExpectedCertificateOcspRevocationStatusMetrics(configEntityData.getEntityId(), configEntityData.getEncryptionCertificate()).ifPresent(
-            expectedCertificateOcspRevocationStatusMetrics -> expectedCertificatesMetrics.addAll(expectedCertificateOcspRevocationStatusMetrics));
+                expectedCertificatesMetrics::addAll);
         addExpectedCertificateExpiryDateLastUpdate(expectedCertificatesMetrics);
         return expectedCertificatesMetrics;
     }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigDataBootstrap.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/ConfigDataBootstrap.java
@@ -124,7 +124,7 @@ public class ConfigDataBootstrap implements Managed {
         final Set<IdentityProviderConfig> enabledIdentityProviders = identityProviderConfigRepository
                 .getAllData()
                 .stream()
-                .filter(input -> input.isEnabled())
+                .filter(IdentityProviderConfig::isEnabled)
                 .collect(Collectors.toSet());
 
         Set<TransactionConfig> transactionConfigs = transactionConfigRepository.getAllData();

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/ConfigStubRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/ConfigStubRule.java
@@ -45,7 +45,7 @@ public class ConfigStubRule extends HttpStubRule {
     public void setUpStubForEnabledCountries(String rpEntityId, Collection<EidasCountryDto> enabledCountries) throws JsonProcessingException {
         register(Urls.ConfigUrls.COUNTRIES_ROOT, OK, enabledCountries);
 
-        List<String> countryEntityIds = enabledCountries.stream().map(country -> country.getEntityId()).collect(Collectors.toList());
+        List<String> countryEntityIds = enabledCountries.stream().map(EidasCountryDto::getEntityId).collect(Collectors.toList());
         UriBuilder countriesForTransactionUriBuilder = UriBuilder.fromPath(Urls.ConfigUrls.EIDAS_RP_COUNTRIES_FOR_TRANSACTION_RESOURCE);
         String countriesForTransactionPath = countriesForTransactionUriBuilder.buildFromEncoded(StringEncoding.urlEncode(rpEntityId).replace("+", "%20")).getPath();
         register(countriesForTransactionPath, OK, countryEntityIds);

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -364,7 +364,7 @@ public class SamlEngineModule extends AbstractModule {
     public Optional<EidasValidatorFactory> getEidasValidatorFactory(Optional<EidasMetadataResolverRepository> eidasMetadataResolverRepository, SamlEngineConfiguration configuration){
         if (configuration.isEidasEnabled()){
             Optional<EidasValidatorFactory> eidasValidatorFactory = eidasMetadataResolverRepository
-                    .map(repository -> new  EidasValidatorFactory(repository));
+                    .map(EidasValidatorFactory::new);
             return eidasValidatorFactory;
         }
         return Optional.empty();
@@ -375,7 +375,7 @@ public class SamlEngineModule extends AbstractModule {
     public Optional<CountrySingleSignOnServiceHelper> getCountrySingleSignOnServiceHelper(Optional<EidasMetadataResolverRepository> eidasMetadataResolverRepository, SamlEngineConfiguration configuration){
         if (configuration.isEidasEnabled()){
             Optional<CountrySingleSignOnServiceHelper> countrySingleSignOnServiceHelper = eidasMetadataResolverRepository
-                    .map(repository -> new CountrySingleSignOnServiceHelper(repository));
+                    .map(CountrySingleSignOnServiceHelper::new);
             return countrySingleSignOnServiceHelper;
         }
         return Optional.empty();
@@ -387,7 +387,7 @@ public class SamlEngineModule extends AbstractModule {
         Optional<EidasMetadataResolverRepository> metadataResolverRepository,
         Environment environment){
         Optional<EidasTrustAnchorHealthCheck> metadataHealthCheck = metadataResolverRepository
-                .map(repository -> new EidasTrustAnchorHealthCheck(repository));
+                .map(EidasTrustAnchorHealthCheck::new);
 
         metadataHealthCheck.ifPresent(healthCheck -> environment.healthChecks().register(COUNTRY_METADATA_HEALTH_CHECK, healthCheck));
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -255,7 +255,7 @@ public class SamlProxyModule extends AbstractModule {
         Environment environment){
 
         Optional<EidasTrustAnchorHealthCheck> metadataHealthCheck = metadataResolverRepository
-                .map(repository -> new EidasTrustAnchorHealthCheck(repository));
+                .map(EidasTrustAnchorHealthCheck::new);
 
         metadataHealthCheck.ifPresent(healthCheck -> environment.healthChecks().register(COUNTRY_METADATA_HEALTH_CHECK, healthCheck));
         return metadataHealthCheck;


### PR DESCRIPTION
Replace some anonymous types with lambdas and use method references instead of lambdas where we can