### PR TITLE
BAU: Revert change that made code target JDK 1.8

### DIFF
--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -3,9 +3,6 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 publishing {
     repositories {
         maven {

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -3,9 +3,6 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
We should not be building with a target of 1.8. We have code that requires 11. Target of 1.8 was added to enable compatibility with the VSP, however the VSP's dependency on this project was removed.