### PR TITLE
BAU: Limit the maximum number of threads to 50 for Prometheus client

### DIFF
--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/PrometheusClient.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/client/PrometheusClient.java
@@ -2,7 +2,6 @@ package uk.gov.ida.hub.samlsoapproxy.client;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.util.Duration;
 import io.prometheus.client.Gauge;
 import uk.gov.ida.hub.samlsoapproxy.SamlSoapProxyConfiguration;
 import uk.gov.ida.hub.samlsoapproxy.config.PrometheusClientServiceConfiguration;
@@ -57,9 +56,9 @@ public class PrometheusClient {
                 environment.lifecycle()
                            .executorService(MSA_HEALTH_CHECK_TASK_MANAGER)
                            .threadFactory(new ThreadFactoryBuilder().setNameFormat(MSA_HEALTH_CHECK_TASK_MANAGER).setDaemon(USE_DAEMON_THREADS).build())
-                           .minThreads(0)
-                           .maxThreads(Integer.MAX_VALUE)
-                           .keepAliveTime(Duration.seconds(60L))
+                           .minThreads(configuration.getMinNumOfThreads())
+                           .maxThreads(configuration.getMaxNumOfThreads())
+                           .keepAliveTime(configuration.getKeepAliveTime())
                            .workQueue(new SynchronousQueue<>())
                            .build();
             MatchingServiceHealthCheckService matchingServiceHealthCheckService = new MatchingServiceHealthCheckService(

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/config/PrometheusClientServiceConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/config/PrometheusClientServiceConfiguration.java
@@ -15,12 +15,27 @@ public class PrometheusClientServiceConfiguration {
     @NotNull
     @Valid
     @JsonProperty
-    private Duration initialDelay = Duration.seconds(10);
+    private Duration initialDelay = Duration.seconds(10L);
 
     @NotNull
     @Valid
     @JsonProperty
-    private Duration delay =  Duration.minutes(1);
+    private Duration delay =  Duration.minutes(1L);
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Integer minNumOfThreads = 0;
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Integer maxNumOfThreads = 50;
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Duration keepAliveTime = Duration.seconds(60L);
 
     public PrometheusClientServiceConfiguration() { }
 
@@ -34,5 +49,17 @@ public class PrometheusClientServiceConfiguration {
 
     public Duration getDelay() {
         return delay;
+    }
+
+    public Integer getMinNumOfThreads() {
+        return minNumOfThreads;
+    }
+
+    public Integer getMaxNumOfThreads() {
+        return maxNumOfThreads;
+    }
+
+    public Duration getKeepAliveTime() {
+        return keepAliveTime;
     }
 }


### PR DESCRIPTION
Creating a large number of threads will require a large memory. This change also makes the following three thread pool settings configurable. This allows us to change the settings using SAML SOAP Proxy's configuration file instead of changing its code.

1. Minimum number of threads (defaults to 0)
2. Maximum number of threads (defaults to 50)
3. Keep alive time (defaults to 60 seconds)

Author: @adityapahuja