### PR TITLE
bump to latest gds-metrics-dropwizard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ subprojects {
 
         dropwizard_infinispan "uk.gov.ida:dropwizard-infinispan:$dependencyVersions.dropwizard_infinispan"
 
-        prometheus 'engineering.gds-reliability:gds-metrics-dropwizard:0.1.0'
+        prometheus 'engineering.gds-reliability:gds-metrics-dropwizard:0.7.0'
 
         saml "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
                 project(":hub-saml")


### PR DESCRIPTION
This is mainly a bump to upstream transitive dependencies, such as to
prometheus:client_java 0.7.0.