### PR TITLE
ErCu45oA: Test CertificateOrigin on overridden

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/ManagedEntityConfigRepository.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/ManagedEntityConfigRepository.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.config.domain.CertificateConfigurable;
 import uk.gov.ida.hub.config.domain.CertificateOrigin;
-import uk.gov.ida.hub.config.domain.remoteconfig.RemoteComponentConfig;
 import uk.gov.ida.hub.config.domain.remoteconfig.RemoteConfigCollection;
 
 import javax.inject.Inject;
@@ -44,17 +43,15 @@ public class ManagedEntityConfigRepository<T extends CertificateConfigurable<T>>
 
     private T overrideWithRemote(T local, RemoteConfigCollection remoteConfigCollection){
         if (local.isSelfService()){
-            Optional<RemoteComponentConfig> remoteComponentConfigOptional = remoteConfigCollection.getRemoteComponent(local);
-            if (remoteComponentConfigOptional.isPresent()) {
-                return remoteComponentConfigOptional
-                        .map(remote -> local.override(
-                                remote.getSignatureVerificationCertificates(),
-                                remote.getEncryptionCertificate(),
-                                CertificateOrigin.SELFSERVICE))
-                        .get();
-            } else {
-                LOG.warn("Local config for '{}' expects there to be remote config but it could not be found", local.getEntityId());
-            }
+            return remoteConfigCollection.getRemoteComponent(local)
+                    .map(remote -> local.override(
+                            remote.getSignatureVerificationCertificates(),
+                            remote.getEncryptionCertificate(),
+                            CertificateOrigin.SELFSERVICE))
+                    .orElseGet(()-> {
+                        LOG.warn("Local config for '{}' expects there to be remote config but it could not be found", local.getEntityId());
+                        return local;
+                    });
         }
         return local;
     }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/ManagedEntityConfigRepositoryTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/ManagedEntityConfigRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.hub.config.domain.CertificateOrigin;
 import uk.gov.ida.hub.config.domain.TransactionConfig;
 import uk.gov.ida.hub.config.domain.remoteconfig.RemoteConfigCollection;
 import uk.gov.ida.hub.config.domain.remoteconfig.SelfServiceMetadata;
@@ -87,6 +88,7 @@ public class ManagedEntityConfigRepositoryTest {
 
         assertThat(result.get().getEntityId()).isEqualTo(LOCAL_ONLY_ENTITY_ID);
         assertThat(result.get().getEncryptionCertificate().getBase64Encoded().get()).isEqualTo(localOnlyTransaction.getEncryptionCertificate().getBase64Encoded().get());
+        assertThat(result.get().getEncryptionCertificate().getCertificateOrigin()).isEqualTo(CertificateOrigin.FEDERATION);
     }
 
     @Test
@@ -96,6 +98,7 @@ public class ManagedEntityConfigRepositoryTest {
 
         assertThat(result.get().getEntityId()).isEqualTo(REMOTE_DISABLED_ENTITY_ID);
         assertThat(result.get().getEncryptionCertificate().getBase64Encoded().get()).isEqualTo(remoteDisabledTransaction.getEncryptionCertificate().getBase64Encoded().get());
+        assertThat(result.get().getEncryptionCertificate().getCertificateOrigin()).isEqualTo(CertificateOrigin.FEDERATION);
     }
 
     @Test
@@ -105,6 +108,7 @@ public class ManagedEntityConfigRepositoryTest {
 
         assertThat(result.get().getEntityId()).isEqualTo(REMOTE_ENABLED_ENTITY_ID);
         assertThat(result.get().getEncryptionCertificate().getBase64Encoded().get()).isEqualTo(REMOTE_CERT);
+        assertThat(result.get().getEncryptionCertificate().getCertificateOrigin()).isEqualTo(CertificateOrigin.SELFSERVICE);
     }
 
 }


### PR DESCRIPTION
Certificates overridden by remote config need to be flagged as such. This was actually done in 8HRTuUnq. These are tests that were not included there.

Also a little refactor to the the override code to make it a little cleaner.