### PR TITLE
BAU: Update Mockito version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,8 @@ subprojects {
                 'com.github.tomakehurst:wiremock-standalone:2.23.2',
                 "uk.gov.ida:saml-test:$dependencyVersions.saml_lib",
                 'org.assertj:assertj-core:3.9.1',
-                'io.dropwizard:dropwizard-testing:' + dependencyVersions.dropwizard]
+                'io.dropwizard:dropwizard-testing:' + dependencyVersions.dropwizard,
+                'org.mockito:mockito-core:2.28.2']
 
         test_deps_deps.each { dep ->
             test_deps_runtime(dep)


### PR DESCRIPTION
Builds of `hub-saml` were failing in some environments when the build target was java 11. This was due to an old version of mockito that was not compatible with java 11 in some circumstances.

We are transitively dependant on Mockito via Junit 4, but we are already on the latest version of the 4 branch.

Forced upgraded to latest mockito 2.xx.xx version.