### PR TITLE
Eid 1714 pass country resposne data to cycle3 attribute query

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionResource.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionResource.java
@@ -179,7 +179,8 @@ public class TestSessionResource {
                 dto.getPersistentId(),
                 dto.getLevelOfAssurance(),
                 dto.getEncryptedIdentityAssertion(),
-                null
+                null,
+                    null
             )
         );
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionResource.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/TestSessionResource.java
@@ -180,7 +180,7 @@ public class TestSessionResource {
                 dto.getLevelOfAssurance(),
                 dto.getEncryptedIdentityAssertion(),
                 null,
-                    null
+                null
             )
         );
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateController.java
@@ -59,7 +59,7 @@ public class EidasAwaitingCycle3DataStateController extends AbstractAwaitingCycl
             Optional.ofNullable(cycle3Dataset),
             Optional.empty(),
             getState().getEncryptedIdentityAssertion(),
-            Optional.empty()
+            getState().getCountrySignedResponseContainer()
         );
     }
 
@@ -86,7 +86,8 @@ public class EidasAwaitingCycle3DataStateController extends AbstractAwaitingCycl
             getState().getMatchingServiceEntityId(),
             getState().getEncryptedIdentityAssertion(),
             getState().getPersistentId(),
-            getState().getForceAuthentication().orElse(null)
+            getState().getForceAuthentication().orElse(null),
+            getState().getCountrySignedResponseContainer().orElse(null)
         );
 
         getStateTransitionAction().transitionTo(eidasCycle3MatchRequestSentState);

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -234,7 +234,8 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 getMatchingServiceEntityId(),
                 translatedResponse.getEncryptedIdentityAssertionBlob().get(),
                 new PersistentId(translatedResponse.getPersistentId().get()),
-                state.getForceAuthentication().orElse(null)
+                state.getForceAuthentication().orElse(null),
+                translatedResponse.getCountrySignedResponseContainer().orElse(null)
         );
     }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateController.java
@@ -96,6 +96,7 @@ public class EidasCycle0And1MatchRequestSentStateController extends EidasMatchRe
                 state.getPersistentId(),
                 state.getIdpLevelOfAssurance(),
                 state.getEncryptedIdentityAssertion(),
-                state.getForceAuthentication().orElse(null));
+                state.getForceAuthentication().orElse(null),
+                state.getCountrySignedResponseContainer().orElse(null));
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasAwaitingCycle3DataState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasAwaitingCycle3DataState.java
@@ -6,8 +6,10 @@ import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.net.URI;
+import java.util.Optional;
 
 public class EidasAwaitingCycle3DataState extends AbstractAwaitingCycle3DataState {
 
@@ -15,6 +17,8 @@ public class EidasAwaitingCycle3DataState extends AbstractAwaitingCycle3DataStat
 
     @JsonProperty
     private final String encryptedIdentityAssertion;
+    @JsonProperty
+    private final CountrySignedResponseContainer countrySignedResponseContainer;
 
     @JsonCreator
     public EidasAwaitingCycle3DataState(
@@ -30,7 +34,8 @@ public class EidasAwaitingCycle3DataState extends AbstractAwaitingCycle3DataStat
         @JsonProperty("persistentId") final PersistentId persistentId,
         @JsonProperty("levelOfAssurance") final LevelOfAssurance levelOfAssurance,
         @JsonProperty("encryptedIdentityAssertion") final String encryptedIdentityAssertion,
-        @JsonProperty("forceAuthentication") final Boolean forceAuthentication) {
+        @JsonProperty("forceAuthentication") final Boolean forceAuthentication,
+        @JsonProperty("countrySignedResponseContainer") final CountrySignedResponseContainer countrySignedResponseContainer) {
 
         super(
             requestId,
@@ -48,9 +53,14 @@ public class EidasAwaitingCycle3DataState extends AbstractAwaitingCycle3DataStat
         );
 
         this.encryptedIdentityAssertion = encryptedIdentityAssertion;
+        this.countrySignedResponseContainer = countrySignedResponseContainer;
     }
 
     public String getEncryptedIdentityAssertion() {
         return encryptedIdentityAssertion;
+    }
+
+    public Optional<CountrySignedResponseContainer> getCountrySignedResponseContainer() {
+        return Optional.ofNullable(countrySignedResponseContainer);
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCycle0And1MatchRequestSentState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCycle0And1MatchRequestSentState.java
@@ -6,8 +6,10 @@ import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.net.URI;
+import java.util.Optional;
 
 public class EidasCycle0And1MatchRequestSentState extends EidasMatchRequestSentState {
 
@@ -17,6 +19,8 @@ public class EidasCycle0And1MatchRequestSentState extends EidasMatchRequestSentS
     private final String encryptedIdentityAssertion;
     @JsonProperty
     private final PersistentId persistentId;
+    @JsonProperty
+    private final CountrySignedResponseContainer countrySignedResponseContainer;
 
     @JsonCreator
     public EidasCycle0And1MatchRequestSentState(
@@ -32,7 +36,8 @@ public class EidasCycle0And1MatchRequestSentState extends EidasMatchRequestSentS
             @JsonProperty("matchingServiceAdapterEntityId") final String matchingServiceAdapterEntityId,
             @JsonProperty("encryptedIdentityAssertion") final String encryptedIdentityAssertion,
             @JsonProperty("persistentId") final PersistentId persistentId,
-            @JsonProperty("forceAuthentication") final Boolean forceAuthentication) {
+            @JsonProperty("forceAuthentication") final Boolean forceAuthentication,
+            @JsonProperty("countrySignedResponseContainer") final CountrySignedResponseContainer countrySignedResponseContainer) {
 
         super(
                 requestId,
@@ -49,6 +54,7 @@ public class EidasCycle0And1MatchRequestSentState extends EidasMatchRequestSentS
 
         this.encryptedIdentityAssertion = encryptedIdentityAssertion;
         this.persistentId = persistentId;
+        this.countrySignedResponseContainer = countrySignedResponseContainer;
     }
 
     public String getEncryptedIdentityAssertion() {
@@ -57,5 +63,9 @@ public class EidasCycle0And1MatchRequestSentState extends EidasMatchRequestSentS
 
     public PersistentId getPersistentId() {
         return persistentId;
+    }
+
+    public Optional<CountrySignedResponseContainer> getCountrySignedResponseContainer() {
+        return Optional.ofNullable(countrySignedResponseContainer);
     }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCycle3MatchRequestSentState.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/state/EidasCycle3MatchRequestSentState.java
@@ -6,6 +6,7 @@ import org.joda.time.DateTime;
 import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.net.URI;
 
@@ -27,7 +28,8 @@ public class EidasCycle3MatchRequestSentState extends EidasCycle0And1MatchReques
             @JsonProperty("matchingServiceAdapterEntityId") final String matchingServiceAdapterEntityId,
             @JsonProperty("encryptedIdentityAssertion") final String encryptedIdentityAssertion,
             @JsonProperty("persistentId") final PersistentId persistentId,
-            @JsonProperty("forceAuthentication") final Boolean forceAuthentication) {
+            @JsonProperty("forceAuthentication") final Boolean forceAuthentication,
+            @JsonProperty("countrySignedResponseContainer") final CountrySignedResponseContainer countrySignedResponseContainer) {
 
         super(
                 requestId,
@@ -42,7 +44,8 @@ public class EidasCycle3MatchRequestSentState extends EidasCycle0And1MatchReques
                 matchingServiceAdapterEntityId,
                 encryptedIdentityAssertion,
                 persistentId,
-                forceAuthentication
+                forceAuthentication,
+                countrySignedResponseContainer
         );
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasAwaitingCycle3DataStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasAwaitingCycle3DataStateBuilder.java
@@ -6,12 +6,15 @@ import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.EidasAwaitingCycle3DataState;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.net.URI;
+import java.util.List;
 
 public class EidasAwaitingCycle3DataStateBuilder {
 
     private SessionId sessionId = new SessionId("sessionId");
+    private CountrySignedResponseContainer countrySignedResponseContainer;
 
     public static EidasAwaitingCycle3DataStateBuilder anEidasAwaitingCycle3DataState() {
         return new EidasAwaitingCycle3DataStateBuilder();
@@ -36,7 +39,18 @@ public class EidasAwaitingCycle3DataStateBuilder {
             new PersistentId("nameId"),
             LevelOfAssurance.LEVEL_2,
             "encryptedIdentityAssertion",
-            null
+            null,
+            countrySignedResponseContainer
         );
+    }
+    public EidasAwaitingCycle3DataStateBuilder withCountrySignedResponseContainer(CountrySignedResponseContainer countrySignedResponseContainer) {
+        this.countrySignedResponseContainer = countrySignedResponseContainer;
+        return this;
+    }
+    public EidasAwaitingCycle3DataStateBuilder withCountrySignedResponseContainer() {
+        this.countrySignedResponseContainer = new CountrySignedResponseContainer(
+                "MIEBASE64STRING==", List.of("MIEKEY=="), "http://country.com"
+        );
+        return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasCycle0And1MatchRequestSentStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasCycle0And1MatchRequestSentStateBuilder.java
@@ -6,8 +6,10 @@ import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.EidasCycle0And1MatchRequestSentState;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.net.URI;
+import java.util.List;
 
 import static uk.gov.ida.hub.policy.builder.domain.PersistentIdBuilder.aPersistentId;
 
@@ -16,6 +18,7 @@ public class EidasCycle0And1MatchRequestSentStateBuilder {
     private String encryptedIdentityAssertion = "encryptedIdentityAssertion";
     private PersistentId persistentId = aPersistentId().build();
     private Boolean forceAuthentication = false;
+    private CountrySignedResponseContainer countrySignedResponseContainer;
 
     public static EidasCycle0And1MatchRequestSentStateBuilder anEidasCycle0And1MatchRequestSentState() {
         return new EidasCycle0And1MatchRequestSentStateBuilder();
@@ -35,7 +38,8 @@ public class EidasCycle0And1MatchRequestSentStateBuilder {
             "matchingServiceAdapterEntityId",
             encryptedIdentityAssertion,
             persistentId,
-            forceAuthentication
+            forceAuthentication,
+            countrySignedResponseContainer
         );
     }
 
@@ -53,6 +57,14 @@ public class EidasCycle0And1MatchRequestSentStateBuilder {
         this.forceAuthentication = forceAuthentication;
         return this;
     }
-
-
+    public EidasCycle0And1MatchRequestSentStateBuilder withCountrySignedResponseContainer(CountrySignedResponseContainer countrySignedResponseContainer) {
+        this.countrySignedResponseContainer = countrySignedResponseContainer;
+        return this;
+    }
+    public EidasCycle0And1MatchRequestSentStateBuilder withCountrySignedResponseContainer() {
+        this.countrySignedResponseContainer = new CountrySignedResponseContainer(
+                "MIEBASE64STRING==", List.of("MIEKEY=="), "http://country.com"
+        );
+        return this;
+    }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasCycle3MatchRequestSentStateBuilder.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/builder/state/EidasCycle3MatchRequestSentStateBuilder.java
@@ -6,8 +6,10 @@ import uk.gov.ida.hub.policy.domain.LevelOfAssurance;
 import uk.gov.ida.hub.policy.domain.PersistentId;
 import uk.gov.ida.hub.policy.domain.SessionId;
 import uk.gov.ida.hub.policy.domain.state.EidasCycle3MatchRequestSentState;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.net.URI;
+import java.util.List;
 
 import static uk.gov.ida.hub.policy.builder.domain.PersistentIdBuilder.aPersistentId;
 
@@ -18,6 +20,7 @@ public class EidasCycle3MatchRequestSentStateBuilder {
     private SessionId sessionId = new SessionId("sessionId");
     private String requestId = "requestId";
     private Boolean forceAuthentication = false;
+    private CountrySignedResponseContainer countrySignedResponseContainer;
 
     public static EidasCycle3MatchRequestSentStateBuilder anEidasCycle3MatchRequestSentState() {
         return new EidasCycle3MatchRequestSentStateBuilder();
@@ -37,7 +40,8 @@ public class EidasCycle3MatchRequestSentStateBuilder {
             "matchingServiceAdapterEntityId",
             encryptedIdentityAssertion,
             persistentId,
-            forceAuthentication
+            forceAuthentication,
+            countrySignedResponseContainer
         );
     }
 
@@ -63,6 +67,17 @@ public class EidasCycle3MatchRequestSentStateBuilder {
 
     public EidasCycle3MatchRequestSentStateBuilder withForceAuthentication(Boolean forceAuthentication) {
         this.forceAuthentication = forceAuthentication;
+        return this;
+    }
+
+    public EidasCycle3MatchRequestSentStateBuilder withCountrySignedResponseContainer(CountrySignedResponseContainer countrySignedResponseContainer) {
+        this.countrySignedResponseContainer = countrySignedResponseContainer;
+        return this;
+    }
+    public EidasCycle3MatchRequestSentStateBuilder withCountrySignedResponseContainer() {
+        this.countrySignedResponseContainer = new CountrySignedResponseContainer(
+                "MIEBASE64STRING==", List.of("MIEKEY=="), "http://country.com"
+        );
         return this;
     }
 }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasAwaitingCycle3DataStateControllerTest.java
@@ -210,7 +210,8 @@ public class EidasAwaitingCycle3DataStateControllerTest {
             state.getMatchingServiceEntityId(),
             state.getEncryptedIdentityAssertion(),
             state.getPersistentId(),
-            state.getForceAuthentication().orElse(null)
+            state.getForceAuthentication().orElse(null),
+            state.getCountrySignedResponseContainer().orElse(null)
         );
 
         controller.handleCycle3DataSubmitted(principalIpAddressAsSeenByHub);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -227,7 +227,8 @@ public class EidasCountrySelectedStateControllerTest {
             MSA_ID,
             eidasAttributeQueryRequestDto.getEncryptedIdentityAssertion(),
             eidasAttributeQueryRequestDto.getPersistentId(),
-                false
+                false,
+            INBOUND_RESPONSE_FROM_COUNTRY.getCountrySignedResponseContainer().orElse(null)
         );
 
         InboundResponseFromCountry inboundResponseFromCountry = new InboundResponseFromCountry(

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateControllerTest.java
@@ -149,7 +149,8 @@ public class EidasCycle0And1MatchRequestSentStateControllerTest {
             state.getPersistentId(),
             state.getIdpLevelOfAssurance(),
             state.getEncryptedIdentityAssertion(),
-            state.getForceAuthentication().orElse(null)
+            state.getForceAuthentication().orElse(null),
+            state.getCountrySignedResponseContainer().orElse(null)
         );
 
         eidasCycle0And1MatchRequestSentStateController.transitionToNextStateForNoMatchResponse();

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/serialization/StateJsonSerializationTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/serialization/StateJsonSerializationTest.java
@@ -38,6 +38,7 @@ import uk.gov.ida.hub.policy.domain.state.TimeoutState;
 import uk.gov.ida.hub.policy.domain.state.UserAccountCreatedState;
 import uk.gov.ida.hub.policy.domain.state.UserAccountCreationFailedState;
 import uk.gov.ida.hub.policy.domain.state.UserAccountCreationRequestSentState;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 import uk.gov.ida.shared.utils.datetime.DateTimeFreezer;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -120,9 +121,9 @@ public class StateJsonSerializationTest {
 
     @Test
     public void shouldSerializeEidasAwaitingCycle3DataState() throws JsonProcessingException  {
-        EidasAwaitingCycle3DataState expectedState = anEidasAwaitingCycle3DataState().withSessionId(SESSION_ID).build();
+        EidasAwaitingCycle3DataState expectedState = anEidasAwaitingCycle3DataState().withSessionId(SESSION_ID).withCountrySignedResponseContainer().build();
         String actual = objectMapper.writeValueAsString(expectedState);
-        String expected = "{\"@class\":\"uk.gov.ida.hub.policy.domain.state.EidasAwaitingCycle3DataState\",\"requestId\":\"requestId\",\"sessionExpiryTimestamp\":567994200000,\"assertionConsumerServiceUri\":\"assertionConsumerServiceUri\",\"sessionId\":{\"sessionId\":\"some-session-id\"},\"transactionSupportsEidas\":true,\"identityProviderEntityId\":\"identityProviderEntityId\",\"relayState\":\"relayState\",\"persistentId\":{\"nameId\":\"nameId\"},\"levelOfAssurance\":\"LEVEL_2\",\"encryptedIdentityAssertion\":\"encryptedIdentityAssertion\",\"forceAuthentication\":null,\"requestIssuerEntityId\":\"requestIssuerId\",\"matchingServiceEntityId\":\"matchingServiceAdapterEntityId\"}";
+        String expected = "{\"@class\":\"uk.gov.ida.hub.policy.domain.state.EidasAwaitingCycle3DataState\",\"requestId\":\"requestId\",\"sessionExpiryTimestamp\":567994200000,\"assertionConsumerServiceUri\":\"assertionConsumerServiceUri\",\"sessionId\":{\"sessionId\":\"some-session-id\"},\"transactionSupportsEidas\":true,\"identityProviderEntityId\":\"identityProviderEntityId\",\"relayState\":\"relayState\",\"persistentId\":{\"nameId\":\"nameId\"},\"levelOfAssurance\":\"LEVEL_2\",\"encryptedIdentityAssertion\":\"encryptedIdentityAssertion\",\"forceAuthentication\":null,\"countrySignedResponseContainer\":{\"base64SamlResponse\":\"MIEBASE64STRING==\",\"countryEntityId\":\"http://country.com\",\"base64encryptedKeys\":[\"MIEKEY==\"]},\"requestIssuerEntityId\":\"requestIssuerId\",\"matchingServiceEntityId\":\"matchingServiceAdapterEntityId\"}";
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -216,17 +217,17 @@ public class StateJsonSerializationTest {
 
     @Test
     public void shouldSerializeEidasCycle0And1MatchRequestSentState() throws JsonProcessingException { 
-        EidasCycle0And1MatchRequestSentState expectedState = anEidasCycle0And1MatchRequestSentState().build();
+        EidasCycle0And1MatchRequestSentState expectedState = anEidasCycle0And1MatchRequestSentState().withCountrySignedResponseContainer().build();
         String actual = objectMapper.writeValueAsString(expectedState);
-        String expected = "{\"@class\":\"uk.gov.ida.hub.policy.domain.state.EidasCycle0And1MatchRequestSentState\",\"requestId\":\"requestId\",\"requestIssuerEntityId\":\"requestIssuerId\",\"sessionExpiryTimestamp\":567994200000,\"assertionConsumerServiceUri\":\"assertionConsumerServiceUri\",\"sessionId\":{\"sessionId\":\"sessionId\"},\"transactionSupportsEidas\":true,\"identityProviderEntityId\":\"identityProviderEntityId\",\"relayState\":null,\"idpLevelOfAssurance\":\"LEVEL_2\",\"matchingServiceAdapterEntityId\":\"matchingServiceAdapterEntityId\",\"encryptedIdentityAssertion\":\"encryptedIdentityAssertion\",\"persistentId\":{\"nameId\":\"default-name-id\"},\"forceAuthentication\":false,\"requestSentTime\":567993600000}";
+        String expected = "{\"@class\":\"uk.gov.ida.hub.policy.domain.state.EidasCycle0And1MatchRequestSentState\",\"requestId\":\"requestId\",\"requestIssuerEntityId\":\"requestIssuerId\",\"sessionExpiryTimestamp\":567994200000,\"assertionConsumerServiceUri\":\"assertionConsumerServiceUri\",\"sessionId\":{\"sessionId\":\"sessionId\"},\"transactionSupportsEidas\":true,\"identityProviderEntityId\":\"identityProviderEntityId\",\"relayState\":null,\"idpLevelOfAssurance\":\"LEVEL_2\",\"matchingServiceAdapterEntityId\":\"matchingServiceAdapterEntityId\",\"encryptedIdentityAssertion\":\"encryptedIdentityAssertion\",\"persistentId\":{\"nameId\":\"default-name-id\"},\"forceAuthentication\":false,\"countrySignedResponseContainer\":{\"base64SamlResponse\":\"MIEBASE64STRING==\",\"countryEntityId\":\"http://country.com\",\"base64encryptedKeys\":[\"MIEKEY==\"]},\"requestSentTime\":567993600000}";
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void shouldSerializeEidasCycle3MatchRequestSentState() throws JsonProcessingException { 
-        EidasCycle3MatchRequestSentState expectedState = anEidasCycle3MatchRequestSentState().build();
+        EidasCycle3MatchRequestSentState expectedState = anEidasCycle3MatchRequestSentState().withCountrySignedResponseContainer().build();
         String actual = objectMapper.writeValueAsString(expectedState);
-        String expected = "{\"@class\":\"uk.gov.ida.hub.policy.domain.state.EidasCycle3MatchRequestSentState\",\"requestId\":\"requestId\",\"requestIssuerEntityId\":\"requestIssuerId\",\"sessionExpiryTimestamp\":567994200000,\"assertionConsumerServiceUri\":\"assertionConsumerServiceUri\",\"sessionId\":{\"sessionId\":\"sessionId\"},\"transactionSupportsEidas\":true,\"identityProviderEntityId\":\"identityProviderEntityId\",\"relayState\":null,\"idpLevelOfAssurance\":\"LEVEL_2\",\"matchingServiceAdapterEntityId\":\"matchingServiceAdapterEntityId\",\"encryptedIdentityAssertion\":\"encryptedIdentityAssertion\",\"persistentId\":{\"nameId\":\"default-name-id\"},\"forceAuthentication\":false,\"requestSentTime\":567993600000}";
+        String expected = "{\"@class\":\"uk.gov.ida.hub.policy.domain.state.EidasCycle3MatchRequestSentState\",\"requestId\":\"requestId\",\"requestIssuerEntityId\":\"requestIssuerId\",\"sessionExpiryTimestamp\":567994200000,\"assertionConsumerServiceUri\":\"assertionConsumerServiceUri\",\"sessionId\":{\"sessionId\":\"sessionId\"},\"transactionSupportsEidas\":true,\"identityProviderEntityId\":\"identityProviderEntityId\",\"relayState\":null,\"idpLevelOfAssurance\":\"LEVEL_2\",\"matchingServiceAdapterEntityId\":\"matchingServiceAdapterEntityId\",\"encryptedIdentityAssertion\":\"encryptedIdentityAssertion\",\"persistentId\":{\"nameId\":\"default-name-id\"},\"forceAuthentication\":false,\"countrySignedResponseContainer\":{\"base64SamlResponse\":\"MIEBASE64STRING==\",\"countryEntityId\":\"http://country.com\",\"base64encryptedKeys\":[\"MIEKEY==\"]},\"requestSentTime\":567993600000}";
         assertThat(actual).isEqualTo(expected);
     }
 

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/builders/ResponseBuilder.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/builders/ResponseBuilder.java
@@ -3,7 +3,7 @@ package uk.gov.ida.hub.samlengine.builders;
 import org.joda.time.DateTime;
 import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatus;
 
-// qTODO - is this a builder?
+// TODO - is this a builder?
 public class ResponseBuilder<T extends ResponseBuilder> {
 
     protected String responseId = null;

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/builders/ResponseBuilder.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/builders/ResponseBuilder.java
@@ -3,7 +3,7 @@ package uk.gov.ida.hub.samlengine.builders;
 import org.joda.time.DateTime;
 import uk.gov.ida.saml.hub.transformers.inbound.MatchingServiceIdaStatus;
 
-// TODO - is this a builder?
+// qTODO - is this a builder?
 public class ResponseBuilder<T extends ResponseBuilder> {
 
     protected String responseId = null;


### PR DESCRIPTION
CountrySignedResponseContainer is now passed back in the various matching cycle states unless it's not present in which case an Optional.empty() is returned. This allows the original SAML Country Response to be sent with the Cycle3 data if required.

Co-authored by: Chris Wynne <christopher.wynne@digital.cabinet.office.gov.uk>