### PR TITLE
Simplify our handing of arrays in various places

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/HubIdentityProviderMetadataDto.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/metadata/domain/HubIdentityProviderMetadataDto.java
@@ -4,9 +4,10 @@ import org.joda.time.DateTime;
 import uk.gov.ida.common.shared.security.Certificate;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+
+import static java.util.Collections.singletonList;
 
 public class HubIdentityProviderMetadataDto extends MetadataDto {
 
@@ -23,7 +24,7 @@ public class HubIdentityProviderMetadataDto extends MetadataDto {
             List<Certificate> hubSigningCertificates,
             Certificate hubEncryptionCertificate) {
 
-        super(entityId, validUntil, organisation, contactPersons, hubSigningCertificates, Arrays.asList(hubEncryptionCertificate));
+        super(entityId, validUntil, organisation, contactPersons, hubSigningCertificates, singletonList(hubEncryptionCertificate));
 
         this.singleSignOnEndpoints = singleSignOnEndpoints;
 

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/CertificatesResourceIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/CertificatesResourceIntegrationTest.java
@@ -18,7 +18,7 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collection;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
 import static uk.gov.ida.hub.config.domain.builders.MatchingServiceConfigBuilder.aMatchingServiceConfig;
@@ -57,7 +57,7 @@ public class CertificatesResourceIntegrationTest {
                     .build())
             .addIdp(anIdentityProviderConfigData()
                     .withEntityId("idp-entity-id")
-                    .withOnboarding(asList(RP_ENTITY_ID))
+                    .withOnboarding(singletonList(RP_ENTITY_ID))
                     .build());
 
     @BeforeClass

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/MatchingServiceResourceIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/MatchingServiceResourceIntegrationTest.java
@@ -18,7 +18,7 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collection;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.config.domain.builders.TransactionConfigBuilder.aTransactionConfigData;
 import static uk.gov.ida.hub.config.domain.builders.MatchingServiceConfigBuilder.aMatchingServiceConfig;
@@ -46,7 +46,7 @@ public class MatchingServiceResourceIntegrationTest {
                     .build())
             .addIdp(anIdentityProviderConfigData()
                     .withEntityId("idp-entity-id")
-                    .withOnboarding(asList("rp-entity-id"))
+                    .withOnboarding(singletonList("rp-entity-id"))
                     .build());
 
 

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/PrometheusMetricsIntegrationTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.config.application.OcspCertificateChainValidationService.INVALID;
 import static uk.gov.ida.hub.config.application.PrometheusClientService.VERIFY_CONFIG_CERTIFICATE_EXPIRY_DATE;
@@ -61,7 +61,7 @@ public class PrometheusMetricsIntegrationTest {
     private static final MatchingServiceConfig MATCHING_SERVICE_CONFIG_ENTITY_DATA = aMatchingServiceConfig().withEntityId(RP_MS_ENTITY_ID)
                                                                                                                                  .build();
     private static final IdentityProviderConfig IDENTITY_PROVIDER_CONFIG_ENTITY_DATA = anIdentityProviderConfigData().withEntityId("idp-entity-id")
-                                                                                                                               .withOnboarding(asList(RP_ENTITY_ID))
+                                                                                                                               .withOnboarding(singletonList(RP_ENTITY_ID))
                                                                                                                                .build();
     private static final String RP_ENTITY_ID_BAD_SIGNATURE_CERT = "rp-entity-id-bad-cert";
     private static final String RP_ENTITY_ID_BAD_ENCRYPTION_CERT = "rp-entity-id-bad-encryption-cert";

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/SelfServiceCertificatesResourceIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/SelfServiceCertificatesResourceIntegrationTest.java
@@ -24,7 +24,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
 import static uk.gov.ida.hub.config.domain.builders.MatchingServiceConfigBuilder.aMatchingServiceConfig;
@@ -63,7 +63,7 @@ public class SelfServiceCertificatesResourceIntegrationTest {
                     .build())
             .addIdp(anIdentityProviderConfigData()
                     .withEntityId("idp-entity-id")
-                    .withOnboarding(asList("rp-entity-id"))
+                    .withOnboarding(singletonList("rp-entity-id"))
                     .build());
 
     @ClassRule

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static uk.gov.ida.hub.config.domain.builders.CountryConfigBuilder.aCountryConfig;
 import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
 import static uk.gov.ida.hub.config.domain.builders.MatchingServiceConfigBuilder.aMatchingServiceConfig;
@@ -169,7 +169,7 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
             idps.add(
                 anIdentityProviderConfigData()
                     .withEntityId("default-idp-entity-id")
-                    .withOnboarding(asList("default-rp-entity-id"))
+                    .withOnboarding(singletonList("default-rp-entity-id"))
                     .build()
             );
         }

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -77,7 +77,7 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
                 .add(config("translationsDirectory", TRANSLATIONS_RELATIVE_PATH))
                 .add(configOverrides)
                 .build();
-        return overrides.toArray(new ConfigOverride[overrides.size()]);
+        return overrides.toArray(new ConfigOverride[0]);
     }
 
     public ConfigAppRule addTransaction(TransactionConfig transaction) {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.config.application;
 
 import com.google.inject.Inject;
-import uk.gov.ida.hub.config.data.LocalConfigRepository;
 import uk.gov.ida.hub.config.data.ManagedEntityConfigRepository;
 import uk.gov.ida.hub.config.domain.Certificate;
 import uk.gov.ida.hub.config.domain.CertificateConfigurable;
@@ -64,15 +63,8 @@ public class CertificateService <T extends CertificateConfigurable<T>> {
         return list;
     }
 
-    private Stream<Certificate> getAllCertificates(LocalConfigRepository<T> configRepository) {
-        return configRepository.getAllData()
-                .stream()
-                .flatMap(this::getAllCertificates);
-    }
-
     private Stream<Certificate> getAllCertificates(T config){
-        List<Certificate> certs = new ArrayList();
-        certs.addAll(config.getSignatureVerificationCertificates());
+        ArrayList<Certificate> certs = new ArrayList<>(config.getSignatureVerificationCertificates());
         certs.add(config.getEncryptionCertificate());
         return certs.stream();
     }
@@ -83,6 +75,6 @@ public class CertificateService <T extends CertificateConfigurable<T>> {
                 .findFirst()
                 .orElseThrow(NoCertificateFoundException::new)
                 .get(entityId)
-                .get();
+                .orElseThrow();
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidator.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidator.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static uk.gov.ida.hub.config.domain.LevelOfAssurance.LEVEL_1;
 import static uk.gov.ida.hub.config.domain.LevelOfAssurance.LEVEL_2;
@@ -61,7 +62,7 @@ public class LevelsOfAssuranceConfigValidator {
                 .filter(x -> {
                     List<LevelOfAssurance> levelsOfAssurance = x.getLevelsOfAssurance();
                     boolean isLoa1 = levelsOfAssurance.equals(asList(LEVEL_1, LEVEL_2));
-                    boolean isLoa2 = levelsOfAssurance.equals(asList(LEVEL_2));
+                    boolean isLoa2 = levelsOfAssurance.equals(singletonList(LEVEL_2));
                     return !(isLoa1 || isLoa2);
                 })
                 .collect(Collectors.toList());

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidatorTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidatorTest.java
@@ -14,6 +14,7 @@ import uk.gov.ida.hub.config.exceptions.ConfigValidationException;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.fail;
 
 public class LevelsOfAssuranceConfigValidatorTest {
@@ -34,10 +35,10 @@ public class LevelsOfAssuranceConfigValidatorTest {
             .build();
 
     private final TransactionConfig loa1OnlyTransaction = TransactionConfigBuilder.aTransactionConfigData()
-            .withLevelsOfAssurance(asList(LevelOfAssurance.LEVEL_1))
+            .withLevelsOfAssurance(singletonList(LevelOfAssurance.LEVEL_1))
             .build();
     private final TransactionConfig loa3OnlyTransaction = TransactionConfigBuilder.aTransactionConfigData()
-            .withLevelsOfAssurance(asList(LevelOfAssurance.LEVEL_3))
+            .withLevelsOfAssurance(singletonList(LevelOfAssurance.LEVEL_3))
             .build();
     private final TransactionConfig loa2And1Transaction = TransactionConfigBuilder.aTransactionConfigData()
             .withLevelsOfAssurance(asList(LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_1))
@@ -46,7 +47,7 @@ public class LevelsOfAssuranceConfigValidatorTest {
             .withLevelsOfAssurance(asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .build();
     final TransactionConfig loa2Transaction = TransactionConfigBuilder.aTransactionConfigData()
-            .withLevelsOfAssurance(asList(LevelOfAssurance.LEVEL_2))
+            .withLevelsOfAssurance(singletonList(LevelOfAssurance.LEVEL_2))
             .build();
 
     @Before

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/exceptions/ConfigValidationExceptionTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/exceptions/ConfigValidationExceptionTest.java
@@ -12,7 +12,7 @@ import java.security.cert.CertPathValidatorException;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
 import static uk.gov.ida.hub.config.domain.builders.TransactionConfigBuilder.aTransactionConfigData;
@@ -45,7 +45,7 @@ public class ConfigValidationExceptionTest {
     @Test
     public void createInvalidCertificatesException() throws Exception {
         InvalidCertificateDto invalidCertificateDto = new InvalidCertificateDto("entity-id", CertPathValidatorException.BasicReason.EXPIRED, CertificateType.ENCRYPTION, FederationEntityType.IDP, "description");
-        ConfigValidationException exception = ConfigValidationException.createInvalidCertificatesException(asList(invalidCertificateDto));
+        ConfigValidationException exception = ConfigValidationException.createInvalidCertificatesException(singletonList(invalidCertificateDto));
         assertThat(exception.getMessage()).isEqualTo("Invalid certificate found.\n" +
                 "Entity Id: entity-id\n" +
                 "Certificate Type: ENCRYPTION\n" +
@@ -56,13 +56,13 @@ public class ConfigValidationExceptionTest {
 
     @Test
     public void createIDPLevelsOfAssuranceUnsupportedException() throws Exception {
-        ConfigValidationException exception = ConfigValidationException.createIDPLevelsOfAssuranceUnsupportedException(asList(anIdentityProviderConfigData().build()));
+        ConfigValidationException exception = ConfigValidationException.createIDPLevelsOfAssuranceUnsupportedException(singletonList(anIdentityProviderConfigData().build()));
         assertThat(exception.getMessage()).isEqualTo("Unsupported level of assurance in IDP config.\nEntity Id: default-idp-entity-id\nLevels: [LEVEL_2]\n");
     }
 
     @Test
     public void createTransactionsRequireUnsupportedLevelOfAssurance() throws Exception {
-        ConfigValidationException exception = ConfigValidationException.createTransactionsRequireUnsupportedLevelOfAssurance(asList(aTransactionConfigData().build()));
+        ConfigValidationException exception = ConfigValidationException.createTransactionsRequireUnsupportedLevelOfAssurance(singletonList(aTransactionConfigData().build()));
         assertThat(exception.getMessage()).isEqualTo("Unsupported level of assurance in transaction config.\n" +
                 "Entity Id: default-transaction-entity-id\n" +
                 "Levels of assurance: [LEVEL_1, LEVEL_2]\n");
@@ -70,7 +70,7 @@ public class ConfigValidationExceptionTest {
 
     @Test
     public void createIncompatiblePairsOfTransactionsAndIDPs() throws Exception {
-        Map<TransactionConfig, List<IdentityProviderConfig>> incompatiblePairs = ImmutableMap.of(aTransactionConfigData().build(), asList(anIdentityProviderConfigData().build()));
+        Map<TransactionConfig, List<IdentityProviderConfig>> incompatiblePairs = ImmutableMap.of(aTransactionConfigData().build(), singletonList(anIdentityProviderConfigData().build()));
         ConfigValidationException exception = ConfigValidationException.createIncompatiblePairsOfTransactionsAndIDPs(incompatiblePairs);
         assertThat(exception.getMessage()).isEqualTo("Transaction unsupported by IDP(s).\n" +
                 "Transaction: default-transaction-entity-id\n" +

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
@@ -32,7 +32,7 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
                 .add(config("eventEmitterConfiguration.enabled", "false"))
                 .add(configOverrides)
                 .build();
-        return mergedConfigOverrides.toArray(new ConfigOverride[mergedConfigOverrides.size()]);
+        return mergedConfigOverrides.toArray(new ConfigOverride[0]);
     }
 
     @Override

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRuleWithRedis.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRuleWithRedis.java
@@ -38,7 +38,7 @@ public class PolicyAppRuleWithRedis extends DropwizardAppRule<PolicyConfiguratio
                 .add(config("sessionStore.redis.uri", "redis://localhost:" + REDIS_PORT))
                 .add(configOverrides)
                 .build();
-        return mergedConfigOverrides.toArray(new ConfigOverride[mergedConfigOverrides.size()]);
+        return mergedConfigOverrides.toArray(new ConfigOverride[0]);
     }
 
     @Override

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/validators/LevelOfAssuranceValidator.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/validators/LevelOfAssuranceValidator.java
@@ -3,8 +3,7 @@ package uk.gov.ida.hub.policy.validators;
 import com.google.common.base.Optional;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 
-import java.util.Arrays;
-
+import static java.util.Collections.singletonList;
 import static uk.gov.ida.hub.policy.domain.exception.StateProcessingValidationException.noLevelOfAssurance;
 import static uk.gov.ida.hub.policy.domain.exception.StateProcessingValidationException.wrongLevelOfAssurance;
 
@@ -17,7 +16,7 @@ public class LevelOfAssuranceValidator {
         }
 
         if (!responseLevelOfAssurance.get().equals(requiredLevelOfAssurance)) {
-            throw wrongLevelOfAssurance(java.util.Optional.of(responseLevelOfAssurance.get()), Arrays.asList(requiredLevelOfAssurance));
+            throw wrongLevelOfAssurance(java.util.Optional.of(responseLevelOfAssurance.get()), singletonList(requiredLevelOfAssurance));
         }
     }
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/exception/StateProcessingValidationExceptionMapperTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/exception/StateProcessingValidationExceptionMapperTest.java
@@ -16,7 +16,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -61,9 +61,9 @@ public class StateProcessingValidationExceptionMapperTest {
     public void shouldDoFormatMessage(){
         StateProcessingValidationException exception = StateProcessingValidationException.transactionLevelsOfAssuranceUnsupportedByIDP(
                 "requestIssuerEntityId",
-                asList(LevelOfAssurance.LEVEL_2),
+                singletonList(LevelOfAssurance.LEVEL_2),
                 "idpEntityId",
-                asList(LevelOfAssurance.LEVEL_1));
+                singletonList(LevelOfAssurance.LEVEL_1));
         assertThat(exception.getMessage()).isEqualTo("Transaction LevelsOfAssurance unsupported by IDP. Transaction: requestIssuerEntityId, LOAs: [LEVEL_2], IDP: idpEntityId, IDP LOAs: [LEVEL_1]");
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/CountriesServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/CountriesServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -69,17 +70,16 @@ public class CountriesServiceTest {
     public void shouldReturnIntersectionOfEnabledSystemWideCountriesAndRPConfiguredCountries() {
         setSystemWideCountries(asList(COUNTRY_1, COUNTRY_2, DISABLED_COUNTRY));
         when(sessionRepository.getRequestIssuerEntityId(sessionId)).thenReturn(RELYING_PARTY_ID);
-        when(configProxy.getEidasSupportedCountriesForRP(RELYING_PARTY_ID)).thenReturn(asList(COUNTRY_2.getEntityId()));
-        List<EidasCountryDto> countries = service.getCountries(sessionId);
+        when(configProxy.getEidasSupportedCountriesForRP(RELYING_PARTY_ID)).thenReturn(singletonList(COUNTRY_2.getEntityId()));
 
-        assertThat(countries, equalTo(Arrays.asList(COUNTRY_2)));
+        assertThat(service.getCountries(sessionId), equalTo(singletonList(COUNTRY_2)));
     }
 
     @Test
     public void shouldSetSelectedCountry() {
         EidasCountrySelectedStateController mockEidasCountrySelectedStateController = mock(EidasCountrySelectedStateController.class);
         when(sessionRepository.getStateController(sessionId, EidasCountrySelectingState.class)).thenReturn(mockEidasCountrySelectedStateController);
-        setSystemWideCountries(asList(COUNTRY_1));
+        setSystemWideCountries(singletonList(COUNTRY_1));
 
         service.setSelectedCountry(sessionId, COUNTRY_1.getSimpleId());
 
@@ -88,7 +88,7 @@ public class CountriesServiceTest {
 
     @Test(expected = EidasCountryNotSupportedException.class)
     public void shouldReturnErrorWhenAnInvalidCountryIsSelected() {
-        setSystemWideCountries(asList(COUNTRY_1));
+        setSystemWideCountries(singletonList(COUNTRY_1));
 
         service.setSelectedCountry(sessionId, "not-a-valid-country-code");
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/validators/LevelOfAssuranceValidatorTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/validators/LevelOfAssuranceValidatorTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.exception.StateProcessingValidationException;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -42,7 +42,7 @@ public class LevelOfAssuranceValidatorTest {
             levelOfAssuranceValidator.validate(Optional.fromNullable(LevelOfAssurance.LEVEL_2), LevelOfAssurance.LEVEL_4);
             fail("fail");
         } catch (StateProcessingValidationException e) {
-            assertThat(e.getMessage()).isEqualTo(StateProcessingValidationException.wrongLevelOfAssurance(java.util.Optional.of(LevelOfAssurance.LEVEL_2), asList(LevelOfAssurance.LEVEL_4)).getMessage());
+            assertThat(e.getMessage()).isEqualTo(StateProcessingValidationException.wrongLevelOfAssurance(java.util.Optional.of(LevelOfAssurance.LEVEL_2), singletonList(LevelOfAssurance.LEVEL_4)).getMessage());
         }
     }
 }

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/EidasDisabledResourceTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/EidasDisabledResourceTest.java
@@ -21,7 +21,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_ONE;
@@ -68,7 +68,7 @@ public class EidasDisabledResourceTest {
     private Response generateCountryAuthnRequest() {
         IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = new IdaAuthnRequestFromHubDto(
                 "1",
-                asList(AuthnContext.LEVEL_2),
+                singletonList(AuthnContext.LEVEL_2),
                 Optional.of(false),
                 new DateTime(),
                 STUB_IDP_ONE,

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/IdpAuthnRequestGeneratorResourceTest.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/IdpAuthnRequestGeneratorResourceTest.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Optional;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.TestEntityIds.STUB_IDP_ONE;
 
@@ -50,7 +50,7 @@ public class IdpAuthnRequestGeneratorResourceTest {
         final String idpEntityId = STUB_IDP_ONE;
         final URI ssoUri = URI.create("http://foo.com/bar");
 
-        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = new IdaAuthnRequestFromHubDto("1", asList(AuthnContext.LEVEL_2), Optional.of(false), new DateTime(), idpEntityId, false);
+        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = new IdaAuthnRequestFromHubDto("1", singletonList(AuthnContext.LEVEL_2), Optional.of(false), new DateTime(), idpEntityId, false);
 
         final URI uri = samlEngineAppRule.getUri(Urls.SamlEngineUrls.GENERATE_IDP_AUTHN_REQUEST_RESOURCE);
         Response clientResponse = client.target(uri)

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -154,7 +154,7 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
             overrides.addAll(countryOverrides);
         }
         overrides.addAll(Arrays.asList(configOverrides));
-        return overrides.toArray(new ConfigOverride[overrides.size()]);
+        return overrides.toArray(new ConfigOverride[0]);
     }
 
     @Override

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/IdaAuthnRequestTranslatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/services/IdaAuthnRequestTranslatorTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class IdaAuthnRequestTranslatorTest {
@@ -21,7 +22,7 @@ public class IdaAuthnRequestTranslatorTest {
 
     @Test
     public void shouldUseExactComparisonTypeAndLevelsOfAssurance(){
-        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = aRequestDto(asList(AuthnContext.LEVEL_2), true);
+        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = aRequestDto(singletonList(AuthnContext.LEVEL_2), true);
 
         IdaAuthnRequestFromHub idaAuthnRequestFromHub = idaAuthnRequestTranslator.getIdaAuthnRequestFromHub(idaAuthnRequestFromHubDto, URI.create("http://example.com"), HUB_ENTITY_ID);
 
@@ -31,7 +32,7 @@ public class IdaAuthnRequestTranslatorTest {
 
     @Test
     public void shouldUseMinimumComparisonTypeAndDuplicateSingleLevelOfAssurance(){
-        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = aRequestDto(asList(AuthnContext.LEVEL_2), false);
+        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = aRequestDto(singletonList(AuthnContext.LEVEL_2), false);
 
         IdaAuthnRequestFromHub idaAuthnRequestFromHub = idaAuthnRequestTranslator.getIdaAuthnRequestFromHub(idaAuthnRequestFromHubDto, URI.create("http://example.com"), HUB_ENTITY_ID);
 
@@ -51,7 +52,7 @@ public class IdaAuthnRequestTranslatorTest {
 
     @Test
     public void shouldUseMinimumComparisonTypeAndSendDuplicateLOAs(){
-        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = aRequestDto(asList(AuthnContext.LEVEL_2), false);
+        IdaAuthnRequestFromHubDto idaAuthnRequestFromHubDto = aRequestDto(singletonList(AuthnContext.LEVEL_2), false);
 
         IdaAuthnRequestFromHub idaAuthnRequestFromHub = idaAuthnRequestTranslator.getIdaAuthnRequestFromHub(idaAuthnRequestFromHubDto, URI.create("http://example.com"), HUB_ENTITY_ID);
 

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
@@ -128,7 +128,7 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
             overrides.addAll(countryOverrides);
         }
         overrides.addAll(Arrays.asList(configOverrides));
-        return overrides.toArray(new ConfigOverride[overrides.size()]);
+        return overrides.toArray(new ConfigOverride[0]);
     }
 
     @Override

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/handlers/HubAsIdpMetadataHandler.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/handlers/HubAsIdpMetadataHandler.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static uk.gov.ida.hub.samlproxy.Urls.FrontendUrls.SAML2_SSO_REQUEST_ENDPOINT;
 
 public class HubAsIdpMetadataHandler {
@@ -98,7 +98,7 @@ public class HubAsIdpMetadataHandler {
                 .collect(Collectors.toList());
 
         return new HubIdentityProviderMetadataDto(
-                asList(binding),
+                singletonList(binding),
                 hubEntityId,
                 organisationDto,
                 Collections.<ContactPersonDto>emptySet(),

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
@@ -61,7 +61,7 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
         ).collect(Collectors.toList());
 
         overrides.addAll(Arrays.asList(configOverrides));
-        return overrides.toArray(new ConfigOverride[overrides.size()]);
+        return overrides.toArray(new ConfigOverride[0]);
     }
 
     @Override

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/healthcheck/MatchingServiceHealthCheckHandlerTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/healthcheck/MatchingServiceHealthCheckHandlerTest.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.util.Collection;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -41,7 +42,7 @@ public class MatchingServiceHealthCheckHandlerTest {
     @Test
     public void handle_shouldReturnSuccessWhenMatchingServiceIsHealthy() throws Exception {
         MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto = MatchingServiceConfigEntityDataDtoBuilder.aMatchingServiceConfigEntityDataDto().build();
-        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(asList(matchingServiceConfigEntityDataDto));
+        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(singletonList(matchingServiceConfigEntityDataDto));
         when(matchingServiceHealthChecker.performHealthCheck(matchingServiceConfigEntityDataDto))
                 .thenReturn(MatchingServiceHealthCheckResult.healthy(MatchingServiceHealthCheckDetailsBuilder.aMatchingServiceHealthCheckDetails().build()));
 
@@ -53,7 +54,7 @@ public class MatchingServiceHealthCheckHandlerTest {
     @Test
     public void handle_shouldReturnSuccessWhenMatchingServiceIsNotHealthy() throws Exception {
         MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto = MatchingServiceConfigEntityDataDtoBuilder.aMatchingServiceConfigEntityDataDto().build();
-        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(asList(matchingServiceConfigEntityDataDto));
+        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(singletonList(matchingServiceConfigEntityDataDto));
         when(matchingServiceHealthChecker.performHealthCheck(matchingServiceConfigEntityDataDto))
                 .thenReturn(MatchingServiceHealthCheckResult.unhealthy(MatchingServiceHealthCheckDetailsBuilder.aMatchingServiceHealthCheckDetails().build()));
 
@@ -81,7 +82,7 @@ public class MatchingServiceHealthCheckHandlerTest {
     @Test
     public void handle_shouldNotExecuteHealthCheckForMatchingServiceWithHealthCheckDisabled() {
         MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto = aMatchingServiceConfigEntityDataDto().withHealthCheckDisabled().build();
-        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(asList(matchingServiceConfigEntityDataDto));
+        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(singletonList(matchingServiceConfigEntityDataDto));
 
         matchingServiceHealthCheckHandler.handle();
 
@@ -92,7 +93,7 @@ public class MatchingServiceHealthCheckHandlerTest {
     @Test
     public void handle_shouldExecuteHealthCheckForMatchingServiceWithHealthCheckDisabledWhenForced() {
         MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto = aMatchingServiceConfigEntityDataDto().withHealthCheckDisabled().build();
-        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(asList(matchingServiceConfigEntityDataDto));
+        when(matchingServiceConfigProxy.getMatchingServices()).thenReturn(singletonList(matchingServiceConfigEntityDataDto));
 
         matchingServiceHealthCheckHandler.forceCheckAllMSAs();
 


### PR DESCRIPTION
Make use of `singletonList()` where we can
Stop passing sizes to `toArray()` where we don't need to
Simplify `CertificateService` by removing the unused `getAllCertificates` method and make use of the constructor to `ArrayList` which takes a `List` in `getAllCertificates`