### PR TITLE
BAU: Clean up the IDP Config

### DIFF
--- a/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/IdentityProviderResourceIntegrationTest.java
+++ b/hub/config/src/integration-test/java/uk/gov/ida/integrationtest/hub/config/apprule/IdentityProviderResourceIntegrationTest.java
@@ -90,12 +90,6 @@ public class IdentityProviderResourceIntegrationTest {
                 .withOnboarding(Collections.singletonList(LOA_1_TEST_RP))
                 .build())
         .addIdp(anIdentityProviderConfigData()
-                .withEntityId(ONBOARDING_TO_LOA_1_IDP_USING_TEMP_LIST)
-                .withSupportedLevelsOfAssurance(asList(LevelOfAssurance.LEVEL_1, LevelOfAssurance.LEVEL_2))
-                .withOnboardingLevels(Collections.singletonList(LevelOfAssurance.LEVEL_1))
-                .withOnboardingTemp(Collections.singletonList(LOA_1_TEST_RP))
-                .build())
-        .addIdp(anIdentityProviderConfigData()
                 .withEntityId(DISABLED_IDP)
                 .withEnabled(false)
                 .build())
@@ -128,8 +122,7 @@ public class IdentityProviderResourceIntegrationTest {
         List<IdpDto> idps = response.readEntity(new GenericType<List<IdpDto>>(){});
         assertThat(idps).extracting("entityId").containsOnly(
                 ENABLED_ALL_RP_IDP,
-                ONBOARDING_TO_LOA_1_IDP,
-                ONBOARDING_TO_LOA_1_IDP_USING_TEMP_LIST
+                ONBOARDING_TO_LOA_1_IDP
         );
     }
 
@@ -155,8 +148,7 @@ public class IdentityProviderResourceIntegrationTest {
         List<IdpDto> idps = response.readEntity(new GenericType<List<IdpDto>>(){});
         assertThat(idps).extracting("entityId").containsOnly(
                 ENABLED_ALL_RP_IDP,
-                ONBOARDING_TO_LOA_1_IDP,
-                ONBOARDING_TO_LOA_1_IDP_USING_TEMP_LIST
+                ONBOARDING_TO_LOA_1_IDP
         );
     }
 
@@ -172,7 +164,6 @@ public class IdentityProviderResourceIntegrationTest {
         assertThat(idps).extracting("entityId").containsOnly(
                 ENABLED_ALL_RP_IDP,
                 ONBOARDING_TO_LOA_1_IDP,
-                ONBOARDING_TO_LOA_1_IDP_USING_TEMP_LIST,
                 SOFT_DISCONNECTING_IDP,
                 HARD_DISCONNECTING_IDP
         );
@@ -266,7 +257,6 @@ public class IdentityProviderResourceIntegrationTest {
         assertThat(providerEntityIds).containsOnly(
                 ENABLED_ALL_RP_IDP,
                 ONBOARDING_TO_LOA_1_IDP,
-                ONBOARDING_TO_LOA_1_IDP_USING_TEMP_LIST,
                 SOFT_DISCONNECTING_IDP,
                 HARD_DISCONNECTING_IDP
         );

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfig.java
@@ -3,7 +3,6 @@ package uk.gov.ida.hub.config.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
-import org.apache.commons.collections.ListUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 
@@ -17,17 +16,9 @@ import static java.util.Collections.emptyList;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class IdentityProviderConfig implements EntityIdentifiable {
 
-    // If present, the IDP will only be visible when fulfilling a request from
-    // the specified onboardingTransactionEntity.
-    // If absent, this IDP will be available to all
     @Valid
     @JsonProperty
     protected List<String> onboardingTransactionEntityIds = emptyList();
-
-    // This is a temporary field to be used for zero down time while we change how we configure onboarding idps
-    @Valid
-    @JsonProperty
-    protected List<String> onboardingTransactionEntityIdsTemp = emptyList();
 
     @Valid
     @NotNull
@@ -135,12 +126,8 @@ public class IdentityProviderConfig implements EntityIdentifiable {
         return onboardingTransactionEntityIds;
     }
 
-    public List<String> getOnboardingTransactionEntityIdsTemp() {
-        return ListUtils.union(onboardingTransactionEntityIdsTemp, onboardingTransactionEntityIds);
-    }
-
     public boolean isOnboardingForTransactionEntity(String transactionEntity) {
-        return this.getOnboardingTransactionEntityIdsTemp().contains(transactionEntity);
+        return this.getOnboardingTransactionEntityIds().contains(transactionEntity);
     }
 
     public boolean isOnboardingAtAllLevels() {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicate.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/filters/OnboardingIdpPredicate.java
@@ -20,7 +20,7 @@ public class OnboardingIdpPredicate implements Predicate<IdentityProviderConfig>
                 identityProviderConfig.isOnboardingAtLoa(levelOfAssurance) :
                 identityProviderConfig.isOnboardingAtAllLevels();
 
-        return !isOnboarding || identityProviderConfig.getOnboardingTransactionEntityIdsTemp().contains(transactionEntity);
+        return !isOnboarding || identityProviderConfig.getOnboardingTransactionEntityIds().contains(transactionEntity);
     }
 
 }

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/IdentityProviderConfigTest.java
@@ -92,33 +92,12 @@ public class IdentityProviderConfigTest {
     }
 
     @Test
-    public void shouldReturnAllOnboardingEntityIds() {
-        IdentityProviderConfig data = dataBuilder
-                .withOnboarding(Arrays.asList("EID1", "EID2"))
-                .withOnboardingTemp(Arrays.asList("EID_OT1", "EID_OT2"))
-                .build();
-
-        final List<String> onboardingEntityIds = data.getOnboardingTransactionEntityIds();
-        assertThat(onboardingEntityIds.size()).isEqualTo(2);
-        assertThat(onboardingEntityIds).contains("EID1");
-        assertThat(onboardingEntityIds).contains("EID2");
-
-        final List<String> onboardingEntityIdsTemp = data.getOnboardingTransactionEntityIdsTemp();
-        assertThat(onboardingEntityIdsTemp.size()).isEqualTo(4);
-        assertThat(onboardingEntityIdsTemp).contains("EID1");
-        assertThat(onboardingEntityIdsTemp).contains("EID2");
-        assertThat(onboardingEntityIdsTemp).contains("EID_OT1");
-        assertThat(onboardingEntityIdsTemp).contains("EID_OT2");
-    }
-
-    @Test
     public void shouldCheckThatIsOnboardingForTransactionEntity() {
         final IdentityProviderConfig dataWithoutOnboarding = dataBuilder.withEntityId("EID").build();
         assertThat(dataWithoutOnboarding.isOnboardingForTransactionEntity("EID")).isFalse();
 
         final IdentityProviderConfig data = dataBuilder
-                .withOnboarding(Collections.singletonList("EID_O"))
-                .withOnboardingTemp(Collections.singletonList("EID_OT"))
+                .withOnboarding(List.of("EID_O","EID_OT"))
                 .build();
 
         assertThat(data.isOnboardingForTransactionEntity("EID_O")).isTrue();

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/IdentityProviderConfigDataBuilder.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/domain/builders/IdentityProviderConfigDataBuilder.java
@@ -17,7 +17,6 @@ public class IdentityProviderConfigDataBuilder {
     private Boolean enabled = true;
     private Boolean enabledForSingleIdp = false;
     private List<String> transactionEntityIds = emptyList();
-    private List<String> transactionEntityIdsTemp = emptyList();
     private List<LevelOfAssurance> onboardingLevelsOfAssurance = emptyList();
     private List<LevelOfAssurance> supportedLevelsOfAssurance = List.of(LevelOfAssurance.LEVEL_2);
     private boolean useExactComparisonType = false;
@@ -35,7 +34,6 @@ public class IdentityProviderConfigDataBuilder {
                 enabled,
                 enabledForSingleIdp,
                 transactionEntityIds,
-                transactionEntityIdsTemp,
                 onboardingLevelsOfAssurance,
                 supportedLevelsOfAssurance,
                 useExactComparisonType,
@@ -74,11 +72,6 @@ public class IdentityProviderConfigDataBuilder {
         return this;
     }
 
-    public IdentityProviderConfigDataBuilder withOnboardingTemp(List<String> transactionEntityIdsTemp) {
-        this.transactionEntityIdsTemp = transactionEntityIdsTemp;
-        return this;
-    }
-
     public IdentityProviderConfigDataBuilder withOnboardingLevels(List<LevelOfAssurance> onboardingLevelsOfAssurance) {
         this.onboardingLevelsOfAssurance = onboardingLevelsOfAssurance;
         return this;
@@ -108,7 +101,6 @@ public class IdentityProviderConfigDataBuilder {
                 boolean enabled,
                 boolean enabledForSingleIdp,
                 List<String> transactionEntityIds,
-                List<String> transactionEntityIdsTemp,
                 List<LevelOfAssurance> onboardingLevelsOfAssurance,
                 List<LevelOfAssurance> supportedLevelsOfAssurance,
                 boolean useExactComparisonType,
@@ -121,7 +113,6 @@ public class IdentityProviderConfigDataBuilder {
             this.enabledForSingleIdp = enabledForSingleIdp;
             this.onboardingTransactionEntityIds = transactionEntityIds;
             this.onboardingLevelsOfAssurance = onboardingLevelsOfAssurance;
-            this.onboardingTransactionEntityIdsTemp = transactionEntityIdsTemp;
             this.supportedLevelsOfAssurance = supportedLevelsOfAssurance;
             this.useExactComparisonType = useExactComparisonType;
             this.provideRegistrationUntil = provideRegistrationUntil;


### PR DESCRIPTION
Clean up `IdentityProviderConfig` by removing `onboardingTransactionEntityIdsTemp`.

This looks like it should have been removed a loooong time ago, but was just crufting up the code.