### PR TITLE
5CR1WpE4: RP truststore flag for saml-engine

### DIFF
--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -46,6 +46,7 @@ featureFlagConfiguration: {}
 rpTrustStoreConfiguration:
   path: /tmp/truststores/${DEPLOYMENT}/rp_ca_certs.ts
   password: puppet
+  enabled: ${RP_TRUSTSTORE_ENABLED:-true}
 logging:
   loggers:
     uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger:


### PR DESCRIPTION
We need to turn off cert chain validation on staging, which we will do by disabling the RP truststore there.