### PR TITLE
Remove more guava from tests

### DIFF
--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/domain/EidasAttributesLoggerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/domain/EidasAttributesLoggerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.saml.hub.domain;
 
-import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,6 +19,8 @@ import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.extensions.Date;
 import uk.gov.ida.saml.core.extensions.PersonName;
 import uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger;
+
+import java.util.List;
 
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -76,9 +77,9 @@ public class EidasAttributesLoggerTest {
         when(attributeValue.getDOM()).thenReturn(element);
         Attribute attribute = mock(Attribute.class);
         when(attribute.getName()).thenReturn(IdaConstants.Attributes_1_1.Firstname.NAME);
-        when(attribute.getAttributeValues()).thenReturn(Lists.newArrayList(attributeValue));
-        when(assertion.getAttributeStatements()).thenReturn(Lists.newArrayList(attributeStatement));
-        when(attributeStatement.getAttributes()).thenReturn(Lists.newArrayList(attribute));
+        when(attribute.getAttributeValues()).thenReturn(List.of(attributeValue));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(attribute));
         eidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
         verify(response).getInResponseTo();
         verify(response).getDestination();
@@ -103,10 +104,10 @@ public class EidasAttributesLoggerTest {
 
         Attribute attribute = mock(Attribute.class);
         when(attribute.getName()).thenReturn(IdaConstants.Attributes_1_1.Firstname.NAME);
-        when(attribute.getAttributeValues()).thenReturn(Lists.newArrayList(attributeValue0, attributeValue1, attributeValue2));
+        when(attribute.getAttributeValues()).thenReturn(List.of(attributeValue0, attributeValue1, attributeValue2));
 
-        when(assertion.getAttributeStatements()).thenReturn(Lists.newArrayList(attributeStatement));
-        when(attributeStatement.getAttributes()).thenReturn(Lists.newArrayList(attribute));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(attribute));
         eidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setFirstName("Paul");
@@ -133,10 +134,10 @@ public class EidasAttributesLoggerTest {
 
         Attribute attribute = mock(Attribute.class);
         when(attribute.getName()).thenReturn(IdaConstants.Attributes_1_1.Firstname.NAME);
-        when(attribute.getAttributeValues()).thenReturn(Lists.newArrayList(attributeValue0, attributeValue1));
+        when(attribute.getAttributeValues()).thenReturn(List.of(attributeValue0, attributeValue1));
 
-        when(assertion.getAttributeStatements()).thenReturn(Lists.newArrayList(attributeStatement));
-        when(attributeStatement.getAttributes()).thenReturn(Lists.newArrayList(attribute));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(attribute));
 
         eidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
 
@@ -164,10 +165,10 @@ public class EidasAttributesLoggerTest {
 
         Attribute attribute = mock(Attribute.class);
         when(attribute.getName()).thenReturn(IdaConstants.Attributes_1_1.DateOfBirth.NAME);
-        when(attribute.getAttributeValues()).thenReturn(Lists.newArrayList(attributeValue0, attributeValue1, attributeValue2));
+        when(attribute.getAttributeValues()).thenReturn(List.of(attributeValue0, attributeValue1, attributeValue2));
 
-        when(assertion.getAttributeStatements()).thenReturn(Lists.newArrayList(attributeStatement));
-        when(attributeStatement.getAttributes()).thenReturn(Lists.newArrayList(attribute));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(attribute));
         eidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
         verify(hashLogger).setPid(hashedPid);
         verify(hashLogger).setDateOfBirth(DateTime.parse("2000-01-25"));
@@ -196,10 +197,10 @@ public class EidasAttributesLoggerTest {
 
         Attribute attributeMiddleName = mock(Attribute.class);
         when(attributeMiddleName.getName()).thenReturn(IdaConstants.Attributes_1_1.Middlename.NAME);
-        when(attributeMiddleName.getAttributeValues()).thenReturn(Lists.newArrayList(attributeValue0, attributeValue1));
+        when(attributeMiddleName.getAttributeValues()).thenReturn(List.of(attributeValue0, attributeValue1));
 
-        when(assertion.getAttributeStatements()).thenReturn(Lists.newArrayList(attributeStatement));
-        when(attributeStatement.getAttributes()).thenReturn(Lists.newArrayList(attributeMiddleName));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(attributeMiddleName));
         eidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
         verify(hashLogger).setPid(hashedPid);
 
@@ -228,10 +229,10 @@ public class EidasAttributesLoggerTest {
 
         Attribute attributeSurname = mock(Attribute.class);
         when(attributeSurname.getName()).thenReturn(IdaConstants.Attributes_1_1.Surname.NAME);
-        when(attributeSurname.getAttributeValues()).thenReturn(Lists.newArrayList(attributeValue0, attributeValue1));
+        when(attributeSurname.getAttributeValues()).thenReturn(List.of(attributeValue0, attributeValue1));
 
-        when(assertion.getAttributeStatements()).thenReturn(Lists.newArrayList(attributeStatement));
-        when(attributeStatement.getAttributes()).thenReturn(Lists.newArrayList(attributeSurname));
+        when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement));
+        when(attributeStatement.getAttributes()).thenReturn(List.of(attributeSurname));
         eidasAttributesLogger.logEidasAttributesAsHash(assertion, response);
         verify(hashLogger).setPid(hashedPid);
 

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdaResponseFromIdpUnmarshallerTest.java
@@ -15,7 +15,8 @@ import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 
-import static com.google.common.collect.Lists.newArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.core.test.builders.AssertionBuilder.anAssertion;
@@ -49,7 +50,7 @@ public class IdaResponseFromIdpUnmarshallerTest {
         Assertion mdsAssertion = anAssertion().addAttributeStatement(anAttributeStatement().build()).buildUnencrypted();
         Assertion authnStatementAssertion = anAssertion().addAuthnStatement(anAuthnStatement().build()).buildUnencrypted();
 
-        when(response.getAssertions()).thenReturn(newArrayList(mdsAssertion, authnStatementAssertion));
+        when(response.getAssertions()).thenReturn(List.of(mdsAssertion, authnStatementAssertion));
         PassthroughAssertion passthroughMdsAssertion = aPassthroughAssertion().buildMatchingDatasetAssertion();
         when(passthroughAssertionUnmarshaller.fromAssertion(mdsAssertion)).thenReturn(passthroughMdsAssertion);
         PassthroughAssertion passthroughAuthnAssertion = aPassthroughAssertion().buildAuthnStatementAssertion();

--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/support/ConfigAppRule.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.google.common.collect.ImmutableList;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -30,6 +29,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static uk.gov.ida.hub.config.domain.builders.CountryConfigBuilder.aCountryConfig;
 import static uk.gov.ida.hub.config.domain.builders.IdentityProviderConfigDataBuilder.anIdentityProviderConfigData;
@@ -67,16 +67,17 @@ public class ConfigAppRule extends DropwizardAppRule<ConfigConfiguration> {
         );
     }
 
-    public static ConfigOverride[] withDefaultOverrides(ConfigOverride ... configOverrides) {
-        ImmutableList<ConfigOverride> overrides = ImmutableList.<ConfigOverride>builder()
-                .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
-                .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
-                .add(config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()))
-                .add(config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()))
-                .add(config("rootDataDirectory", FED_CONFIG_ROOT.getAbsolutePath()))
-                .add(config("translationsDirectory", TRANSLATIONS_RELATIVE_PATH))
-                .add(configOverrides)
-                .build();
+    private static ConfigOverride[] withDefaultOverrides(ConfigOverride ... configOverrides) {
+        List<ConfigOverride> overrides = new ArrayList<>(List.of(
+                config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()),
+                config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()),
+                config("rpTrustStoreConfiguration.path", rpTrustStore.getAbsolutePath()),
+                config("rpTrustStoreConfiguration.password", rpTrustStore.getPassword()),
+                config("rootDataDirectory", FED_CONFIG_ROOT.getAbsolutePath()),
+                config("translationsDirectory", TRANSLATIONS_RELATIVE_PATH)));
+        if (configOverrides != null) {
+            overrides.addAll(asList(configOverrides));
+        }
         return overrides.toArray(new ConfigOverride[0]);
     }
 

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/filters/IdpPredicateFactoryTest.java
@@ -3,7 +3,6 @@ package uk.gov.ida.hub.config.domain.filters;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import com.google.common.collect.Collections2;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.ida.hub.config.domain.IdentityProviderConfig;
@@ -28,16 +27,11 @@ public class IdpPredicateFactoryTest {
     public void createPredicatesForTransactionEntityAndLoA_shouldNotIncludeExtraPredicate() throws Exception {
         Set<Predicate<IdentityProviderConfig>> predicates = idpPredicateFactory.createPredicatesForTransactionEntityAndLoa(TRANSACTION_ENTITY, LEVEL_OF_ASSURANCE);
 
-        Predicate<Predicate> findEnabled = input -> input instanceof EnabledIdpPredicate;
-        Predicate<Predicate> findOnboarding = input -> input instanceof OnboardingIdpPredicate;
-        Predicate<Predicate> supportedLoa = input -> input instanceof SupportedLoaIdpPredicate;
-        Predicate<Predicate> findNewUserIdp = input -> input instanceof NewUserIdpPredicate;
-
         assertThat(predicates).hasSize(4);
-        assertThat(Collections2.filter(predicates, findEnabled::test)).hasSize(1);
-        assertThat(Collections2.filter(predicates, findOnboarding::test)).hasSize(1);
-        assertThat(Collections2.filter(predicates, supportedLoa::test)).hasSize(1);
-        assertThat(Collections2.filter(predicates, findNewUserIdp::test)).hasSize(1);
+        assertThat(predicates.stream().filter(predicate -> predicate instanceof EnabledIdpPredicate)).hasSize(1);
+        assertThat(predicates.stream().filter(predicate -> predicate instanceof OnboardingIdpPredicate)).hasSize(1);
+        assertThat(predicates.stream().filter(predicate -> predicate instanceof SupportedLoaIdpPredicate)).hasSize(1);
+        assertThat(predicates.stream().filter(predicate -> predicate instanceof NewUserIdpPredicate)).hasSize(1);
     }
 
     @Test
@@ -51,18 +45,14 @@ public class IdpPredicateFactoryTest {
     public void createPredicatesForTransactionEntity_shouldIncludeEnabledPredicateWhenTransactionEntityIdIsProvided() throws Exception {
         Set<Predicate<IdentityProviderConfig>> predicates = idpPredicateFactory.createPredicatesForTransactionEntity(Optional.of(TRANSACTION_ENTITY));
 
-        Predicate<Predicate> findEnabled = input -> input instanceof EnabledIdpPredicate;
-
-        assertThat(Collections2.filter(predicates, findEnabled::test)).hasSize(1);
+        assertThat(predicates.stream().filter(predicate -> predicate instanceof EnabledIdpPredicate)).hasSize(1);
     }
 
     @Test
     public void createPredicatesForTransactionEntity_shouldIncludeEnabledPredicateWhenTransactionEntityIdIsNotProvided() throws Exception {
         Set<Predicate<IdentityProviderConfig>> predicates = idpPredicateFactory.createPredicatesForTransactionEntity(null);
 
-        Predicate<Predicate> findEnabled = input -> input instanceof EnabledIdpPredicate;
-
-        assertThat(Collections2.filter(predicates, findEnabled::test)).hasSize(1);
+        assertThat(predicates.stream().filter(predicate -> predicate instanceof EnabledIdpPredicate)).hasSize(1);
     }
 
     @Test
@@ -78,7 +68,7 @@ public class IdpPredicateFactoryTest {
             return ((OnboardingForTransactionEntityPredicate) input).getTransactionEntity().equals(TRANSACTION_ENTITY);
         };
 
-        assertThat(Collections2.filter(predicates, findEnabled::test)).hasSize(1);
+        assertThat(predicates.stream().filter(findEnabled)).hasSize(1);
     }
 
     @Test
@@ -93,6 +83,6 @@ public class IdpPredicateFactoryTest {
             return ((OnboardingForTransactionEntityPredicate) input).getTransactionEntity().equals(TRANSACTION_ENTITY);
         };
 
-        assertThat(Collections2.filter(predicates, findEnabled::test)).isEmpty();
+        assertThat(predicates.stream().filter(findEnabled)).isEmpty();
     }
 }

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule.support;
 
 import certificates.values.CACertificates;
-import com.google.common.collect.ImmutableList;
 import helpers.ResourceHelpers;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -13,9 +12,12 @@ import uk.gov.ida.hub.policy.domain.State;
 
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static java.util.Arrays.asList;
 
 public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
 
@@ -25,14 +27,16 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
         super(PolicyIntegrationApplication.class, ResourceHelpers.resourceFilePath("policy.yml"), withDefaultOverrides(configOverrides));
     }
 
-    public static ConfigOverride[] withDefaultOverrides(final ConfigOverride... configOverrides) {
-        ImmutableList<ConfigOverride> mergedConfigOverrides = ImmutableList.<ConfigOverride>builder()
-                .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
-                .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
-                .add(config("eventEmitterConfiguration.enabled", "false"))
-                .add(configOverrides)
-                .build();
-        return mergedConfigOverrides.toArray(new ConfigOverride[0]);
+    private static ConfigOverride[] withDefaultOverrides(final ConfigOverride... configOverrides) {
+        List<ConfigOverride> overrides = new ArrayList<>(List.of(
+                config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()),
+                config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()),
+                config("eventEmitterConfiguration.enabled", "false")));
+
+        if (configOverrides != null) {
+            overrides.addAll(asList(configOverrides));
+        }
+        return overrides.toArray(new ConfigOverride[0]);
     }
 
     @Override

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRuleWithRedis.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRuleWithRedis.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.policy.apprule.support;
 
 import certificates.values.CACertificates;
-import com.google.common.collect.ImmutableList;
 import helpers.ResourceHelpers;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -16,9 +15,12 @@ import uk.gov.ida.hub.policy.domain.State;
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static java.util.Arrays.asList;
 
 public class PolicyAppRuleWithRedis extends DropwizardAppRule<PolicyConfiguration> {
 
@@ -31,14 +33,17 @@ public class PolicyAppRuleWithRedis extends DropwizardAppRule<PolicyConfiguratio
     }
 
     public static ConfigOverride[] withDefaultOverrides(final ConfigOverride... configOverrides) {
-        ImmutableList<ConfigOverride> mergedConfigOverrides = ImmutableList.<ConfigOverride>builder()
-                .add(config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()))
-                .add(config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()))
-                .add(config("eventEmitterConfiguration.enabled", "false"))
-                .add(config("sessionStore.redis.uri", "redis://localhost:" + REDIS_PORT))
-                .add(configOverrides)
-                .build();
-        return mergedConfigOverrides.toArray(new ConfigOverride[0]);
+        List<ConfigOverride> overrides = new ArrayList<>(List.of(
+                config("clientTrustStoreConfiguration.path", clientTrustStore.getAbsolutePath()),
+                config("clientTrustStoreConfiguration.password", clientTrustStore.getPassword()),
+                config("eventEmitterConfiguration.enabled", "false"),
+                config("sessionStore.redis.uri", "redis://localhost:" + REDIS_PORT)));
+
+        if (configOverrides != null) {
+            overrides.addAll(asList(configOverrides));
+        }
+
+        return overrides.toArray(new ConfigOverride[0]);
     }
 
     @Override

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.hub.policy.logging;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Maps;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -122,14 +121,12 @@ public class HubEventLoggerTest {
 
         eventLogger.logSessionStartedEvent(samlResponse, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB, SESSION_EXPIRY_TIMESTAMP, SESSION_ID, MINIMUM_LEVEL_OF_ASSURANCE, REQUIRED_LEVEL_OF_ASSURANCE);
 
-        final Map<EventDetailsKey, String> details = new HashMap<>();
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(message_id, samlResponse.getId());
-        details.put(minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name());
-        details.put(required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name());
-        details.put(session_event_type, SESSION_STARTED);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                message_id, samlResponse.getId(),
+                minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name(),
+                required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name(),
+                session_event_type, SESSION_STARTED));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -139,11 +136,9 @@ public class HubEventLoggerTest {
     public void logEventSinkHubEvent_shouldSendEvent() {
         eventLogger.logRequestFromHub(SESSION_ID, TRANSACTION_ENTITY_ID);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(hub_event_type, RECEIVED_AUTHN_REQUEST_FROM_HUB);
-        details.put(transaction_entity_id, TRANSACTION_ENTITY_ID);
-
-        final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(SERVICE_INFO, SESSION_ID, HUB_EVENT, details);
+        final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(SERVICE_INFO, SESSION_ID, HUB_EVENT, Map.of(
+                hub_event_type, RECEIVED_AUTHN_REQUEST_FROM_HUB,
+                transaction_entity_id, TRANSACTION_ENTITY_ID));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -167,19 +162,17 @@ public class HubEventLoggerTest {
             JOURNEY_TYPE
         );
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(idp_entity_id, IDP_ENTITY_ID);
-        details.put(pid, PERSISTENT_ID.getNameId());
-        details.put(minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name());
-        details.put(required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name());
-        details.put(provided_level_of_assurance, PROVIDED_LEVEL_OF_ASSURANCE.name());
-        details.put(principal_ip_address_as_seen_by_idp, PRINCIPAL_IP_ADDRESS_SEEN_BY_IDP);
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(session_event_type, IDP_AUTHN_SUCCEEDED);
-        details.put(analytics_session_id, ANALYTICS_SESSION_ID);
-        details.put(journey_type, JOURNEY_TYPE);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                idp_entity_id, IDP_ENTITY_ID,
+                pid, PERSISTENT_ID.getNameId(),
+                minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name(),
+                required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name(),
+                provided_level_of_assurance, PROVIDED_LEVEL_OF_ASSURANCE.name(),
+                principal_ip_address_as_seen_by_idp, PRINCIPAL_IP_ADDRESS_SEEN_BY_IDP,
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                session_event_type, IDP_AUTHN_SUCCEEDED,
+                analytics_session_id, ANALYTICS_SESSION_ID,
+                journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -208,18 +201,16 @@ public class HubEventLoggerTest {
             JOURNEY_TYPE
         );
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(session_event_type, FRAUD_DETECTED);
-        details.put(idp_entity_id, IDP_ENTITY_ID);
-        details.put(pid, PERSISTENT_ID.getNameId());
-        details.put(idp_fraud_event_id, fraudEventId);
-        details.put(gpg45_status, fraudIndicator);
-        details.put(principal_ip_address_as_seen_by_idp, PRINCIPAL_IP_ADDRESS_SEEN_BY_IDP);
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(analytics_session_id, ANALYTICS_SESSION_ID);
-        details.put(journey_type, JOURNEY_TYPE);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                session_event_type, FRAUD_DETECTED,
+                idp_entity_id, IDP_ENTITY_ID,
+                pid, PERSISTENT_ID.getNameId(),
+                idp_fraud_event_id, fraudEventId,
+                gpg45_status, fraudIndicator,
+                principal_ip_address_as_seen_by_idp, PRINCIPAL_IP_ADDRESS_SEEN_BY_IDP,
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                analytics_session_id, ANALYTICS_SESSION_ID,
+                journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -229,10 +220,9 @@ public class HubEventLoggerTest {
     public void logSessionTimeoutEvent_shouldSendEvent() {
         eventLogger.logSessionTimeoutEvent(SESSION_ID, SESSION_EXPIRY_TIMESTAMP, TRANSACTION_ENTITY_ID, REQUEST_ID);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(session_event_type, SESSION_TIMEOUT);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(
+                Map.of(session_event_type, SESSION_TIMEOUT)
+        );
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -251,16 +241,14 @@ public class HubEventLoggerTest {
 
         eventLogger.logIdpSelectedEvent(state, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB, ANALYTICS_SESSION_ID, JOURNEY_TYPE);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(session_event_type, IDP_SELECTED);
-        details.put(idp_entity_id, IDP_ENTITY_ID);
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name());
-        details.put(required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name());
-        details.put(analytics_session_id, ANALYTICS_SESSION_ID);
-        details.put(journey_type, JOURNEY_TYPE);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                session_event_type, IDP_SELECTED,
+                idp_entity_id, IDP_ENTITY_ID,
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name(),
+                required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name(),
+                analytics_session_id, ANALYTICS_SESSION_ID,
+                journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -281,14 +269,12 @@ public class HubEventLoggerTest {
             JOURNEY_TYPE
         );
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(message, errorMessage);
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(session_event_type, REQUESTER_ERROR);
-        details.put(analytics_session_id, ANALYTICS_SESSION_ID);
-        details.put(journey_type, JOURNEY_TYPE);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                message, errorMessage,
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                session_event_type, REQUESTER_ERROR,
+                analytics_session_id, ANALYTICS_SESSION_ID,
+                journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -307,13 +293,11 @@ public class HubEventLoggerTest {
             JOURNEY_TYPE
         );
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(session_event_type, IDP_AUTHN_FAILED);
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(analytics_session_id, ANALYTICS_SESSION_ID);
-        details.put(journey_type, JOURNEY_TYPE);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                session_event_type, IDP_AUTHN_FAILED,
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                analytics_session_id, ANALYTICS_SESSION_ID,
+                journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -331,13 +315,11 @@ public class HubEventLoggerTest {
             JOURNEY_TYPE
         );
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(session_event_type, IDP_AUTHN_PENDING);
-        details.put(analytics_session_id, ANALYTICS_SESSION_ID);
-        details.put(journey_type, JOURNEY_TYPE);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                session_event_type, IDP_AUTHN_PENDING,
+                analytics_session_id, ANALYTICS_SESSION_ID,
+                journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -355,13 +337,12 @@ public class HubEventLoggerTest {
             JOURNEY_TYPE
         );
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(session_event_type, NO_AUTHN_CONTEXT);
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(analytics_session_id, ANALYTICS_SESSION_ID);
-        details.put(journey_type, JOURNEY_TYPE);
 
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                session_event_type, NO_AUTHN_CONTEXT,
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                analytics_session_id, ANALYTICS_SESSION_ID,
+                journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -371,11 +352,9 @@ public class HubEventLoggerTest {
     public void logCycle3DataObtained_shouldLogEvent() {
         eventLogger.logCycle3DataObtained(SESSION_ID, TRANSACTION_ENTITY_ID, SESSION_EXPIRY_TIMESTAMP, REQUEST_ID, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB);
-        details.put(session_event_type, CYCLE3_DATA_OBTAINED);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+                session_event_type, CYCLE3_DATA_OBTAINED));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -390,10 +369,8 @@ public class HubEventLoggerTest {
             REQUEST_ID
         );
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(session_event_type, USER_ACCOUNT_CREATION_REQUEST_SENT);
-
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(details);
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
+                session_event_type, USER_ACCOUNT_CREATION_REQUEST_SENT));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -403,16 +380,14 @@ public class HubEventLoggerTest {
     public void shouldLogErrorEvent() {
         eventLogger.logErrorEvent(ERROR_ID, SESSION_ID, ERROR_MESSAGE);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(message, ERROR_MESSAGE);
-        details.put(error_id, ERROR_ID.toString());
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             ERROR_EVENT,
-            details
-        );
+            Map.of(
+                    message, ERROR_MESSAGE,
+                    error_id, ERROR_ID.toString()
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -424,16 +399,14 @@ public class HubEventLoggerTest {
 
         eventLogger.logErrorEvent(ERROR_ID, idpEntityId, SESSION_ID);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(idp_entity_id, idpEntityId);
-        details.put(error_id, ERROR_ID.toString());
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             ERROR_EVENT,
-            details
-        );
+            Map.of(
+                    idp_entity_id, idpEntityId,
+                    error_id, ERROR_ID.toString()
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -445,17 +418,15 @@ public class HubEventLoggerTest {
 
         eventLogger.logErrorEvent(ERROR_ID, SESSION_ID, ERROR_MESSAGE, downstreamUri);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(downstream_uri, downstreamUri);
-        details.put(message, ERROR_MESSAGE);
-        details.put(error_id, ERROR_ID.toString());
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             ERROR_EVENT,
-            details
-        );
+            Map.of(
+                    downstream_uri, downstreamUri,
+                    message, ERROR_MESSAGE,
+                    error_id, ERROR_ID.toString()
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -465,14 +436,12 @@ public class HubEventLoggerTest {
     public void shouldLogErrorEventContainingAnErrorMessage() {
         eventLogger.logErrorEvent(ERROR_MESSAGE, SESSION_ID);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(message, ERROR_MESSAGE);
 
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             ERROR_EVENT,
-            details
+            Map.of(message, ERROR_MESSAGE)
         );
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
@@ -480,16 +449,19 @@ public class HubEventLoggerTest {
     }
 
     @NotNull
-    private EventSinkHubEvent createExpectedEventSinkHubEvent(Map<EventDetailsKey, String> details) {
-        details.put(session_expiry_time, SESSION_EXPIRY_TIMESTAMP.toString());
-        details.put(transaction_entity_id, TRANSACTION_ENTITY_ID);
-        details.put(request_id, REQUEST_ID);
+    private EventSinkHubEvent createExpectedEventSinkHubEvent(Map<EventDetailsKey, String> extraDetails) {
+        Map<EventDetailsKey, String> details = new HashMap<>(Map.of(
+                session_expiry_time, SESSION_EXPIRY_TIMESTAMP.toString(),
+                transaction_entity_id, TRANSACTION_ENTITY_ID,
+                request_id, REQUEST_ID));
+
+        details.putAll(extraDetails);
 
         return new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             SESSION_EVENT,
-            details
+            Map.copyOf(details)
         );
     }
 

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLoggerTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/logging/ExternalCommunicationEventLoggerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlproxy.logging;
 
-import com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,7 +10,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.eventemitter.EventEmitter;
-import uk.gov.ida.eventemitter.EventDetailsKey;
 import uk.gov.ida.hub.shared.eventsink.EventSinkHubEvent;
 import uk.gov.ida.hub.shared.eventsink.EventSinkProxy;
 import uk.gov.ida.shared.utils.IpAddressResolver;
@@ -74,18 +72,16 @@ public class ExternalCommunicationEventLoggerTest {
     public void logMatchingServiceRequest_shouldPassHubEventToEventSinkProxy() {
         externalCommunicationEventLogger.logMatchingServiceRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(external_communication_type, MATCHING_SERVICE_REQUEST);
-        details.put(message_id, MESSAGE_ID);
-        details.put(external_endpoint, ENDPOINT_URL.toString());
-        details.put(external_ip_address, ENDPOINT_IP_ADDRESS);
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             EXTERNAL_COMMUNICATION_EVENT,
-            details
-        );
+            Map.of(
+                    external_communication_type, MATCHING_SERVICE_REQUEST,
+                    message_id, MESSAGE_ID,
+                    external_endpoint, ENDPOINT_URL.toString(),
+                    external_ip_address, ENDPOINT_IP_ADDRESS
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -95,18 +91,16 @@ public class ExternalCommunicationEventLoggerTest {
     public void logAuthenticationRequest_shouldPassHubEventToEventSinkProxy() {
         externalCommunicationEventLogger.logIdpAuthnRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(external_communication_type, AUTHN_REQUEST);
-        details.put(message_id, MESSAGE_ID);
-        details.put(external_endpoint, ENDPOINT_URL.toString());
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             EXTERNAL_COMMUNICATION_EVENT,
-            details
-        );
+            Map.of(
+                    external_communication_type, AUTHN_REQUEST,
+                    message_id, MESSAGE_ID,
+                    external_endpoint, ENDPOINT_URL.toString(),
+                    principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -116,18 +110,16 @@ public class ExternalCommunicationEventLoggerTest {
     public void logResponseFromHub_shouldPassHubEventToEventSinkProxy() {
         externalCommunicationEventLogger.logResponseFromHub(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(external_communication_type, RESPONSE_FROM_HUB);
-        details.put(message_id, MESSAGE_ID);
-        details.put(external_endpoint, ENDPOINT_URL.toString());
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB);
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             EXTERNAL_COMMUNICATION_EVENT,
-            details
-        );
+            Map.of(
+                external_communication_type, RESPONSE_FROM_HUB,
+                message_id, MESSAGE_ID,
+                external_endpoint, ENDPOINT_URL.toString(),
+                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_THE_HUB
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/PrometheusMetricsIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.integrationtest.hub.samlsoapproxy.apprule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.Sets;
 import helpers.JerseyClientConfigurationBuilder;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -158,7 +157,7 @@ public class PrometheusMetricsIntegrationTest {
             msaStubThree.getAttributeQueryRequestUri(), MSA_THREE_ENTITY_ID, RP_THREE_ENTITY_ID);
         final MatchingServiceDetails msaFourDetails = new MatchingServiceDetails(
             msaStubFour.getAttributeQueryRequestUri(), MSA_FOUR_ENTITY_ID, RP_FOUR_ENTITY_ID);
-        Set<MatchingServiceDetails> msaDetailsSet = new HashSet<>(Sets.newHashSet(msaOneDetails, msaTwoDetails, msaThreeDetails, msaFourDetails));
+        Set<MatchingServiceDetails> msaDetailsSet = new HashSet<>(Set.of(msaOneDetails, msaTwoDetails, msaThreeDetails, msaFourDetails));
         final Element msaOneResponse = aHealthyHealthCheckResponse(MSA_ONE_ENTITY_ID, MSA_ONE_RESPONSE_ID, MSA_ONE_VERSION);
         final Element msaTwoResponse = aHealthyHealthCheckResponse(MSA_TWO_ENTITY_ID, MSA_TWO_RESPONSE_ID, MSA_TWO_VERSION);
         final Element msaFourResponse = aHealthyHealthCheckResponse(MSA_FOUR_ENTITY_ID, MSA_FOUR_RESPONSE_ID, MSA_FOUR_VERSION);

--- a/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/logging/ExternalCommunicationEventLoggerTest.java
+++ b/hub/saml-soap-proxy/src/test/java/uk/gov/ida/hub/samlsoapproxy/logging/ExternalCommunicationEventLoggerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.hub.samlsoapproxy.logging;
 
-import com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,7 +11,6 @@ import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.common.ServiceInfoConfigurationBuilder;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.eventemitter.EventEmitter;
-import uk.gov.ida.eventemitter.EventDetailsKey;
 import uk.gov.ida.hub.shared.eventsink.EventSinkHubEvent;
 import uk.gov.ida.hub.shared.eventsink.EventSinkProxy;
 import uk.gov.ida.shared.utils.IpAddressResolver;
@@ -72,18 +70,16 @@ public class ExternalCommunicationEventLoggerTest {
     public void logMatchingServiceRequest_shouldPassHubEventToEventSinkProxyNew() {
         externalCommunicationEventLogger.logMatchingServiceRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(external_communication_type, MATCHING_SERVICE_REQUEST);
-        details.put(message_id, MESSAGE_ID);
-        details.put(external_endpoint, ENDPOINT_URL.toString());
-        details.put(external_ip_address, ENDPOINT_IP_ADDRESS);
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             EXTERNAL_COMMUNICATION_EVENT,
-            details
-        );
+            Map.of(
+                    external_communication_type, MATCHING_SERVICE_REQUEST,
+                    message_id, MESSAGE_ID,
+                    external_endpoint, ENDPOINT_URL.toString(),
+                    external_ip_address, ENDPOINT_IP_ADDRESS
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -93,18 +89,16 @@ public class ExternalCommunicationEventLoggerTest {
     public void logAuthenticationRequest_shouldPassHubEventToEventSinkProxy() {
         externalCommunicationEventLogger.logIdpAuthnRequest(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(external_communication_type, AUTHN_REQUEST);
-        details.put(message_id, MESSAGE_ID);
-        details.put(external_endpoint, ENDPOINT_URL.toString());
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB);
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             EXTERNAL_COMMUNICATION_EVENT,
-            details
-        );
+            Map.of(
+                    external_communication_type, AUTHN_REQUEST,
+                    message_id, MESSAGE_ID,
+                    external_endpoint, ENDPOINT_URL.toString(),
+                    principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -114,18 +108,16 @@ public class ExternalCommunicationEventLoggerTest {
     public void logResponseFromHub_shouldPassHubEventToEventSinkProxy() {
         externalCommunicationEventLogger.logResponseFromHub(MESSAGE_ID, SESSION_ID, ENDPOINT_URL, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB);
 
-        final Map<EventDetailsKey, String> details = Maps.newHashMap();
-        details.put(external_communication_type, RESPONSE_FROM_HUB);
-        details.put(message_id, MESSAGE_ID);
-        details.put(external_endpoint, ENDPOINT_URL.toString());
-        details.put(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB);
-
         final EventSinkHubEvent expectedEvent = new EventSinkHubEvent(
             SERVICE_INFO,
             SESSION_ID,
             EXTERNAL_COMMUNICATION_EVENT,
-            details
-        );
+            Map.of(
+                    external_communication_type, RESPONSE_FROM_HUB,
+                    message_id, MESSAGE_ID,
+                    external_endpoint, ENDPOINT_URL.toString(),
+                    principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB
+            ));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));


### PR DESCRIPTION
Now we have Java 9, we can make use of Java's built-in immutable collection
support.