### PR TITLE
EID-1605 Set hub-saml and hub-saml-test-utils to 1.8

### DIFF
--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -3,6 +3,9 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 publishing {
     repositories {
         maven {

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -3,6 +3,9 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
hub-saml and hub-saml-test-utils are currently consumed by the
verify-service-provider (VSP). The VSP supports Java 8 and needs these
libraries to be compatible. Currently they're built with Java 11.