### PR TITLE
EID-1721 Pass countrySignedResponseContainer to MSA for user account creation

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle0And1MatchRequestSentStateController.java
@@ -68,7 +68,11 @@ public class EidasCycle0And1MatchRequestSentStateController extends EidasMatchRe
 
         List<UserAccountCreationAttribute> userAccountCreationAttributes = transactionsConfigProxy.getUserAccountCreationAttributes(state.getRequestIssuerEntityId());
         if (!userAccountCreationAttributes.isEmpty()) {
-            EidasAttributeQueryRequestDto attributeQueryRequestDto = createAttributeQuery(userAccountCreationAttributes, state.getEncryptedIdentityAssertion(), state.getPersistentId());
+            EidasAttributeQueryRequestDto attributeQueryRequestDto = createAttributeQuery(
+                    userAccountCreationAttributes,
+                    state.getEncryptedIdentityAssertion(),
+                    state.getPersistentId(),
+                    state.getCountrySignedResponseContainer());
             transitionToUserAccountCreationRequestSentState(attributeQueryRequestDto);
             return;
         }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle3MatchRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCycle3MatchRequestSentStateController.java
@@ -55,7 +55,12 @@ public class EidasCycle3MatchRequestSentStateController extends EidasMatchReques
     protected void transitionToNextStateForNoMatchResponse() {
         List<UserAccountCreationAttribute> userAccountCreationAttributes = transactionsConfigProxy.getUserAccountCreationAttributes(state.getRequestIssuerEntityId());
         if (!userAccountCreationAttributes.isEmpty()) {
-            EidasAttributeQueryRequestDto attributeQueryRequestDto = createAttributeQuery(userAccountCreationAttributes, state.getEncryptedIdentityAssertion(), state.getPersistentId());
+            EidasAttributeQueryRequestDto attributeQueryRequestDto = createAttributeQuery(
+                    userAccountCreationAttributes,
+                    state.getEncryptedIdentityAssertion(),
+                    state.getPersistentId(),
+                    state.getCountrySignedResponseContainer()
+            );
             transitionToUserAccountCreationRequestSentState(attributeQueryRequestDto);
             return;
         }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasMatchRequestSentStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasMatchRequestSentStateController.java
@@ -17,6 +17,7 @@ import uk.gov.ida.hub.policy.proxy.MatchingServiceConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 import uk.gov.ida.hub.policy.services.AttributeQueryService;
 import uk.gov.ida.hub.policy.validators.LevelOfAssuranceValidator;
+import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +79,10 @@ public abstract class EidasMatchRequestSentStateController<T extends EidasMatchR
     }
 
     public EidasAttributeQueryRequestDto createAttributeQuery(
-            List<UserAccountCreationAttribute> userAccountCreationAttributes, String encryptedIdentityAssertion, PersistentId persistentId) {
+            List<UserAccountCreationAttribute> userAccountCreationAttributes,
+            String encryptedIdentityAssertion,
+            PersistentId persistentId,
+            Optional<CountrySignedResponseContainer> countrySignedResponseContainer) {
 
         MatchingServiceConfigEntityDataDto matchingServiceConfig = matchingServiceConfigProxy.getMatchingService(state.getMatchingServiceAdapterEntityId());
 
@@ -96,6 +100,6 @@ public abstract class EidasMatchRequestSentStateController<T extends EidasMatchR
                 Optional.empty(),
                 Optional.of(userAccountCreationAttributes),
                 encryptedIdentityAssertion,
-                Optional.empty());
+                countrySignedResponseContainer);
     }
 }


### PR DESCRIPTION
When the MSA doesn't find a user we enter the user account creation flow. In the case of unsigned assertions, we need to send the data from the `countrySignedResponseContainer` object as an assertion in the attribute query, rather than the original encrypted assertion.

Work has already been done to ensure that this object is available in the correct states, as well as the work to include the unsigned response assertion rather than the encrypted assertion (in `HubEidasAttributeQueryRequestToSamlAttributeQueryTransformer`).