### PR TITLE
Two small cleanups

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/domain/UserAccountCreationAttribute.java
@@ -19,7 +19,7 @@ public enum UserAccountCreationAttribute implements Serializable {
 
     private String attributeName;
 
-    private UserAccountCreationAttribute(final String attributeName) {
+    UserAccountCreationAttribute(final String attributeName) {
         this.attributeName = attributeName;
     }
 

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -205,7 +205,7 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
 
     private void writeFile(File folder, int index, Object content) {
         try {
-            FileUtils.write(new File(folder.getAbsolutePath(), folder.getName() + Integer.toString(index) + ".yml"), mapper.writeValueAsString(content));
+            FileUtils.write(new File(folder.getAbsolutePath(), folder.getName() + index + ".yml"), mapper.writeValueAsString(content));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/UserAccountCreationAttribute.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/UserAccountCreationAttribute.java
@@ -20,7 +20,7 @@ public enum UserAccountCreationAttribute implements Serializable {
 
     private String attributeName;
 
-    private UserAccountCreationAttribute(final String attributeName) {
+    UserAccountCreationAttribute(final String attributeName) {
         this.attributeName = attributeName;
     }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/UserAccountCreationAttribute.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/UserAccountCreationAttribute.java
@@ -20,7 +20,7 @@ public enum UserAccountCreationAttribute implements Serializable {
 
     private String attributeName;
 
-    private UserAccountCreationAttribute(final String attributeName) {
+    UserAccountCreationAttribute(final String attributeName) {
         this.attributeName = attributeName;
     }
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageType.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/controllogic/SamlMessageType.java
@@ -4,7 +4,7 @@ public enum SamlMessageType {
     SAML_REQUEST  ("SAMLRequest"),
     SAML_RESPONSE ("SAMLResponse") ;
 
-    private SamlMessageType(String formName) {
+    SamlMessageType(String formName) {
         this.formName = formName;
     }
 


### PR DESCRIPTION
Remove an unnecessary `Integer.toString()` and also `private` modifies for enums, which are superfluous

Co-Authored-By: IntelliJ