### PR TITLE
5CR1WpE4: RP truststore flag for saml-soap-proxy

### DIFF
--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -75,6 +75,7 @@ matchingServiceExecutorConfiguration:
 rpTrustStoreConfiguration:
   path: /tmp/truststores/${DEPLOYMENT}/rp_ca_certs.ts
   password: puppet
+  enabled: ${RP_TRUSTSTORE_ENABLED:-true}
 
 featureFlagConfiguration: {}
 


### PR DESCRIPTION
We need to turn off cert chain validation on staging, which we will do by disabling the RP truststore there.