### PR TITLE
Simplify UnknownMethodAlgorithmLogger

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/UnknownMethodAlgorithmLogger.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/logging/UnknownMethodAlgorithmLogger.java
@@ -7,6 +7,7 @@ import org.apache.xml.security.signature.XMLSignature;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
 import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
 import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA512;
 import org.opensaml.xmlsec.signature.Signature;
@@ -17,11 +18,10 @@ import org.slf4j.LoggerFactory;
 import uk.gov.ida.saml.hub.domain.AuthnRequestFromRelyingParty;
 import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
 
-import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import static java.text.MessageFormat.format;
+import static java.lang.String.format;
 
 /**
  * UnknownMethodAlgorithmLogger is responsible for logging identity providers and service providers
@@ -37,38 +37,28 @@ public final class UnknownMethodAlgorithmLogger {
             "%s is using %s for digest method algorithm in %s.";
 
     private static final Logger LOG = LoggerFactory.getLogger(UnknownMethodAlgorithmLogger.class);
-    private static final Set<String> VALID_SIGNATURE_ALGORITHMS = new HashSet<>();
-    private static final Set<String> VALID_DIGEST_ALGORITHMS = new HashSet<>();
+    private static final Set<String> VALID_SIGNATURE_ALGORITHMS = Set.of(
+            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256,
+            SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512
+    );
+    private static final Set<String> VALID_DIGEST_ALGORITHMS = Set.of(
+            new DigestSHA256(),
+            new DigestSHA512()
+    ).stream().map(DigestAlgorithm::getJCAAlgorithmID).collect(Collectors.toUnmodifiableSet());
 
-    static {
-        VALID_SIGNATURE_ALGORITHMS.add(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
-        VALID_SIGNATURE_ALGORITHMS.add(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512);
-        VALID_DIGEST_ALGORITHMS.add(new DigestSHA256().getJCAAlgorithmID());
-        VALID_DIGEST_ALGORITHMS.add(new DigestSHA512().getJCAAlgorithmID());
-    }
-
-    private static String getSignatureMethodAlgorithm(final Optional<Signature> signature) {
-        if (signature.isPresent()) {
-            return signature.get().getSignatureAlgorithm();
-        }
-        return null;
-    }
-
-    private static String getDigestMethodAlgorithm(final Optional<Signature> signature) {
-        if (signature.isPresent()) {
-            XMLSignature xmlSignature = ((SignatureImpl) signature.get()).getXMLSignature();
-            if (xmlSignature != null) {
-                SignedInfo signedInfo = xmlSignature.getSignedInfo();
-                try {
-                    if (signedInfo != null && signedInfo.getLength() != 0 && signedInfo.item(0) != null) {
-                        MessageDigestAlgorithm messageDigestAlgorithm = signedInfo.item(0).getMessageDigestAlgorithm();
-                        if (messageDigestAlgorithm != null) {
-                            return messageDigestAlgorithm.getJCEAlgorithmString();
-                        }
+    private static String getDigestMethodAlgorithm(final Signature signature) {
+        XMLSignature xmlSignature = ((SignatureImpl) signature).getXMLSignature();
+        if (xmlSignature != null) {
+            SignedInfo signedInfo = xmlSignature.getSignedInfo();
+            try {
+                if (signedInfo != null && signedInfo.getLength() != 0 && signedInfo.item(0) != null) {
+                    MessageDigestAlgorithm messageDigestAlgorithm = signedInfo.item(0).getMessageDigestAlgorithm();
+                    if (messageDigestAlgorithm != null) {
+                        return messageDigestAlgorithm.getJCEAlgorithmString();
                     }
-                } catch (XMLSecurityException e) {
-                    LOG.debug(format("Error getting message digest algorithm: {0}", e));
                 }
+            } catch (XMLSecurityException e) {
+                LOG.debug("Error getting message digest algorithm", e);
             }
         }
         return null;
@@ -76,59 +66,44 @@ public final class UnknownMethodAlgorithmLogger {
 
     private static void logMethodAlgorithm(
             final Role role,
-            final String signatureMethodAlgorithm,
-            final String digestMethodAlgorithm,
+            final Signature signature,
             final String location) {
+        final String signatureMethodAlgorithm = signature.getSignatureAlgorithm();
+        final String digestMethodAlgorithm = getDigestMethodAlgorithm(signature);
         final boolean validSignatureAlgorithm = VALID_SIGNATURE_ALGORITHMS.contains(signatureMethodAlgorithm);
         final boolean validDigestAlgorithm = VALID_DIGEST_ALGORITHMS.contains(digestMethodAlgorithm);
         if (!validSignatureAlgorithm && !validDigestAlgorithm) {
-            LOG.info(
-                String.format(SIGNATURE_AND_DIGEST_ALGORITHMS_MESSAGE, role, signatureMethodAlgorithm, digestMethodAlgorithm, location)
-            );
-        }
-        else if (!validSignatureAlgorithm) {
-            LOG.info(
-                    String.format(SIGNATURE_ALGORITHM_MESSAGE, role, signatureMethodAlgorithm, location)
-            );
-        }
-        else if (!validDigestAlgorithm) {
-            LOG.info(
-                    String.format(DIGEST_ALGORITHM_MESSAGE, role, digestMethodAlgorithm, location)
-            );
+            LOG.info(format(SIGNATURE_AND_DIGEST_ALGORITHMS_MESSAGE, role, signatureMethodAlgorithm, digestMethodAlgorithm, location));
+        } else if (!validSignatureAlgorithm) {
+            LOG.info(format(SIGNATURE_ALGORITHM_MESSAGE, role, signatureMethodAlgorithm, location));
+        } else if (!validDigestAlgorithm) {
+            LOG.info(format(DIGEST_ALGORITHM_MESSAGE, role, digestMethodAlgorithm, location));
         }
     }
 
     public static void probeResponseForMethodAlgorithm(final InboundResponseFromIdp response) {
         if (response != null) {
-            final Optional<Signature> signature = response.getSignature();
-            if (signature != null) {
-                final String signatureMethodAlgorithm = getSignatureMethodAlgorithm(signature);
-                final String digestMethodAlgorithm = getDigestMethodAlgorithm(signature);
-                logMethodAlgorithm(Role.IDP, signatureMethodAlgorithm, digestMethodAlgorithm, Response.DEFAULT_ELEMENT_LOCAL_NAME);
-            }
+            response.getSignature().ifPresent((signature) ->
+                logMethodAlgorithm(Role.IDP, signature, Response.DEFAULT_ELEMENT_LOCAL_NAME)
+            );
         }
     }
 
     public static void probeAssertionForMethodAlgorithm(final Assertion assertion, final String typeOfAssertion) {
         String prefixAssertion = typeOfAssertion + Assertion.DEFAULT_ELEMENT_LOCAL_NAME;
         if (assertion != null) {
-            final Optional<Signature> signature = Optional.ofNullable(assertion.getSignature());
+            Signature signature = assertion.getSignature();
             if (signature != null) {
-                final String signatureMethodAlgorithm = getSignatureMethodAlgorithm(signature);
-                final String digestMethodAlgorithm = getDigestMethodAlgorithm(signature);
-                logMethodAlgorithm(Role.IDP, signatureMethodAlgorithm, digestMethodAlgorithm, prefixAssertion);
+                logMethodAlgorithm(Role.IDP, signature, prefixAssertion);
             }
         }
     }
 
     public static void probeAuthnRequestForMethodAlgorithm(final AuthnRequestFromRelyingParty authnRequest) {
         if (authnRequest != null) {
-            final Optional<Signature> signature = authnRequest.getSignature();
-            if (signature != null) {
-                final String signatureMethodAlgorithm = getSignatureMethodAlgorithm(signature);
-                final String digestMethodAlgorithm = getDigestMethodAlgorithm(signature);
-                logMethodAlgorithm(Role.SP, signatureMethodAlgorithm, digestMethodAlgorithm, AuthnRequest.DEFAULT_ELEMENT_LOCAL_NAME);
-            }
+            authnRequest.getSignature().ifPresent((signature) ->
+                logMethodAlgorithm(Role.SP, signature, AuthnRequest.DEFAULT_ELEMENT_LOCAL_NAME)
+            );
         }
     }
 }


### PR DESCRIPTION
We don't need the static initialiser here now that we can do `Set.of(...)`

Also, by passing `Signature` objects around a bit more, we can reduce some boilerplate and remove an `Optional` at the same time as making better use of the `Optional`s we have