### PR TITLE
BAU Set shouldSignWithSHA1 default to false

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/TransactionConfig.java
@@ -87,7 +87,7 @@ public class TransactionConfig implements CertificateConfigurable<TransactionCon
     @Valid
     @NotNull
     @JsonProperty
-    protected boolean shouldSignWithSHA1 = true;
+    protected boolean shouldSignWithSHA1 = false;
 
     @Valid
     @JsonProperty


### PR DESCRIPTION
All services services should be using SHA256. This changes the default.