### PR TITLE
5CR1WpE4: RP truststore flag for saml-proxy

### DIFF
--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -32,6 +32,7 @@ serviceInfo:
 rpTrustStoreConfiguration:
   path: /tmp/truststores/${DEPLOYMENT}/rp_ca_certs.ts
   password: puppet
+  enabled: ${RP_TRUSTSTORE_ENABLED:-true}
 metadataValidDuration: 1h
 featureFlagConfiguration: {}
 logging:


### PR DESCRIPTION
We need to turn off cert chain validation on staging, which we will do by disabling the RP truststore there.

https://trello.com/c/5CR1WpE4/627-verify-the-e2e-journey-with-self-signed-certs