### PR TITLE
Replace guava immutable collections with Java ones in tests

### DIFF
--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestFromRelyingPartyUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/AuthnRequestFromRelyingPartyUnmarshallerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.saml.hub.transformers.inbound;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -31,6 +30,7 @@ import uk.gov.ida.saml.security.EncrypterFactory;
 import java.net.URI;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,7 +50,7 @@ public class AuthnRequestFromRelyingPartyUnmarshallerTest {
         final BasicCredential basicCredential = createBasicCredential();
         encrypter = new EncrypterFactory().createEncrypter(basicCredential);
 
-        unmarshaller = new AuthnRequestFromRelyingPartyUnmarshaller(new DecrypterFactory().createDecrypter(ImmutableList.of(basicCredential)));
+        unmarshaller = new AuthnRequestFromRelyingPartyUnmarshaller(new DecrypterFactory().createDecrypter(List.of(basicCredential)));
     }
 
     @Test

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidatorTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.saml.hub.validators.response.idp;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,7 +74,7 @@ public class IdpResponseValidatorTest {
     @Test
     public void shouldValidateSamlAssertionSignature() {
         Assertion assertion = mock(Assertion.class);
-        List<Assertion> assertions = ImmutableList.of(assertion);
+        List<Assertion> assertions = List.of(assertion);
         ValidatedResponse validatedResponse = mock(ValidatedResponse.class);
 
         when(samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME)).thenReturn(validatedResponse);

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/ConfigDataBootstrapTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/ConfigDataBootstrapTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.config.data;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +20,7 @@ import java.security.cert.CertPathValidatorException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,7 +82,7 @@ public class ConfigDataBootstrapTest {
         final String simpleId = "simple-id";
         final String matchingServiceEntityId = "matching-service-entity-id";
         final String nonExistentTransactionEntityId = "non-existent-transaction";
-        final IdentityProviderConfig identityProviderConfigData = anIdentityProviderConfigData().withEntityId(idpEntityId).withOnboarding(ImmutableList.of(nonExistentTransactionEntityId)).build();
+        final IdentityProviderConfig identityProviderConfigData = anIdentityProviderConfigData().withEntityId(idpEntityId).withOnboarding(List.of(nonExistentTransactionEntityId)).build();
         final TransactionConfig transactionConfigData = aTransactionConfigData().withEntityId("transaction-entity-id").withMatchingServiceEntityId(matchingServiceEntityId).build();
         final TranslationData translationData = aTranslationData().withSimpleId(simpleId).build();
         final CountryConfig countryConfig = new CountryConfig() {};
@@ -152,7 +152,7 @@ public class ConfigDataBootstrapTest {
         InvalidCertificateDto invalidIdpCertificateDto = new InvalidCertificateDto(idpEntityId, CertPathValidatorException.BasicReason.INVALID_SIGNATURE, CertificateUse.SIGNING, FederationEntityType.IDP, "certificate was bad!");
         InvalidCertificateDto invalidMatchingServiceCertificateDto = new InvalidCertificateDto(matchingServiceId, CertPathValidatorException.BasicReason.NOT_YET_VALID, CertificateUse.SIGNING, FederationEntityType.MS, "certificate was not yet valid!");
 
-        doThrow(createInvalidCertificatesException(ImmutableList.of(invalidMatchingServiceCertificateDto, invalidIdpCertificateDto))).when(certificateChainConfigValidator)
+        doThrow(createInvalidCertificatesException(List.of(invalidMatchingServiceCertificateDto, invalidIdpCertificateDto))).when(certificateChainConfigValidator)
                 .validate(Set.of(transactionConfigData, matchingServiceConfigData));
 
         CountryConfig countryConfig = createCountriesConfig();

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidatorTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidatorTest.java
@@ -1,7 +1,5 @@
 package uk.gov.ida.hub.config.data;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfig;
@@ -11,6 +9,7 @@ import uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder;
 import uk.gov.ida.hub.config.domain.builders.TransactionConfigBuilder;
 import uk.gov.ida.hub.config.exceptions.ConfigValidationException;
 
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
@@ -22,16 +21,16 @@ public class LevelsOfAssuranceConfigValidatorTest {
     private LevelsOfAssuranceConfigValidator levelsOfAssuranceConfigValidator;
 
     private final IdentityProviderConfig loa1And2Idp = IdentityProviderConfigDataBuilder.anIdentityProviderConfigData()
-            .withSupportedLevelsOfAssurance(ImmutableList.of(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
+            .withSupportedLevelsOfAssurance(List.of(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
             .build();
     private final IdentityProviderConfig loa1Idp = IdentityProviderConfigDataBuilder.anIdentityProviderConfigData()
-            .withSupportedLevelsOfAssurance(ImmutableList.of(LevelOfAssurance.LEVEL_1))
+            .withSupportedLevelsOfAssurance(List.of(LevelOfAssurance.LEVEL_1))
             .build();
     private final IdentityProviderConfig loa2Idp = IdentityProviderConfigDataBuilder.anIdentityProviderConfigData()
-            .withSupportedLevelsOfAssurance(ImmutableList.of(LevelOfAssurance.LEVEL_2))
+            .withSupportedLevelsOfAssurance(List.of(LevelOfAssurance.LEVEL_2))
             .build();
     private final IdentityProviderConfig loa1To3Idp = IdentityProviderConfigDataBuilder.anIdentityProviderConfigData()
-            .withSupportedLevelsOfAssurance(ImmutableList.of(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_3))
+            .withSupportedLevelsOfAssurance(List.of(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_3))
             .build();
 
     private final TransactionConfig loa1OnlyTransaction = TransactionConfigBuilder.aTransactionConfigData()
@@ -57,25 +56,25 @@ public class LevelsOfAssuranceConfigValidatorTest {
 
     @Test
     public void checkIDPConfigIsWithinVerifyPolicyLevelsOfAssurance() {
-        Set<IdentityProviderConfig> identityProviderConfig = ImmutableSet.of(loa1And2Idp);
+        Set<IdentityProviderConfig> identityProviderConfig = Set.of(loa1And2Idp);
         levelsOfAssuranceConfigValidator.validateAllIDPsSupportLOA1orLOA2(identityProviderConfig);
     }
 
     @Test
     public void shouldAllowSingleLevelOfAssurance() {
-        Set<IdentityProviderConfig> identityProviderConfig = ImmutableSet.of(loa1Idp);
+        Set<IdentityProviderConfig> identityProviderConfig = Set.of(loa1Idp);
         levelsOfAssuranceConfigValidator.validateAllIDPsSupportLOA1orLOA2(identityProviderConfig);
     }
 
     @Test(expected = ConfigValidationException.class)
     public void checkValidationThrowsExceptionWhenIDPSupportsAnLOAThatIsOutsideVerifyPolicyLevelsOfAssurance() {
-        Set<IdentityProviderConfig> identityProviderConfig = ImmutableSet.of(loa1To3Idp);
+        Set<IdentityProviderConfig> identityProviderConfig = Set.of(loa1To3Idp);
         levelsOfAssuranceConfigValidator.validateAllIDPsSupportLOA1orLOA2(identityProviderConfig);
     }
 
     @Test
     public void shouldAllowLOA1TransactionConfiguration() {
-        Set<TransactionConfig> transactionsConfig = ImmutableSet.of(loa1And2Transaction);
+        Set<TransactionConfig> transactionsConfig = Set.of(loa1And2Transaction);
         try {
             levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(transactionsConfig);
         } catch (Exception e) {
@@ -85,7 +84,7 @@ public class LevelsOfAssuranceConfigValidatorTest {
 
     @Test
     public void shouldAllowLOA2TransactionConfiguration() {
-        Set<TransactionConfig> transactionsConfig = ImmutableSet.of(loa2Transaction);
+        Set<TransactionConfig> transactionsConfig = Set.of(loa2Transaction);
         try {
             levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(transactionsConfig);
         } catch(Exception e) {
@@ -95,31 +94,31 @@ public class LevelsOfAssuranceConfigValidatorTest {
 
     @Test (expected = ConfigValidationException.class)
     public void shouldThrowWhenTransactionIsLoa1Only() {
-        levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(ImmutableSet.of(loa1OnlyTransaction));
+        levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(Set.of(loa1OnlyTransaction));
     }
 
     @Test (expected = ConfigValidationException.class)
     public void shouldThrowWhenTransactionIsNotLoa1OrLoa2() {
-        levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(ImmutableSet.of(loa3OnlyTransaction));
+        levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(Set.of(loa3OnlyTransaction));
     }
 
     @Test (expected = ConfigValidationException.class)
     public void shouldThrowWhenTransactionLOAsAreInWrongOrder() {
-        levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(ImmutableSet.of(loa2And1Transaction));
+        levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(Set.of(loa2And1Transaction));
     }
 
     @Test (expected = ConfigValidationException.class)
     public void shouldThrowWhenOneIdpDoesNotSupportATransaction(){
-        Set<IdentityProviderConfig> identityProviderConfig = ImmutableSet.of(loa1Idp, loa2Idp);
-        Set<TransactionConfig> transactionsConfig = ImmutableSet.of(loa2Transaction);
+        Set<IdentityProviderConfig> identityProviderConfig = Set.of(loa1Idp, loa2Idp);
+        Set<TransactionConfig> transactionsConfig = Set.of(loa2Transaction);
 
         levelsOfAssuranceConfigValidator.validateAllTransactionsAreSupportedByIDPs(identityProviderConfig, transactionsConfig);
     }
 
     @Test
     public void shouldNotThrowWhenAllIdpsSupportATransaction(){
-        Set<IdentityProviderConfig> identityProviderConfig = ImmutableSet.of(loa2Idp, loa1And2Idp);
-        Set<TransactionConfig> transactionsConfig = ImmutableSet.of(loa2Transaction);
+        Set<IdentityProviderConfig> identityProviderConfig = Set.of(loa2Idp, loa1And2Idp);
+        Set<TransactionConfig> transactionsConfig = Set.of(loa2Transaction);
 
         try {
             levelsOfAssuranceConfigValidator.validateAllTransactionsAreSupportedByIDPs(identityProviderConfig, transactionsConfig);
@@ -130,14 +129,14 @@ public class LevelsOfAssuranceConfigValidatorTest {
 
     @Test
     public void shouldNotThrowWhenAnIdpsIsOnboardingAndDoesNotSupportATransaction(){
-        Set<TransactionConfig> transactionsConfig = ImmutableSet.of(loa1And2Transaction);
+        Set<TransactionConfig> transactionsConfig = Set.of(loa1And2Transaction);
 
         final IdentityProviderConfig onboardingIdp = IdentityProviderConfigDataBuilder.anIdentityProviderConfigData()
-                .withOnboarding(ImmutableList.of("some-other-transaction-id"))
-                .withSupportedLevelsOfAssurance(ImmutableList.of(LevelOfAssurance.LEVEL_3))
+                .withOnboarding(List.of("some-other-transaction-id"))
+                .withSupportedLevelsOfAssurance(List.of(LevelOfAssurance.LEVEL_3))
                 .build();
 
-        Set<IdentityProviderConfig> identityProviderConfig = ImmutableSet.of(onboardingIdp, loa1And2Idp);
+        Set<IdentityProviderConfig> identityProviderConfig = Set.of(onboardingIdp, loa1And2Idp);
 
         try {
             levelsOfAssuranceConfigValidator.validateAllTransactionsAreSupportedByIDPs(identityProviderConfig, transactionsConfig);

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/CertificateValidityCheckerTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/CertificateValidityCheckerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.config.domain;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +13,7 @@ import uk.gov.ida.hub.config.truststore.TrustStoreForCertificateProvider;
 
 import java.security.KeyStore;
 import java.security.cert.CertPathValidatorException;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -53,7 +53,7 @@ public class CertificateValidityCheckerTest {
 
         when(certificateChainValidator.validate(localCertificate.getX509Certificate().get(), trustStore)).thenReturn(CertificateValidity.invalid(certPathValidatorException));
 
-        Set<InvalidCertificateDto> invalidCertificates = certificateValidityChecker.getInvalidCertificates(ImmutableList.of(localCertificate));
+        Set<InvalidCertificateDto> invalidCertificates = certificateValidityChecker.getInvalidCertificates(List.of(localCertificate));
 
         InvalidCertificateDto expected = new InvalidCertificateDto(localCertificate.getIssuerEntityId(), certPathValidatorException.getReason(), CertificateUse.SIGNING, localCertificate.getFederationEntityType(), description);
 
@@ -64,7 +64,7 @@ public class CertificateValidityCheckerTest {
     public void getsEmptyListWhenAllCertificatesAreValid() {
         when(certificateChainValidator.validate(localCertificate.getX509Certificate().get(), trustStore)).thenReturn(CertificateValidity.valid());
 
-        Set<InvalidCertificateDto> invalidCertificates = certificateValidityChecker.getInvalidCertificates(ImmutableList.of(localCertificate));
+        Set<InvalidCertificateDto> invalidCertificates = certificateValidityChecker.getInvalidCertificates(List.of(localCertificate));
 
         assertThat(invalidCertificates).isEmpty();
     }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/IdentityProviderConfigDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/IdentityProviderConfigDataBuilder.java
@@ -1,12 +1,13 @@
 package uk.gov.ida.hub.config.domain.builders;
 
 
-import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfig;
 import uk.gov.ida.hub.config.domain.LevelOfAssurance;
 
 import java.util.List;
+
+import static java.util.Collections.emptyList;
 
 
 public class IdentityProviderConfigDataBuilder {
@@ -15,10 +16,10 @@ public class IdentityProviderConfigDataBuilder {
     private String simpleId = "default-idp-simple-id";
     private Boolean enabled = true;
     private Boolean enabledForSingleIdp = false;
-    private List<String> transactionEntityIds = ImmutableList.of();
-    private List<String> transactionEntityIdsTemp = ImmutableList.of();
-    private List<LevelOfAssurance> onboardingLevelsOfAssurance = ImmutableList.of();
-    private List<LevelOfAssurance> supportedLevelsOfAssurance = ImmutableList.of(LevelOfAssurance.LEVEL_2);
+    private List<String> transactionEntityIds = emptyList();
+    private List<String> transactionEntityIdsTemp = emptyList();
+    private List<LevelOfAssurance> onboardingLevelsOfAssurance = emptyList();
+    private List<LevelOfAssurance> supportedLevelsOfAssurance = List.of(LevelOfAssurance.LEVEL_2);
     private boolean useExactComparisonType = false;
     private String provideRegistrationUntil;
     private String provideAuthenticationUntil;
@@ -84,8 +85,8 @@ public class IdentityProviderConfigDataBuilder {
     }
 
     public IdentityProviderConfigDataBuilder withoutOnboarding() {
-        this.transactionEntityIds = ImmutableList.of();
-        this.onboardingLevelsOfAssurance = ImmutableList.of();
+        this.transactionEntityIds = emptyList();
+        this.onboardingLevelsOfAssurance = emptyList();
         return this;
     }
 

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/exceptions/ConfigValidationExceptionTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/exceptions/ConfigValidationExceptionTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.config.exceptions;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.ida.hub.config.domain.CertificateUse;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfig;
@@ -70,7 +69,7 @@ public class ConfigValidationExceptionTest {
 
     @Test
     public void createIncompatiblePairsOfTransactionsAndIDPs() throws Exception {
-        Map<TransactionConfig, List<IdentityProviderConfig>> incompatiblePairs = ImmutableMap.of(aTransactionConfigData().build(), singletonList(anIdentityProviderConfigData().build()));
+        Map<TransactionConfig, List<IdentityProviderConfig>> incompatiblePairs = Map.of(aTransactionConfigData().build(), singletonList(anIdentityProviderConfigData().build()));
         ConfigValidationException exception = ConfigValidationException.createIncompatiblePairsOfTransactionsAndIDPs(incompatiblePairs);
         assertThat(exception.getMessage()).isEqualTo("Transaction unsupported by IDP(s).\n" +
                 "Transaction: default-transaction-entity-id\n" +

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/validators/IdentityProviderConfigOnboardingTransactionValidatorTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/validators/IdentityProviderConfigOnboardingTransactionValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.config.validators;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,6 +10,7 @@ import uk.gov.ida.hub.config.domain.IdentityProviderConfig;
 import uk.gov.ida.hub.config.domain.TransactionConfig;
 import uk.gov.ida.hub.config.exceptions.ConfigValidationException;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +38,7 @@ public class IdentityProviderConfigOnboardingTransactionValidatorTest {
     @Test
     public void validate_shouldNotThrowExceptionWhenOnboardingTransactionEntityIdExists() throws Exception {
         String transactionEntityID = "transactionEntityID";
-        IdentityProviderConfig identityProviderConfig = anIdentityProviderConfigData().withOnboarding(ImmutableList.of(transactionEntityID)).build();
+        IdentityProviderConfig identityProviderConfig = anIdentityProviderConfigData().withOnboarding(List.of(transactionEntityID)).build();
 
         TransactionConfig transactionConfigEntity = aTransactionConfigData().build();
         when(transactionConfigRepository.getData(transactionEntityID)).thenReturn(Optional.ofNullable(transactionConfigEntity));
@@ -58,7 +58,7 @@ public class IdentityProviderConfigOnboardingTransactionValidatorTest {
         String idpEntityId = "idpEntityId";
         IdentityProviderConfig identityProviderConfig = anIdentityProviderConfigData()
                 .withEntityId(idpEntityId)
-                .withOnboarding(ImmutableList.of(transactionEntityID))
+                .withOnboarding(List.of(transactionEntityID))
                 .build();
 
         when(transactionConfigRepository.getData(transactionEntityID))

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/AuthnRequestFromTransactionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/AuthnRequestFromTransactionResourceIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -39,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.List;
 
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,7 +89,7 @@ public class AuthnRequestFromTransactionResourceIntegrationTest {
     public void setUp() throws Exception {
         samlResponse = aSamlResponseWithAuthnRequestInformationDto().withIssuer(transactionEntityId).build();
         samlRequest = SamlAuthnRequestContainerDtoBuilder.aSamlAuthnRequestContainerDto().build();
-        configStub.setupStubForEnabledIdps(transactionEntityId, REGISTERING, LEVEL_2, ImmutableList.of(idpEntityId, "differentIdp"));
+        configStub.setupStubForEnabledIdps(transactionEntityId, REGISTERING, LEVEL_2, List.of(idpEntityId, "differentIdp"));
         configStub.setupStubForEidasEnabledForTransaction(transactionEntityId, false);
         configStub.setUpStubForLevelsOfAssurance(samlResponse.getIssuer());
         eventSinkStub.setupStubForLogging();

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/CountriesResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/CountriesResourceIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -95,7 +94,7 @@ public class CountriesResourceIntegrationTest {
 
         List<EidasCountryDto> configuredCountries = listCountriesForSession();
 
-        assertThat(configuredCountries).isEqualTo(ImmutableList.of(NETHERLANDS, SPAIN));
+        assertThat(configuredCountries).isEqualTo(List.of(NETHERLANDS, SPAIN));
     }
 
     @Test
@@ -105,7 +104,9 @@ public class CountriesResourceIntegrationTest {
 
         List<EidasCountryDto> configuredCountries = listCountriesForSession();
 
-        assertThat(configuredCountries).isEqualTo(ImmutableList.of(NETHERLANDS));
+
+
+        assertThat(configuredCountries).isEqualTo(List.of(NETHERLANDS));
     }
 
     @Test
@@ -115,7 +116,7 @@ public class CountriesResourceIntegrationTest {
 
         List<EidasCountryDto> configuredCountries = listCountriesForSession();
 
-        assertThat(configuredCountries).isEqualTo(ImmutableList.of(NETHERLANDS));
+        assertThat(configuredCountries).isEqualTo(List.of(NETHERLANDS));
     }
 
     @Test
@@ -125,7 +126,7 @@ public class CountriesResourceIntegrationTest {
 
         List<EidasCountryDto> configuredCountries = listCountriesForSession();
 
-        assertThat(configuredCountries).isEqualTo(ImmutableList.of(NETHERLANDS, SPAIN));
+        assertThat(configuredCountries).isEqualTo(List.of(NETHERLANDS, SPAIN));
     }
 
     @Test

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
@@ -2,7 +2,6 @@ package uk.gov.ida.integrationtest.hub.policy.apprule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -50,6 +49,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,7 +83,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
     private static final String RP_ENTITY_ID = "rpEntityId";
     private static final EidasCountryDto NETHERLANDS = new EidasCountryDto("http://netherlandsEnitity.nl", "NL", true);
     private static final EidasCountryDto SPAIN = new EidasCountryDto("http://spainEnitity.es", "ES", true);
-    private static final ImmutableList<EidasCountryDto> EIDAS_COUNTRIES = ImmutableList.of(NETHERLANDS, SPAIN);
+    private static final List<EidasCountryDto> EIDAS_COUNTRIES = List.of(NETHERLANDS, SPAIN);
 
     private SamlResponseWithAuthnRequestInformationDto translatedAuthnRequest;
     private SamlAuthnRequestContainerDto rpSamlRequest;

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -35,6 +34,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +71,7 @@ public class EidasSessionResourceIntegrationTest {
     private static final String MS_ENTITY_ID = "Matching-service-entity-id";
     private static final EidasCountryDto NETHERLANDS = new EidasCountryDto("http://netherlandsEnitity.nl", "NL", true);
     private static final EidasCountryDto SPAIN = new EidasCountryDto("http://spainEnitity.es", "ES", true);
-    private static final ImmutableList<EidasCountryDto> EIDAS_COUNTRIES = ImmutableList.of(NETHERLANDS, SPAIN);
+    private static final List<EidasCountryDto> EIDAS_COUNTRIES = List.of(NETHERLANDS, SPAIN);
 
     @BeforeClass
     public static void beforeClass() {

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/MatchingServiceResourcesIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/MatchingServiceResourcesIntegrationTest.java
@@ -2,7 +2,6 @@ package uk.gov.ida.integrationtest.hub.policy.apprule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -502,7 +501,7 @@ public class MatchingServiceResourcesIntegrationTest {
                         Optional.absent(),
                         Optional.absent());
         samlEngineStub.setupStubForAttributeResponseTranslate(inboundResponseFromMatchingServiceDto);
-        List<UserAccountCreationAttribute> userAccountCreationAttributes = ImmutableList.of(UserAccountCreationAttribute.CURRENT_ADDRESS);
+        List<UserAccountCreationAttribute> userAccountCreationAttributes = List.of(UserAccountCreationAttribute.CURRENT_ADDRESS);
         configStub.setUpStubForUserAccountCreation(rpEntityId, userAccountCreationAttributes);
 
         URI uri = UriBuilder.fromPath(Urls.PolicyUrls.ATTRIBUTE_QUERY_RESPONSE_RESOURCE).build(sessionId);
@@ -544,7 +543,7 @@ public class MatchingServiceResourcesIntegrationTest {
 
         configStub.setUpStubForCycle01NoMatchCycle3Disabled(rpEntityId);
 
-        List<UserAccountCreationAttribute> userAccountCreationAttributes = ImmutableList.of(UserAccountCreationAttribute.CURRENT_ADDRESS);
+        List<UserAccountCreationAttribute> userAccountCreationAttributes = List.of(UserAccountCreationAttribute.CURRENT_ADDRESS);
         configStub.setUpStubForUserAccountCreation(rpEntityId, userAccountCreationAttributes);
 
         URI uri = UriBuilder.fromPath(Urls.PolicyUrls.ATTRIBUTE_QUERY_RESPONSE_RESOURCE).build(sessionId);

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionResourceAuthnResponseFromIdpIntegrationTests.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/SessionResourceAuthnResponseFromIdpIntegrationTests.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -41,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 
 import static io.dropwizard.testing.ConfigOverride.config;
@@ -99,7 +99,7 @@ public class SessionResourceAuthnResponseFromIdpIntegrationTests {
         samlResponse = SamlResponseWithAuthnRequestInformationDtoBuilder.aSamlResponseWithAuthnRequestInformationDto().withIssuer(THE_TRANSACTION_ID).build();
         samlRequest = SamlAuthnRequestContainerDtoBuilder.aSamlAuthnRequestContainerDto().build();
 
-        configStub.setupStubForEnabledIdps(THE_TRANSACTION_ID, REGISTERING, REQUESTED_LOA, ImmutableList.of(idpEntityId, "differentIdp"));
+        configStub.setupStubForEnabledIdps(THE_TRANSACTION_ID, REGISTERING, REQUESTED_LOA, List.of(idpEntityId, "differentIdp"));
         configStub.setUpStubForLevelsOfAssurance(samlResponse.getIssuer());
         configStub.setupStubForEidasEnabledForTransaction(THE_TRANSACTION_ID, false);
         eventSinkStub.setupStubForLogging();

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/domain/IdpConfigDtoBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/domain/IdpConfigDtoBuilder.java
@@ -1,18 +1,15 @@
 package uk.gov.ida.hub.policy.builder.domain;
 
-import com.google.common.collect.ImmutableList;
 import uk.gov.ida.hub.policy.domain.IdpConfigDto;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.of;
-
 public class IdpConfigDtoBuilder {
 
     private String simpleId = "an-idp";
     private Boolean enabled = true;
-    private List<LevelOfAssurance> supportedLevelsOfAssurance = of(LevelOfAssurance.LEVEL_1);
+    private List<LevelOfAssurance> supportedLevelsOfAssurance = List.of(LevelOfAssurance.LEVEL_1);
 
     public static IdpConfigDtoBuilder anIdpConfigDto() {
         return new IdpConfigDtoBuilder();
@@ -24,7 +21,7 @@ public class IdpConfigDtoBuilder {
     }
 
     public IdpConfigDtoBuilder withLevelsOfAssurance(LevelOfAssurance... levelsOfAssurance) {
-        this.supportedLevelsOfAssurance = ImmutableList.copyOf(levelsOfAssurance);
+        this.supportedLevelsOfAssurance = List.of(levelsOfAssurance);
         return this;
     }
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/IdpSelectedStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/IdpSelectedStateBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.builder.state;
 
-import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import uk.gov.ida.hub.policy.builder.domain.SessionIdBuilder;
@@ -26,7 +25,7 @@ public class IdpSelectedStateBuilder {
     private boolean isRegistration = false;
     private LevelOfAssurance requestedLoa = LevelOfAssurance.LEVEL_2;
     private SessionId sessionId = SessionIdBuilder.aSessionId().build();
-    private List<String> availableIdentityProviders = ImmutableList.of("idp-a", "idp-b", "idp-c");
+    private List<String> availableIdentityProviders = List.of("idp-a", "idp-b", "idp-c");
     private boolean transactionSupportsEidas = false;
 
     public static IdpSelectedStateBuilder anIdpSelectedState() {

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/contracts/AttributeQueryRequestDtoTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/contracts/AttributeQueryRequestDtoTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.policy.contracts;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -205,7 +204,7 @@ public class AttributeQueryRequestDtoTest {
 
     @Test
     public void createUserAccountRequiredMatchingServiceRequest() {
-        final List<UserAccountCreationAttribute> userAccountCreationAttributes = ImmutableList.of(UserAccountCreationAttribute.CURRENT_ADDRESS);
+        final List<UserAccountCreationAttribute> userAccountCreationAttributes = List.of(UserAccountCreationAttribute.CURRENT_ADDRESS);
         AttributeQueryRequestDto expected = new AttributeQueryRequestDto(
             REQUEST_ID,
             AUTHN_REQUEST_ISSUER_ENTITY_ID,

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/Cycle3MatchRequestSentStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/Cycle3MatchRequestSentStateControllerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.policy.domain.controller;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,8 +42,10 @@ import uk.gov.ida.hub.policy.services.AttributeQueryService;
 import uk.gov.ida.hub.policy.validators.LevelOfAssuranceValidator;
 
 import java.net.URI;
+import java.util.List;
 
 import static java.text.MessageFormat.format;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -122,7 +123,7 @@ public class Cycle3MatchRequestSentStateControllerTest {
         ArgumentCaptor<EventSinkHubEvent> eventSinkArgumentCaptor = ArgumentCaptor.forClass(EventSinkHubEvent.class);
         URI userAccountCreationUri = URI.create("a-test-user-account-creation-uri");
         Cycle3MatchRequestSentState state = aCycle3MatchRequestSentState().build();
-        ImmutableList<UserAccountCreationAttribute> userAccountCreationAttributes = ImmutableList.of(UserAccountCreationAttribute.DATE_OF_BIRTH);
+        List<UserAccountCreationAttribute> userAccountCreationAttributes = List.of(UserAccountCreationAttribute.DATE_OF_BIRTH);
         String transactionEntityId = "request issuer id";
         when(transactionsConfigProxy.getUserAccountCreationAttributes(transactionEntityId)).thenReturn(userAccountCreationAttributes);
         when(matchingServiceConfigProxy.getMatchingService(anyString()))
@@ -156,7 +157,7 @@ public class Cycle3MatchRequestSentStateControllerTest {
     public void shouldTransitonToNoMatchStateForNoMatchResponseWhenNoAttributesArePresent(){
         ArgumentCaptor<NoMatchState> capturedState = ArgumentCaptor.forClass(NoMatchState.class);
         Cycle3MatchRequestSentState state = aCycle3MatchRequestSentState().build();
-        ImmutableList<UserAccountCreationAttribute> userAccountCreationAttributes = ImmutableList.of();
+        List<UserAccountCreationAttribute> userAccountCreationAttributes = emptyList();
         when(transactionsConfigProxy.getUserAccountCreationAttributes("request issuer id")).thenReturn(userAccountCreationAttributes);
         Cycle3MatchRequestSentStateController controller =
                 new Cycle3MatchRequestSentStateController(state, hubEventLogger, stateTransitionAction, null, null, null, transactionsConfigProxy, null, null, null);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.policy.domain.controller;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
@@ -35,6 +34,8 @@ import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
 import uk.gov.ida.hub.policy.logging.HubEventLogger;
 import uk.gov.ida.hub.policy.proxy.MatchingServiceConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
+
+import java.util.List;
 
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,7 +94,7 @@ public class EidasCountrySelectedStateControllerTest {
 
     private EidasCountrySelectedState state = anEidasCountrySelectedState()
             .withSelectedCountry(SELECTED_COUNTRY)
-            .withLevelOfAssurance(ImmutableList.of(LevelOfAssurance.LEVEL_2))
+            .withLevelOfAssurance(List.of(LEVEL_2))
             .withTransactionSupportsEidas(true)
             .withForceAuthentication(false)
             .build();
@@ -182,7 +183,7 @@ public class EidasCountrySelectedStateControllerTest {
         exception.expect(StateProcessingValidationException.class);
         exception.expectMessage(
                 String.format("Level of assurance in the response does not match level of assurance in the request. Was [%s] but expected [%s].",
-                        LEVEL_1, ImmutableList.of(LEVEL_2)));
+                        LEVEL_1, List.of(LEVEL_2)));
 
         final InboundResponseFromCountry inboundResponseFromCountry = new InboundResponseFromCountry(
                 CountryAuthenticationStatus.Status.Success,

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle3MatchRequestSentStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle3MatchRequestSentStateControllerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.policy.domain.controller;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,8 +41,10 @@ import uk.gov.ida.hub.policy.services.AttributeQueryService;
 import uk.gov.ida.hub.policy.validators.LevelOfAssuranceValidator;
 
 import java.net.URI;
+import java.util.List;
 
 import static java.text.MessageFormat.format;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -120,7 +121,7 @@ public class EidasCycle3MatchRequestSentStateControllerTest {
         ArgumentCaptor<EventSinkHubEvent> eventSinkArgumentCaptor = ArgumentCaptor.forClass(EventSinkHubEvent.class);
         URI userAccountCreationUri = URI.create("a-test-user-account-creation-uri");
         EidasCycle3MatchRequestSentState state = anEidasCycle3MatchRequestSentState().withForceAuthentication(false).build();
-        ImmutableList<UserAccountCreationAttribute> userAccountCreationAttributes = ImmutableList.of(UserAccountCreationAttribute.DATE_OF_BIRTH);
+        List<UserAccountCreationAttribute> userAccountCreationAttributes = List.of(UserAccountCreationAttribute.DATE_OF_BIRTH);
         when(transactionsConfigProxy.getUserAccountCreationAttributes(state.getRequestIssuerEntityId())).thenReturn(userAccountCreationAttributes);
         when(matchingServiceConfigProxy.getMatchingService(anyString()))
                 .thenReturn(aMatchingServiceConfigEntityDataDto().withUserAccountCreationUri(userAccountCreationUri).build());
@@ -154,7 +155,7 @@ public class EidasCycle3MatchRequestSentStateControllerTest {
     public void shouldTransitionToNoMatchStateForNoMatchResponseWhenNoAttributesArePresent(){
         ArgumentCaptor<NoMatchState> capturedState = ArgumentCaptor.forClass(NoMatchState.class);
         EidasCycle3MatchRequestSentState state = anEidasCycle3MatchRequestSentState().build();
-        ImmutableList<UserAccountCreationAttribute> userAccountCreationAttributes = ImmutableList.of();
+        List<UserAccountCreationAttribute> userAccountCreationAttributes = emptyList();
         when(transactionsConfigProxy.getUserAccountCreationAttributes(state.getRequestIssuerEntityId())).thenReturn(userAccountCreationAttributes);
         EidasCycle3MatchRequestSentStateController controller =
                 new EidasCycle3MatchRequestSentStateController(state, hubEventLogger, stateTransitionAction, policyConfiguration, levelOfAssuranceValidator, responseFromHubFactory,

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectorTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.domain.controller;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +14,8 @@ import uk.gov.ida.hub.policy.domain.state.IdpSelectedState;
 import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
 import uk.gov.ida.hub.policy.proxy.IdentityProvidersConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
+
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -34,14 +35,14 @@ public class IdpSelectorTest {
 
     @Before
     public void setUp() {
-        IdpConfigDto idpConfigDto = new IdpConfigDto(IDP_ENTITY_ID, true, ImmutableList.of(LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_1));
+        IdpConfigDto idpConfigDto = new IdpConfigDto(IDP_ENTITY_ID, true, List.of(LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_1));
         when(identityProvidersConfigProxy.getIdpConfig(IDP_ENTITY_ID)).thenReturn(idpConfigDto);
     }
 
     @Test
     public void buildIdpSelectedState_shouldReturnStateWithIdpSelectedState(){
         IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withRelayState("relay-state").withIdpEntityId(IDP_ENTITY_ID)
-                .withRegistration(true).withAvailableIdentityProviders(ImmutableList.of(IDP_ENTITY_ID)).withRegistration(true).build();
+                .withRegistration(true).withAvailableIdentityProviders(List.of(IDP_ENTITY_ID)).withRegistration(true).build();
         when(transactionsConfigProxy.getLevelsOfAssurance(state.getRequestIssuerEntityId())).thenReturn(asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2));
         when(identityProvidersConfigProxy.getEnabledIdentityProviders(state.getRequestIssuerEntityId(), state.isRegistering(), REQUESTED_LOA)).thenReturn(singletonList(IDP_ENTITY_ID));
 
@@ -53,8 +54,8 @@ public class IdpSelectorTest {
     @Test
     public void buildIdpSelectedState_shouldReturnStateWithNewIdpForIdpSelectedState(){
         IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withRelayState("relay-state").withIdpEntityId("idp-b")
-                .withAvailableIdentityProviders(ImmutableList.of(IDP_ENTITY_ID, OTHER_IDP_ENTITY_ID)).withRegistration(true).build();
-        IdpConfigDto idpConfigDto = new IdpConfigDto(IDP_ENTITY_ID, true, ImmutableList.of(LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_1));
+                .withAvailableIdentityProviders(List.of(IDP_ENTITY_ID, OTHER_IDP_ENTITY_ID)).withRegistration(true).build();
+        IdpConfigDto idpConfigDto = new IdpConfigDto(IDP_ENTITY_ID, true, List.of(LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_1));
         when(identityProvidersConfigProxy.getIdpConfig("idp-b")).thenReturn(idpConfigDto);
         when(transactionsConfigProxy.getLevelsOfAssurance(state.getRequestIssuerEntityId())).thenReturn(asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2));
         when(identityProvidersConfigProxy.getEnabledIdentityProviders(state.getRequestIssuerEntityId(), state.isRegistering(), REQUESTED_LOA)).thenReturn(asList(IDP_ENTITY_ID, OTHER_IDP_ENTITY_ID));
@@ -83,14 +84,14 @@ public class IdpSelectorTest {
 
     @Test(expected= StateProcessingValidationException.class)
          public void shouldRaiseAnExceptionWhenSelectedIDPDoesNotExist() {
-        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(ImmutableList.of(IDP_ENTITY_ID)).build();
+        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(List.of(IDP_ENTITY_ID)).build();
 
         IdpSelector.buildIdpSelectedState(state, "another-idp-entity-id", true, REQUESTED_LOA, transactionsConfigProxy, identityProvidersConfigProxy);
     }
 
     @Test(expected= StateProcessingValidationException.class)
     public void shouldRaiseAnExceptionWhenSelectedIDPDoesNotHaveSupportedLevelsOfAssurance() {
-        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(ImmutableList.of(IDP_ENTITY_ID)).build();
+        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(List.of(IDP_ENTITY_ID)).build();
         when(transactionsConfigProxy.getLevelsOfAssurance(state.getRequestIssuerEntityId())).thenReturn(asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2));
 
         IdpSelector.buildIdpSelectedState(state, IDP_ENTITY_ID, true, LevelOfAssurance.LEVEL_2, transactionsConfigProxy, identityProvidersConfigProxy);
@@ -98,7 +99,7 @@ public class IdpSelectorTest {
 
     @Test(expected= StateProcessingValidationException.class)
     public void shouldRaiseAnExceptionWhenSelectedIDPDoesNotHaveRequestedLevelOfAssurance() {
-        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(ImmutableList.of(IDP_ENTITY_ID)).build();
+        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(List.of(IDP_ENTITY_ID)).build();
         when(transactionsConfigProxy.getLevelsOfAssurance(state.getRequestIssuerEntityId())).thenReturn(asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2));
 
         IdpSelector.buildIdpSelectedState(state, IDP_ENTITY_ID, true, REQUESTED_LOA, transactionsConfigProxy, identityProvidersConfigProxy);
@@ -106,7 +107,7 @@ public class IdpSelectorTest {
 
     @Test(expected= StateProcessingValidationException.class)
     public void shouldRaiseAnExceptionWhenTransactionEntityDoesNotHaveRequestedLevelOfAssurance() {
-        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(ImmutableList.of(IDP_ENTITY_ID)).build();
+        IdpSelectedState state = IdpSelectedStateBuilder.anIdpSelectedState().withIdpEntityId(IDP_ENTITY_ID).withAvailableIdentityProviders(List.of(IDP_ENTITY_ID)).build();
         when(transactionsConfigProxy.getLevelsOfAssurance(state.getRequestIssuerEntityId())).thenReturn(singletonList(LevelOfAssurance.LEVEL_1));
 
         IdpSelector.buildIdpSelectedState(state, IDP_ENTITY_ID, true, REQUESTED_LOA, transactionsConfigProxy, identityProvidersConfigProxy);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/SessionStartedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/SessionStartedStateControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.policy.domain.controller;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,6 +17,8 @@ import uk.gov.ida.hub.policy.domain.state.SessionStartedState;
 import uk.gov.ida.hub.policy.logging.HubEventLogger;
 import uk.gov.ida.hub.policy.proxy.IdentityProvidersConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
+
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -61,7 +62,7 @@ public class SessionStartedStateControllerTest {
             .build();
         when(transactionsConfigProxy.getLevelsOfAssurance(sessionStartedState.getRequestIssuerEntityId()))
                 .thenReturn(asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2));
-        IdpConfigDto idpConfigDto = new IdpConfigDto(IDP_ENTITY_ID, true, ImmutableList.of(LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_1));
+        IdpConfigDto idpConfigDto = new IdpConfigDto(IDP_ENTITY_ID, true, List.of(LevelOfAssurance.LEVEL_2, LevelOfAssurance.LEVEL_1));
         when(identityProvidersConfigProxy.getIdpConfig(IDP_ENTITY_ID)).thenReturn(idpConfigDto);
         when(identityProvidersConfigProxy.getEnabledIdentityProviders(sessionStartedState.getRequestIssuerEntityId(), REGISTERING, LevelOfAssurance.LEVEL_2))
                 .thenReturn(singletonList(IDP_ENTITY_ID));

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/AuthnResponseFactory.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/builders/AuthnResponseFactory.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.samlengine.builders;
 
 import java.util.Optional;
-import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.opensaml.saml.saml2.core.AttributeStatement;
@@ -45,18 +44,16 @@ public class AuthnResponseFactory {
 
     TestCredentialFactory hubEncryptionCredentialFactory =
             new TestCredentialFactory(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT, TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY);
-    Map<String, String> publicSigningCerts = ImmutableMap.<String, String>builder()
-            .put(TestEntityIds.STUB_IDP_ONE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT)
-            .put(TestEntityIds.TEST_RP, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT)
-            .put(TestEntityIds.STUB_IDP_TWO, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT)
-            .put(TestEntityIds.STUB_IDP_THREE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT)
-            .build();
-    Map<String, String> privateSigningKeys = ImmutableMap.<String, String>builder()
-            .put(TestEntityIds.STUB_IDP_ONE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY)
-            .put(TestEntityIds.TEST_RP, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY)
-            .put(TestEntityIds.STUB_IDP_TWO, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY)
-            .put(TestEntityIds.STUB_IDP_THREE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY)
-            .build();
+    Map<String, String> publicSigningCerts = Map.of(
+            TestEntityIds.STUB_IDP_ONE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT,
+            TestEntityIds.TEST_RP, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT,
+            TestEntityIds.STUB_IDP_TWO, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT,
+            TestEntityIds.STUB_IDP_THREE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT);
+    Map<String, String> privateSigningKeys = Map.of(
+            TestEntityIds.STUB_IDP_ONE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY,
+            TestEntityIds.TEST_RP, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY,
+            TestEntityIds.STUB_IDP_TWO, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY,
+            TestEntityIds.STUB_IDP_THREE, TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY);
 
     public AuthnResponseFactory() {
     }

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/support/AssertionDecrypter.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/support/AssertionDecrypter.java
@@ -1,7 +1,5 @@
 package uk.gov.ida.integrationtest.hub.samlengine.support;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.codec.binary.Base64;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.Unmarshaller;
@@ -33,6 +31,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class AssertionDecrypter {
 
@@ -51,8 +50,8 @@ public class AssertionDecrypter {
         IdaKeyStore keyStore = new IdaKeyStore(signingKeyPair, Collections.singletonList(encryptionKeyPair));
         IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
         Decrypter decrypter = new DecrypterFactory().createDecrypter(idaKeyStoreCredentialRetriever.getDecryptingCredentials());
-        ImmutableSet<String> contentEncryptionAlgorithms = ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256, EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM);
-        ImmutableSet<String> keyTransportAlgorithms = ImmutableSet.of(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP11);
+        Set<String> contentEncryptionAlgorithms = Set.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256, EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM);
+        Set<String> keyTransportAlgorithms = Set.of(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP, EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP11);
 
         uk.gov.ida.saml.security.AssertionDecrypter assertionDecrypter = new uk.gov.ida.saml.security.AssertionDecrypter(
             new EncryptionAlgorithmValidator(contentEncryptionAlgorithms, keyTransportAlgorithms),
@@ -89,7 +88,7 @@ public class AssertionDecrypter {
     }
 
     private Assertion decrypt(EncryptedAssertion encryptedAssertion) {
-        Decrypter decrypter = new DecrypterFactory().createDecrypter(ImmutableList.of(new BasicCredential(publicKey, privateKey)));
+        Decrypter decrypter = new DecrypterFactory().createDecrypter(List.of(new BasicCredential(publicKey, privateKey)));
         decrypter.setRootInNewDocument(true);
         try {
             return decrypter.decrypt(encryptedAssertion);

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStoreTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/config/ConfigServiceKeyStoreTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlengine.config;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +78,7 @@ public class ConfigServiceKeyStoreTest {
     public void getVerifyingKeysForEntity_shouldReturnAllKeysReturnedByConfig() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         final CertificateDto certTwoDto = getX509Certificate(SECOND_IDP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -94,7 +93,7 @@ public class ConfigServiceKeyStoreTest {
     public void getVerifyingKeysForEntity_shouldValidateEachKeyReturnedByConfig() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
         final CertificateDto certTwoDto = getX509Certificate(SECOND_IDP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -108,7 +107,7 @@ public class ConfigServiceKeyStoreTest {
     @Test
     public void getVerificationKeyForEntity_shouldThrowExceptionIfCertificateIsInvalid() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         CertPathValidatorException underlyingException = new CertPathValidatorException("Invalid Certificate");
@@ -125,7 +124,7 @@ public class ConfigServiceKeyStoreTest {
     @Test
     public void getVerificationKeyForEntity_shouldNotValidateWhenTrustStoreDisabled() {
         final CertificateDto certOneDto = getX509Certificate(RP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.empty());
         configServiceKeyStore.getVerifyingKeysForEntity(issuerId);

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/VerifiedAttributesLoggerTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/logging/VerifiedAttributesLoggerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.samlengine.logging;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,7 +76,7 @@ public class VerifiedAttributesLoggerTest {
         Map<String, List<VerifiedAttributeLogData>> attributesMap = actual.getAttributes();
 
         assertThat(attributesMap.get(IdaConstants.Attributes_1_1.DateOfBirth.NAME))
-            .isEqualTo(ImmutableList.of(
+            .isEqualTo(List.of(
                 new VerifiedAttributeLogData(true, "less than 180 days"),
                 new VerifiedAttributeLogData(false, null)
             ));
@@ -112,7 +111,7 @@ public class VerifiedAttributesLoggerTest {
         Map<String, List<VerifiedAttributeLogData>> attributesMap = actual.getAttributes();
 
         assertThat(attributesMap.get(IdaConstants.Attributes_1_1.Firstname.NAME))
-            .isEqualTo(ImmutableList.of(
+            .isEqualTo(List.of(
                 new VerifiedAttributeLogData(true, "more than 180 days"),
                 new VerifiedAttributeLogData(false, null)
             ));
@@ -148,7 +147,7 @@ public class VerifiedAttributesLoggerTest {
         Map<String, List<VerifiedAttributeLogData>> attributesMap = actual.getAttributes();
 
         assertThat(attributesMap.get(IdaConstants.Attributes_1_1.Middlename.NAME))
-            .isEqualTo(ImmutableList.of(
+            .isEqualTo(List.of(
                 new VerifiedAttributeLogData(true, "more than 405 days"),
                 new VerifiedAttributeLogData(true, null)
             ));
@@ -178,7 +177,7 @@ public class VerifiedAttributesLoggerTest {
         Map<String, List<VerifiedAttributeLogData>> attributesMap = actual.getAttributes();
 
         assertThat(attributesMap.get(IdaConstants.Attributes_1_1.Surname.NAME))
-            .isEqualTo(ImmutableList.of(
+            .isEqualTo(List.of(
                 new VerifiedAttributeLogData(true, null)
             ));
     }
@@ -207,7 +206,7 @@ public class VerifiedAttributesLoggerTest {
         Map<String, List<VerifiedAttributeLogData>> attributesMap = actual.getAttributes();
 
         assertThat(attributesMap.get(IdaConstants.Attributes_1_1.CurrentAddress.NAME))
-            .isEqualTo(ImmutableList.of(
+            .isEqualTo(List.of(
                 new VerifiedAttributeLogData(true, null)
             ));
     }
@@ -237,7 +236,7 @@ public class VerifiedAttributesLoggerTest {
         Map<String, List<VerifiedAttributeLogData>> attributesMap = actual.getAttributes();
 
         assertThat(attributesMap.get(IdaConstants.Attributes_1_1.PreviousAddress.NAME))
-            .isEqualTo(ImmutableList.of(
+            .isEqualTo(List.of(
                 new VerifiedAttributeLogData(false, "more than 180 days")
             ));
     }

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/metadata/SigningCertFromMetadataExtractorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/metadata/SigningCertFromMetadataExtractorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlengine.metadata;
 
-import com.google.common.collect.ImmutableList;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
 import org.junit.BeforeClass;
@@ -23,7 +22,9 @@ import uk.gov.ida.saml.core.test.builders.metadata.SPSSODescriptorBuilder;
 
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -67,28 +68,28 @@ public class SigningCertFromMetadataExtractorTest {
     @Test
     public void certIsSuccessfullyExtractedFromMetadata() throws ComponentInitializationException, ResolverException {
         signingCertFromMetadataExtractor = new SigningCertFromMetadataExtractor(metadataResolver, HUB_ENTITY_ID);
-        when(metadataResolver.resolve(any())).thenReturn(ImmutableList.of(hubEntityDescriptor));
+        when(metadataResolver.resolve(any())).thenReturn(List.of(hubEntityDescriptor));
         assertThat(signingCertFromMetadataExtractor.getSigningCertForCurrentSigningKey(hubPrimarySigningPublicKey)).isEqualTo(hubPrimarySigningCert);
     }
 
     @Test
     public void certIsSuccessfullyExtractedFromMetadataReversed() throws ComponentInitializationException, ResolverException {
         signingCertFromMetadataExtractor = new SigningCertFromMetadataExtractor(metadataResolver, HUB_ENTITY_ID);
-        when(metadataResolver.resolve(any())).thenReturn(ImmutableList.of(hubEntityDescriptor));
+        when(metadataResolver.resolve(any())).thenReturn(List.of(hubEntityDescriptor));
         assertThat(signingCertFromMetadataExtractor.getSigningCertForCurrentSigningKey(hubSecondarySigningPublicKey)).isEqualTo(hubSecondarySigningCert);
     }
 
     @Test(expected = SigningKeyExtractionException.class)
     public void certIsNotFoundWhenResolvedMetadataDoesNotContainRelevantCert() throws ComponentInitializationException, ResolverException {
         signingCertFromMetadataExtractor = new SigningCertFromMetadataExtractor(metadataResolver, HUB_ENTITY_ID);
-        when(metadataResolver.resolve(any())).thenReturn(ImmutableList.of(hubEntityDescriptor));
+        when(metadataResolver.resolve(any())).thenReturn(List.of(hubEntityDescriptor));
         signingCertFromMetadataExtractor.getSigningCertForCurrentSigningKey(notHubSigningPublicKey);
     }
 
     @Test(expected = SigningKeyExtractionException.class)
     public void certIsNotFoundWhenEmptyMetadataReturned() throws ComponentInitializationException, ResolverException {
         signingCertFromMetadataExtractor = new SigningCertFromMetadataExtractor(metadataResolver, HUB_ENTITY_ID);
-        when(metadataResolver.resolve(any())).thenReturn(ImmutableList.of());
+        when(metadataResolver.resolve(any())).thenReturn(emptyList());
         signingCertFromMetadataExtractor.getSigningCertForCurrentSigningKey(notHubSigningPublicKey);
     }
 

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/EidasAttributeStatementAssertionValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/EidasAttributeStatementAssertionValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlengine.validation.country;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,6 +20,7 @@ import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 
 import javax.xml.namespace.QName;
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,8 +47,8 @@ public class EidasAttributeStatementAssertionValidatorTest {
         dateOfBirth = generateAttribute(Eidas_Attributes.DateOfBirth.NAME, Eidas_Attributes.DateOfBirth.FRIENDLY_NAME, DateOfBirth.TYPE_NAME);
         personIdentifier = generateAttribute(Eidas_Attributes.PersonIdentifier.NAME, Eidas_Attributes.PersonIdentifier.FRIENDLY_NAME, PersonIdentifier.TYPE_NAME);
         validator = new EidasAttributeStatementAssertionValidator();
-        when(assertion.getAttributeStatements()).thenReturn(ImmutableList.of(attributeStatement));
-        when(attributeStatement.getAttributes()).thenReturn(ImmutableList.of(firstName, lastName, dateOfBirth, personIdentifier));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(firstName, lastName, dateOfBirth, personIdentifier));
     }
 
     @Test(expected = SamlTransformationErrorException.class)
@@ -60,7 +60,7 @@ public class EidasAttributeStatementAssertionValidatorTest {
 
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldThrowIfMultipleAttributeStatements() {
-        when(assertion.getAttributeStatements()).thenReturn(ImmutableList.of(attributeStatement, attributeStatement));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement, attributeStatement));
 
         validator.validate(assertion);
     }
@@ -82,7 +82,7 @@ public class EidasAttributeStatementAssertionValidatorTest {
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldThrowIfAttributeValueHasInvalidSchemaType() {
         XMLObject xmlObject = mock(XMLObject.class);
-        when(firstName.getAttributeValues()).thenReturn(ImmutableList.of(xmlObject));
+        when(firstName.getAttributeValues()).thenReturn(List.of(xmlObject));
         when(xmlObject.getSchemaType()).thenReturn(CurrentFamilyName.TYPE_NAME);
 
         validator.validate(assertion);
@@ -93,7 +93,7 @@ public class EidasAttributeStatementAssertionValidatorTest {
         exception.expect(SamlTransformationErrorException.class);
         exception.expectMessage("Mandatory attributes not provided.");
 
-        when(attributeStatement.getAttributes()).thenReturn(ImmutableList.of(firstName, lastName, dateOfBirth));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(firstName, lastName, dateOfBirth));
 
         validator.validate(assertion);
     }
@@ -103,7 +103,7 @@ public class EidasAttributeStatementAssertionValidatorTest {
         XMLObject xmlObject = mock(XMLObject.class);
         when(attribute.getName()).thenReturn(name);
         when(attribute.getFriendlyName()).thenReturn(friendlyName);
-        when(attribute.getAttributeValues()).thenReturn(ImmutableList.of(xmlObject));
+        when(attribute.getAttributeValues()).thenReturn(List.of(xmlObject));
         return attribute;
     }
 

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlengine.validation.country;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,6 +11,8 @@ import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.assertion.IdentityProviderAssertionValidator;
 import uk.gov.ida.saml.core.validators.assertion.AuthnStatementAssertionValidator;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
+
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -45,12 +46,12 @@ public class ResponseAssertionsFromCountryValidatorTest {
             EXPECTED_RECIPIENT_ID);
 
         when(validatedResponse.isSuccess()).thenReturn(true);
-        when(assertion.getAuthnStatements()).thenReturn(ImmutableList.of(authnStatement));
+        when(assertion.getAuthnStatements()).thenReturn(List.of(authnStatement));
     }
 
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldThrowIfMultipleAuthnStatements() {
-        when(assertion.getAuthnStatements()).thenReturn(ImmutableList.of(authnStatement, authnStatement));
+        when(assertion.getAuthnStatements()).thenReturn(List.of(authnStatement, authnStatement));
 
         validator.validate(validatedResponse, assertion);
     }

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseFromCountryValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlengine.validation.country;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,6 +16,7 @@ import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.hub.transformers.inbound.SamlStatusToCountryAuthenticationStatusCodeMapper;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.core.test.builders.ResponseBuilder.aResponse;
@@ -54,7 +54,7 @@ public class ResponseFromCountryValidatorTest {
     public void shouldThrowIfResponseIsSuccessfulAndHasUnencryptedAssertions() {
         exception.expect(SamlTransformationErrorException.class);
         exception.expectMessage("Response has unencrypted assertion.");
-        when(response.getAssertions()).thenReturn(ImmutableList.of(assertion));
+        when(response.getAssertions()).thenReturn(List.of(assertion));
 
         validator.validateAssertionPresence(response);
     }
@@ -80,7 +80,7 @@ public class ResponseFromCountryValidatorTest {
         exception.expect(SamlTransformationErrorException.class);
         exception.expectMessage("Non-success response has unencrypted assertions. Should contain no assertions.");
         when(statusCode.getValue()).thenReturn(StatusCode.AUTHN_FAILED);
-        when(response.getEncryptedAssertions()).thenReturn(ImmutableList.of(encryptedAssertion));
+        when(response.getEncryptedAssertions()).thenReturn(List.of(encryptedAssertion));
 
         validator.validateAssertionPresence(response);
     }
@@ -89,7 +89,7 @@ public class ResponseFromCountryValidatorTest {
     public void shouldThrowIfResponseIsSuccessfulButHasMultipleEncryptedAssertions() {
         exception.expect(SamlTransformationErrorException.class);
         exception.expectMessage("Response expected to contain 1 assertions. 2 assertion(s) found.");
-        when(response.getEncryptedAssertions()).thenReturn(ImmutableList.of(encryptedAssertion, encryptedAssertion));
+        when(response.getEncryptedAssertions()).thenReturn(List.of(encryptedAssertion, encryptedAssertion));
 
         validator.validateAssertionPresence(response);
     }

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/PolicyStubRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/PolicyStubRule.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.samlproxy.apprule.support;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
 import httpstub.HttpStubRule;
 import httpstub.RegisteredResponse;
 import httpstub.builders.RegisteredResponseBuilder;
@@ -18,6 +17,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.Map;
 import java.util.UUID;
 
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
@@ -31,7 +31,7 @@ public class PolicyStubRule extends HttpStubRule {
         URI locationUri = baseUri().path(SESSION_RESOURCE_ROOT + SESSION_ID_PARAM_PATH).build(sessionId.getSessionId());
         RegisteredResponse responseFromPolicy = RegisteredResponseBuilder.aRegisteredResponse()
                 .withStatus(Status.CREATED.getStatusCode())
-                .withHeaders(ImmutableMap.of(HttpHeaders.LOCATION, locationUri.toASCIIString()))
+                .withHeaders(Map.of(HttpHeaders.LOCATION, locationUri.toASCIIString()))
                 .withBody(sessionId)
                 .build();
         register(NEW_SESSION_RESOURCE, responseFromPolicy);

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/config/ConfigServiceKeyStoreTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/config/ConfigServiceKeyStoreTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlproxy.config;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,7 +76,7 @@ public class ConfigServiceKeyStoreTest {
     public void getVerifyingKeysForEntity_shouldReturnAllKeysReturnedByConfig() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID_1);
         final CertificateDto certTwoDto = getX509Certificate(IDP_ENTITY_ID_2);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -92,7 +91,7 @@ public class ConfigServiceKeyStoreTest {
     public void getVerifyingKeysForEntity_shouldValidateEachKeyReturnedByConfig() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID_1);
         final CertificateDto certTwoDto = getX509Certificate(IDP_ENTITY_ID_2);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -106,7 +105,7 @@ public class ConfigServiceKeyStoreTest {
     @Test
     public void getVerificationKeyForEntity_shouldThrowExceptionIfCertificateIsInvalid() {
         final CertificateDto certOneDto = getX509Certificate(IDP_ENTITY_ID_1);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         CertPathValidatorException underlyingException = new CertPathValidatorException("Invalid Certificate");
@@ -123,7 +122,7 @@ public class ConfigServiceKeyStoreTest {
     @Test
     public void getVerificationKeyForEntity_shouldNotValidateWhenTrustStoreDisabled() {
         final CertificateDto certOneDto = getX509Certificate(RP_ENTITY_ID);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.empty());
         configServiceKeyStore.getVerifyingKeysForEntity(issuerId);

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/ConfigStubRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/ConfigStubRule.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import httpstub.HttpStubRule;
 import uk.gov.ida.hub.samlsoapproxy.Urls;
 import uk.gov.ida.hub.samlsoapproxy.builders.CertificateDtoBuilder;
@@ -16,6 +15,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.stream.Collectors.collectingAndThen;
@@ -25,7 +25,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 public class ConfigStubRule extends HttpStubRule {
 
     public void setupStubForMatchingServiceHealthChecks(URI matchingServiceUri) throws JsonProcessingException {
-        Collection<MatchingServiceConfigEntityDataDto> matchingServiceConfigEntityDataDtos = ImmutableList.of(MatchingServiceConfigEntityDataDtoBuilder.aMatchingServiceConfigEntityDataDto().withUri(matchingServiceUri).build());
+        Collection<MatchingServiceConfigEntityDataDto> matchingServiceConfigEntityDataDtos = List.of(MatchingServiceConfigEntityDataDtoBuilder.aMatchingServiceConfigEntityDataDto().withUri(matchingServiceUri).build());
         register(Urls.ConfigUrls.ENABLED_MATCHING_SERVICES_RESOURCE, Response.Status.OK.getStatusCode(), matchingServiceConfigEntityDataDtos);
     }
 
@@ -53,14 +53,14 @@ public class ConfigStubRule extends HttpStubRule {
 
     public void setUpStubForMatchingServiceHealthCheckRequest(URI msaUri, String msaEntityId) throws JsonProcessingException {
         final MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto = new MatchingServiceConfigEntityDataDto(msaEntityId, msaUri, "rp-entity-id", true, false, null);
-        Collection<MatchingServiceConfigEntityDataDto> matchingServices = ImmutableList.of(matchingServiceConfigEntityDataDto);
+        Collection<MatchingServiceConfigEntityDataDto> matchingServices = List.of(matchingServiceConfigEntityDataDto);
         String uri = UriBuilder.fromPath(Urls.ConfigUrls.ENABLED_MATCHING_SERVICES_RESOURCE).build().getPath();
         register(uri, OK.getStatusCode(), matchingServices);
     }
 
     public void setUpStubForForcedMatchingServiceHealthCheckRequest(URI msaUri, String msaEntityId) throws JsonProcessingException {
         final MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto = new MatchingServiceConfigEntityDataDto(msaEntityId, msaUri, "rp-entity-id", false, false, null);
-        Collection<MatchingServiceConfigEntityDataDto> matchingServices = ImmutableList.of(matchingServiceConfigEntityDataDto);
+        Collection<MatchingServiceConfigEntityDataDto> matchingServices = List.of(matchingServiceConfigEntityDataDto);
         String uri = UriBuilder.fromPath(Urls.ConfigUrls.ENABLED_MATCHING_SERVICES_RESOURCE).build().getPath();
         register(uri, OK.getStatusCode(), matchingServices);
     }
@@ -68,7 +68,7 @@ public class ConfigStubRule extends HttpStubRule {
     public void setUpStubForTwoMatchingServiceHealthCheckRequests(URI msaUri, String msaEntityId, URI msaUri2, String msaEntityId2) throws JsonProcessingException {
         final MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto = new MatchingServiceConfigEntityDataDto(msaEntityId, msaUri, "rp-entity-id", true, false, null);
         final MatchingServiceConfigEntityDataDto matchingServiceConfigEntityDataDto2 = new MatchingServiceConfigEntityDataDto(msaEntityId2, msaUri2, "rp-entity-id2", true, false, null);
-        Collection<MatchingServiceConfigEntityDataDto> matchingServices = ImmutableList.of(matchingServiceConfigEntityDataDto, matchingServiceConfigEntityDataDto2);
+        Collection<MatchingServiceConfigEntityDataDto> matchingServices = List.of(matchingServiceConfigEntityDataDto, matchingServiceConfigEntityDataDto2);
         String uri = UriBuilder.fromPath(Urls.ConfigUrls.ENABLED_MATCHING_SERVICES_RESOURCE).build().getPath();
         register(uri, OK.getStatusCode(), matchingServices);
     }

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/PolicyStubRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/PolicyStubRule.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule.support;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
 import httpstub.HttpStubRule;
 import httpstub.RegisteredResponse;
 import httpstub.builders.RegisteredResponseBuilder;
@@ -14,6 +13,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.Map;
 import java.util.UUID;
 
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
@@ -27,7 +27,7 @@ public class PolicyStubRule extends HttpStubRule {
         URI locationUri = baseUri().path(SESSION_RESOURCE_ROOT + SESSION_ID_PARAM_PATH).build(sessionId.getSessionId());
         RegisteredResponse responseFromPolicy = RegisteredResponseBuilder.aRegisteredResponse()
                 .withStatus(Status.CREATED.getStatusCode())
-                .withHeaders(ImmutableMap.of(HttpHeaders.LOCATION, locationUri.toASCIIString()))
+                .withHeaders(Map.of(HttpHeaders.LOCATION, locationUri.toASCIIString()))
                 .withBody(sessionId)
                 .build();
         register(NEW_SESSION_RESOURCE, responseFromPolicy);

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/config/ConfigServiceKeyStoreTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/config/ConfigServiceKeyStoreTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlsoapproxy.config;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,7 +81,7 @@ public class ConfigServiceKeyStoreTest {
     public void getVerifyingKeysForEntity_shouldReturnAllKeysReturnedByConfig() {
         final CertificateDto certOneDto = buildCertificateDto(IDP_ENTITY_ID_1, idpSigningCertPrimary);
         final CertificateDto certTwoDto = buildCertificateDto(IDP_ENTITY_ID_2, idpSigningCertSecondary);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -97,7 +96,7 @@ public class ConfigServiceKeyStoreTest {
     public void getVerifyingKeysForEntity_shouldValidateEachKeyReturnedByConfig() {
         final CertificateDto certOneDto = buildCertificateDto(IDP_ENTITY_ID_1, idpSigningCertPrimary);
         final CertificateDto certTwoDto = buildCertificateDto(IDP_ENTITY_ID_2, idpSigningCertSecondary);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto, certTwoDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto, certTwoDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(x509CertificateFactory.createCertificate(certTwoDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
@@ -111,7 +110,7 @@ public class ConfigServiceKeyStoreTest {
     @Test
     public void getVerificationKeyForEntity_shouldThrowExceptionIfCertificateIsInvalid() {
         final CertificateDto certOneDto = buildCertificateDto(IDP_ENTITY_ID_1, idpSigningCertPrimary);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.of(trustStore));
         CertPathValidatorException underlyingException = new CertPathValidatorException("Invalid Certificate");
@@ -128,7 +127,7 @@ public class ConfigServiceKeyStoreTest {
     @Test
     public void getVerificationKeyForEntity_shouldNotValidateWhenTrustStoreDisabled() {
         final CertificateDto certOneDto = buildCertificateDto(RP_ENTITY_ID, rpSigningCertPrimary);
-        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(ImmutableList.of(certOneDto));
+        when(certificatesConfigProxy.getSignatureVerificationCertificates(issuerId)).thenReturn(List.of(certOneDto));
         when(x509CertificateFactory.createCertificate(certOneDto.getCertificate())).thenReturn(x509Certificate);
         when(trustStoreForCertificateProvider.getTrustStoreFor(any(FederationEntityType.class))).thenReturn(Optional.empty());
         configServiceKeyStore.getVerifyingKeysForEntity(issuerId);

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/logging/HealthCheckEventLoggerTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/logging/HealthCheckEventLoggerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlsoapproxy.logging;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,6 +15,7 @@ import uk.gov.ida.hub.shared.eventsink.EventSinkProxy;
 import uk.gov.ida.exceptions.ApplicationException;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +48,7 @@ public class HealthCheckEventLoggerTest {
     public void shouldLogToEventSinkIfTheExceptionIsUnaudited() {
         URI uri = URI.create("uri-geller");
         ApplicationException unauditedException = ApplicationException.createUnauditedException(ExceptionType.INVALID_SAML, UUID.randomUUID(), uri);
-        ImmutableMap<EventDetailsKey, String> details = ImmutableMap.of(
+        Map<EventDetailsKey, String> details = Map.of(
                 downstream_uri, unauditedException.getUri().or(URI.create("uri-not-present")).toASCIIString(),
                 message, unauditedException.getMessage());
         EventSinkHubEvent event = new EventSinkHubEvent(serviceInfo, NO_SESSION_CONTEXT_IN_ERROR, ERROR_EVENT,details);


### PR DESCRIPTION
Now that Java has {List,Set,Map}.of and friends, we don't need to use so much
guava.

This commit only touches tests.