### PR TITLE
DTO to represent data required to process unsigned assertions in an eIDAS SAML response

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/CountrySignedResponseContainer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/core/domain/CountrySignedResponseContainer.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.saml.core.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CountrySignedResponseContainer {
+
+    private String base64SamlResponse;
+    private String countryEntityId;
+    private List<String> base64encryptedKeys;
+
+    @SuppressWarnings("unused")
+    private CountrySignedResponseContainer() {
+        // needed for JAXB
+    }
+
+    public CountrySignedResponseContainer(String base64SamlResponse, List<String> base64encryptedKeys, String countryEntityId) {
+        this.base64SamlResponse = base64SamlResponse;
+        this.base64encryptedKeys = base64encryptedKeys;
+        this.countryEntityId = countryEntityId;
+    }
+
+    public String getBase64SamlResponse() {
+        return base64SamlResponse;
+    }
+
+    public String getCountryEntityId() {
+        return countryEntityId;
+    }
+
+    public List<String> getBase64encryptedKeys() {
+        return base64encryptedKeys;
+    }
+}

--- a/hub/policy/build.gradle
+++ b/hub/policy/build.gradle
@@ -14,6 +14,7 @@ dependencies {
             configurations.dropwizard_infinispan,
             configurations.prometheus,
             configurations.redis,
+            configurations.saml,
             project(':hub:shared')
 }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasMatchingServiceResourceIntegrationTest.java
@@ -391,7 +391,7 @@ public class EidasMatchingServiceResourceIntegrationTest {
 
     private void stubSamlEngineTranslationLOAForCountry(final LevelOfAssurance loa, final EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        InboundResponseFromCountry translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.empty(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa), Optional.empty());
+        InboundResponseFromCountry translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.empty(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa), Optional.empty(), Optional.empty());
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/EidasSessionResourceIntegrationTest.java
@@ -218,13 +218,13 @@ public class EidasSessionResourceIntegrationTest {
 
     private void stubSamlEngineTranslationLOAForCountry(LevelOfAssurance loa, EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.empty(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa), Optional.empty());
+        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Success, Optional.empty(), country.getEntityId(), Optional.of("BLOB"), Optional.of("PID"), Optional.of(loa), Optional.empty(), Optional.empty());
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 
     private void stubSamlEngineTranslationToFailForCountry(EidasCountryDto country) throws Exception {
         samlEngineStub.reset();
-        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Failure, Optional.empty(), country.getEntityId(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        translationDto = new InboundResponseFromCountry(CountryAuthenticationStatus.Status.Failure, Optional.empty(), country.getEntityId(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
         samlEngineStub.setupStubForCountryAuthnResponseTranslate(translationDto);
     }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromCountry.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/InboundResponseFromCountry.java
@@ -2,6 +2,7 @@ package uk.gov.ida.hub.policy.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.joda.time.DateTime;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.util.Optional;
 
@@ -15,8 +16,17 @@ public class InboundResponseFromCountry {
     private Optional<String> encryptedIdentityAssertionBlob;
     private Optional<LevelOfAssurance> levelOfAssurance;
     private Optional<DateTime> notOnOrAfter;
+    private Optional<CountrySignedResponseContainer> countrySignedResponseContainer;
 
-    public InboundResponseFromCountry(CountryAuthenticationStatus.Status status, Optional<String> statusMessage, String issuer, Optional<String> encryptedIdentityAssertionBlob, Optional<String> persistentId, Optional<LevelOfAssurance> levelOfAssurance, Optional<DateTime> notOnOrAfter) {
+    public InboundResponseFromCountry(
+            CountryAuthenticationStatus.Status status,
+            Optional<String> statusMessage,
+            String issuer,
+            Optional<String> encryptedIdentityAssertionBlob,
+            Optional<String> persistentId,
+            Optional<LevelOfAssurance> levelOfAssurance,
+            Optional<DateTime> notOnOrAfter,
+            Optional<CountrySignedResponseContainer> countrySignedResponseContainer) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.issuer = issuer;
@@ -24,6 +34,7 @@ public class InboundResponseFromCountry {
         this.persistentId = persistentId;
         this.levelOfAssurance = levelOfAssurance;
         this.notOnOrAfter = notOnOrAfter;
+        this.countrySignedResponseContainer = countrySignedResponseContainer;
     }
 
     protected InboundResponseFromCountry() {
@@ -55,5 +66,9 @@ public class InboundResponseFromCountry {
 
     public Optional<DateTime> getNotOnOrAfter() {
         return notOnOrAfter;
+    }
+
+    public Optional<CountrySignedResponseContainer> getCountrySignedResponseContainer() {
+        return countrySignedResponseContainer;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -68,6 +68,7 @@ public class EidasCountrySelectedStateControllerTest {
             Optional.of(BLOB),
             Optional.of(PID),
             Optional.of(LEVEL_2),
+            Optional.empty(),
             Optional.empty());
 
     @Rule
@@ -138,6 +139,7 @@ public class EidasCountrySelectedStateControllerTest {
                 Optional.of(BLOB),
                 Optional.empty(),
                 Optional.of(LEVEL_2),
+                Optional.empty(),
                 Optional.empty());
 
         controller.handleMatchingJourneySuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS, ANALYTICS_SESSION_ID, JOURNEY_TYPE);
@@ -155,6 +157,7 @@ public class EidasCountrySelectedStateControllerTest {
                 Optional.empty(),
                 Optional.of(PID),
                 Optional.of(LEVEL_2),
+                Optional.empty(),
                 Optional.empty());
 
         controller.handleMatchingJourneySuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS, ANALYTICS_SESSION_ID, JOURNEY_TYPE);
@@ -171,6 +174,7 @@ public class EidasCountrySelectedStateControllerTest {
                 STUB_COUNTRY_ONE,
                 Optional.of(BLOB),
                 Optional.of(PID),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
@@ -191,6 +195,7 @@ public class EidasCountrySelectedStateControllerTest {
                 Optional.of(BLOB),
                 Optional.of(PID),
                 Optional.of(LEVEL_1),
+                Optional.empty(),
                 Optional.empty());
 
         controller.handleMatchingJourneySuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS, ANALYTICS_SESSION_ID, JOURNEY_TYPE);
@@ -229,6 +234,7 @@ public class EidasCountrySelectedStateControllerTest {
                 Optional.of(eidasAttributeQueryRequestDto.getEncryptedIdentityAssertion()),
                 Optional.of(eidasAttributeQueryRequestDto.getPersistentId().getNameId()),
                 Optional.of(LEVEL_2),
+                Optional.empty(),
                 Optional.empty());
 
         controller.handleMatchingJourneySuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS, ANALYTICS_SESSION_ID, JOURNEY_TYPE);
@@ -263,6 +269,7 @@ public class EidasCountrySelectedStateControllerTest {
                 Optional.of(eidasAttributeQueryRequestDto.getEncryptedIdentityAssertion()),
                 Optional.of(eidasAttributeQueryRequestDto.getPersistentId().getNameId()),
                 Optional.of(LEVEL_2),
+                Optional.empty(),
                 Optional.empty());
 
         controller.handleNonMatchingJourneySuccessResponseFromCountry(inboundResponseFromCountry, IP_ADDRESS, ANALYTICS_SESSION_ID, JOURNEY_TYPE);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryServiceTest.java
@@ -81,6 +81,7 @@ public class AuthnResponseFromCountryServiceTest {
             Optional.of(BLOB),
             Optional.of(PID),
             Optional.of(LEVEL_2),
+            Optional.empty(),
             Optional.empty());
 
     private static final EidasAttributeQueryRequestDto EIDAS_ATTRIBUTE_QUERY_REQUEST_DTO = new EidasAttributeQueryRequestDto(
@@ -200,6 +201,7 @@ public class AuthnResponseFromCountryServiceTest {
                         Optional.of("blob"),
                         Optional.of("pid"),
                         Optional.of(LEVEL_2),
+                        Optional.empty(),
                         Optional.empty());
 
         when(samlEngineProxy.translateAuthnResponseFromCountry(SAML_AUTHN_RESPONSE_TRANSLATOR_DTO))
@@ -214,7 +216,7 @@ public class AuthnResponseFromCountryServiceTest {
     @Test
     public void shouldReturnNonMatchingJourneySuccessResponseIfTranslationResponseFromSamlEngineIsSuccessfulAndNotUsingMatching() {
         final InboundResponseFromCountry inboundResponseFromCountry =
-                new InboundResponseFromCountry(Status.Success, Optional.of("status"), "issuer", Optional.of("blob-encrypted-for-test-rp"), Optional.of("pid"), Optional.of(LEVEL_2), Optional.empty());
+                new InboundResponseFromCountry(Status.Success, Optional.of("status"), "issuer", Optional.of("blob-encrypted-for-test-rp"), Optional.of("pid"), Optional.of(LEVEL_2), Optional.empty(), Optional.empty());
 
         when(stateController.isMatchingJourney()).thenReturn(false);
         when(samlEngineProxy.translateAuthnResponseFromCountry(NON_MATCHING_SAML_AUTHN_RESPONSE_TRANSLATOR_DTO))
@@ -246,6 +248,7 @@ public class AuthnResponseFromCountryServiceTest {
                         Optional.of("blob"),
                         Optional.of("pid"),
                         Optional.of(LEVEL_2),
+                        Optional.empty(),
                         Optional.empty()));
 
         ResponseAction responseAction = service.receiveAuthnResponseFromCountry(SESSION_ID, SAML_AUTHN_RESPONSE_CONTAINER_DTO);


### PR DESCRIPTION
Microservices in the Hub need a common data transfer object (DTO) to hold data when an eIDAS SAML Response has unsigned assertions. This DTO is the `CountrySignedResponseContainer`.
This data in it is:
- base64 of original eIDAS SAML Response
- list of encrypted secret keys a Government Service can decrypt and then use to decrypt the encrypted eIDAS assertion
- the country entityId in order to set an Assertion Issuer

This PR introduces the DTO to the Hub codebase, and adds it as an optional parameter to the `InboundResponseFromCountry`, which will be used in both the MSA and VSP journeys.