### PR TITLE
Remove guava `Throwables` from tests

### DIFF
--- a/hub-saml/src/test/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStoreTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/metadata/IdpMetadataPublicKeyStoreTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.saml.metadata;
 
-import com.google.common.base.Throwables;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.xml.BasicParserPool;
 import org.apache.xml.security.exceptions.Base64DecodingException;
@@ -39,7 +38,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
-import static com.google.common.base.Throwables.propagate;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,7 +69,7 @@ public class IdpMetadataPublicKeyStoreTest {
             stringBackedMetadataResolver.initialize();
             return stringBackedMetadataResolver;
         } catch (InitializationException | ComponentInitializationException e) {
-            throw propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -95,7 +93,7 @@ public class IdpMetadataPublicKeyStoreTest {
                     .setAddDefaultSpServiceDescriptor(false)
                     .build();
         } catch (MarshallingException | SignatureException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/CountryMetadataRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/CountryMetadataRule.java
@@ -1,13 +1,10 @@
 package uk.gov.ida.integrationtest.hub.samlengine.apprule.support;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Throwables;
 import httpstub.HttpStub;
 import httpstub.HttpStubRule;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
-
-import static com.google.common.base.Throwables.propagate;
 
 public class CountryMetadataRule extends HttpStubRule {
 
@@ -26,7 +23,7 @@ public class CountryMetadataRule extends HttpStubRule {
         try {
             InitializationService.initialize();
         } catch (InitializationException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
 
         countryMetadataUri = entityId;
@@ -35,7 +32,7 @@ public class CountryMetadataRule extends HttpStubRule {
         try {
             this.register(entityId, 200, "application/samlmetadata+xml", countryMetadata);
         } catch (JsonProcessingException e) {
-            propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/NodeMetadataFactory.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/NodeMetadataFactory.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.integrationtest.hub.samlengine.apprule.support;
 
-import com.google.common.base.Throwables;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
@@ -40,7 +39,7 @@ public class NodeMetadataFactory {
         try {
             return getEntityDescriptor(entityID, idpssoDescriptor, entityDescriptorSignature);
         } catch (MarshallingException | SignatureException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Throwables.propagate;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
@@ -184,7 +183,7 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
             trustAnchorServer.register(TRUST_ANCHOR_PATH, 200, MediaType.APPLICATION_OCTET_STREAM, buildTrustAnchorString());
 
         } catch (Exception e) {
-            throw propagate(e);
+            throw new RuntimeException(e);
         }
         super.before();
     }


### PR DESCRIPTION
We can just re-throw a RuntimeException here. Code quality tools won't like it,
but it's going to be good enough to fail a test.