### PR TITLE
BAU Don't check detail for AuthenticationFailed status

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdpIdaStatusMappingsFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/SamlStatusToIdpIdaStatusMappingsFactory.java
@@ -15,27 +15,18 @@ import java.util.function.Predicate;
 
 public class SamlStatusToIdpIdaStatusMappingsFactory {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SamlStatusToIdpIdaStatusMappingsFactory.class);
-
     enum SamlStatusDefinitions {
         Success(DetailedStatusCode.Success, (v) -> true),
         AuthenticationCancelled(DetailedStatusCode.NoAuthenticationContext, StatusValue.CANCEL::equals),
         AuthenticationPending(DetailedStatusCode.NoAuthenticationContext, StatusValue.PENDING::equals),
         NoAuthenticationContext(DetailedStatusCode.NoAuthenticationContext, Objects::isNull),
-        AuthenticationFailed(DetailedStatusCode.AuthenticationFailed, SamlStatusDefinitions::checkNullWithLogging),
+        AuthenticationFailed(DetailedStatusCode.AuthenticationFailed, (v) -> true),
         RequesterErrorFromIdp(DetailedStatusCode.RequesterErrorFromIdp, Objects::isNull),
         RequesterErrorRequestDeniedFromIdp(DetailedStatusCode.RequesterErrorRequestDeniedFromIdp, Objects::isNull),
         UpliftFailed(DetailedStatusCode.NoAuthenticationContext, StatusValue.UPLIFT_FAILED::equals);
 
         private final DetailedStatusCode statusCode;
         private final Predicate<String> statusDetailValuePredicate;
-
-        private static boolean checkNullWithLogging(String value) {
-            if (Objects.nonNull(value)) {
-                LOG.info(String.format("Detail value: %s", value));
-            }
-            return Objects.isNull(value);
-        }
 
         SamlStatusDefinitions(DetailedStatusCode statusCode, Predicate<String> statusDetailValuePredicate) {
             this.statusCode = statusCode;
@@ -44,10 +35,10 @@ public class SamlStatusToIdpIdaStatusMappingsFactory {
 
         public boolean matches(String samlStatusValue, Optional<String> samlSubStatusValue, List<String> statusDetailValues) {
             boolean statusCodesMatch = statusCode.getStatus().equals(samlStatusValue) && statusCode.getSubStatus().equals(samlSubStatusValue);
-            boolean statusDetailsMatch = false;
+            boolean statusDetailsMatch;
             if (statusDetailValues.isEmpty()){
                 statusDetailsMatch = statusDetailValuePredicate.test(null);
-            }else {
+            } else {
                 statusDetailsMatch = statusDetailValues.stream().anyMatch(statusDetailValuePredicate);
             }
             return statusCodesMatch && statusDetailsMatch;

--- a/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshallerTest.java
+++ b/hub-saml/src/test/java/uk/gov/ida/saml/hub/transformers/inbound/IdpIdaStatusUnmarshallerTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.impl.StatusDetailImpl;
 import uk.gov.ida.saml.core.OpenSamlXmlObjectFactory;
 import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.core.test.OpenSAMLRunner;
@@ -76,6 +77,16 @@ public class IdpIdaStatusUnmarshallerTest {
         subStatusCode.setValue(StatusCode.AUTHN_FAILED);
         topLevelStatusCode.setStatusCode(subStatusCode);
         IdpIdaStatus transformedStatus = unmarshaller.fromSaml(status);
+
+        assertThat(transformedStatus).isEqualTo(IdpIdaStatus.authenticationFailed());
+    }
+
+    @Test
+    public void transform_shouldTransformAuthnFailedWithDetail() throws Exception {
+        String authnFailedWithDetailXml = readXmlFile("status-authnfailed-with-detail.xml");
+        Response response = stringToOpenSamlObjectTransformer.apply(authnFailedWithDetailXml);
+
+        IdpIdaStatus transformedStatus = unmarshaller.fromSaml(response.getStatus());
 
         assertThat(transformedStatus).isEqualTo(IdpIdaStatus.authenticationFailed());
     }

--- a/hub-saml/src/test/resources/status-authnfailed-with-detail.xml
+++ b/hub-saml/src/test/resources/status-authnfailed-with-detail.xml
@@ -1,0 +1,17 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_ccb1eabc4827928c9cbb3db34fdbe9df186dfcb8"
+                Version="2.0"
+                IssueInstant="2015-08-20T09:39:53Z"
+                Destination="https://www.signin.service.gov.uk:443/SAML2/SSO/Response/POST"
+                InResponseTo="_7081cbd6-a811-440a-949a-12a9521ed7cc">
+    <saml:Issuer>http://stub-idp</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder">
+            <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:AuthnFailed" />
+        </samlp:StatusCode>
+        <samlp:StatusDetail>
+            <StatusValue>authn-cancel</StatusValue>
+        </samlp:StatusDetail>
+    </samlp:Status>
+</samlp:Response>


### PR DESCRIPTION
My knowledge of status's and the significance of details within them is
low is feedback on this is appreciated.

We've recently seen an increase in errors being thrown when an IDP
returns an AuthenticationFailed status. This is due to a [recent change
in the logic for mapping the status from the SAML to a Java object](https://github.com/alphagov/verify-hub/pull/369).

This status has a top-level status of Responder and a sub-status of
Authn_failed. The recent changes meant that we failed to match this
status when mapping if the IDP also included a status detail value (we
_only_ matched if there was no detail).

We added some logging to check if IDP's were including detail values for
this status and it turns out they were. [An example can be seen here.](https://kibana.logit.io/s/a7c5d5b3-a64d-4a60-961e-f9477bb11536/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'2019-09-18T08:17:35.406Z',mode:absolute,to:'2019-09-18T08:17:35.519Z'))&_a=(columns:!(_source),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:lucene,query:'%22is%20not%20a%20valid%20sub-status%20when%20top-level%20status%20is%22%20OR%20%22Detail%20value%22'),sort:!('@timestamp',desc)))

As this status is the only status with this combination of top-level and
sub-status, we shouldn't care what the detail is and should match
regardless.