### PR TITLE
BAU: Simplify use of generics

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/application/CertificateService.java
@@ -7,6 +7,8 @@ import uk.gov.ida.hub.config.data.ManagedEntityConfigRepository;
 import uk.gov.ida.hub.config.domain.Certificate;
 import uk.gov.ida.hub.config.domain.CertificateConfigurable;
 import uk.gov.ida.hub.config.domain.CertificateValidityChecker;
+import uk.gov.ida.hub.config.domain.MatchingServiceConfig;
+import uk.gov.ida.hub.config.domain.TransactionConfig;
 import uk.gov.ida.hub.config.exceptions.CertificateDisabledException;
 import uk.gov.ida.hub.config.exceptions.NoCertificateFoundException;
 
@@ -19,18 +21,18 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.partitioningBy;
 
-public class CertificateService <T extends CertificateConfigurable<T>> {
+public class CertificateService{
 
     private static final Logger LOG = LoggerFactory.getLogger(CertificateService.class);
 
-    private final ManagedEntityConfigRepository<T> connectedServiceConfigRepository;
-    private final ManagedEntityConfigRepository<T> matchingServiceConfigRepository;
+    private final ManagedEntityConfigRepository<TransactionConfig> connectedServiceConfigRepository;
+    private final ManagedEntityConfigRepository<MatchingServiceConfig> matchingServiceConfigRepository;
     private CertificateValidityChecker certificateValidityChecker;
 
     @Inject
     public CertificateService(
-            ManagedEntityConfigRepository<T> connectedServiceConfigRepository,
-            ManagedEntityConfigRepository<T> matchingServiceConfigRepository,
+            ManagedEntityConfigRepository<TransactionConfig> connectedServiceConfigRepository,
+            ManagedEntityConfigRepository<MatchingServiceConfig> matchingServiceConfigRepository,
             CertificateValidityChecker certificateValidityChecker) {
         this.connectedServiceConfigRepository = connectedServiceConfigRepository;
         this.matchingServiceConfigRepository = matchingServiceConfigRepository;
@@ -44,7 +46,7 @@ public class CertificateService <T extends CertificateConfigurable<T>> {
     }
 
     public  Certificate encryptionCertificateFor(String entityId) {
-        T config = getConfig(entityId);
+        CertificateConfigurable<?> config = getConfig(entityId);
         Certificate cert = config.getEncryptionCertificate();
         if (!certificateValidityChecker.isValid(cert)){
             LOG.warn("Encryption certificate for entityId '{}' was requested but is invalid", entityId);
@@ -57,7 +59,7 @@ public class CertificateService <T extends CertificateConfigurable<T>> {
     }
 
     public List<Certificate> signatureVerificationCertificatesFor(String entityId) {
-        T config = getConfig(entityId);
+        CertificateConfigurable<?> config = getConfig(entityId);
 
         Map<Boolean, List<Certificate>> certsByValidity = config.getSignatureVerificationCertificates()
                 .stream()
@@ -81,13 +83,13 @@ public class CertificateService <T extends CertificateConfigurable<T>> {
         return list;
     }
 
-    private Stream<Certificate> getAllCertificates(T config){
+    private Stream<Certificate> getAllCertificates(CertificateConfigurable<?> config){
         ArrayList<Certificate> certs = new ArrayList<>(config.getSignatureVerificationCertificates());
         certs.add(config.getEncryptionCertificate());
         return certs.stream();
     }
 
-    private T getConfig(String entityId){
+    private CertificateConfigurable<?> getConfig(String entityId){
         return Stream.of(connectedServiceConfigRepository, matchingServiceConfigRepository)
                 .filter(repo -> repo.has(entityId))
                 .findFirst()

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CertificatesResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CertificatesResource.java
@@ -5,7 +5,6 @@ import uk.gov.ida.hub.config.ConfigConfiguration;
 import uk.gov.ida.hub.config.Urls;
 import uk.gov.ida.hub.config.application.CertificateService;
 import uk.gov.ida.hub.config.domain.Certificate;
-import uk.gov.ida.hub.config.domain.CertificateConfigurable;
 import uk.gov.ida.hub.config.domain.OCSPCertificateChainValidityChecker;
 import uk.gov.ida.hub.config.dto.CertificateDto;
 import uk.gov.ida.hub.config.dto.CertificateHealthCheckDto;
@@ -35,7 +34,7 @@ public class CertificatesResource {
     private final ExceptionFactory exceptionFactory;
     private final ConfigConfiguration configuration;
     private final OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker;
-    private final CertificateService<? extends CertificateConfigurable<?>> certificateService;
+    private final CertificateService certificateService;
 
 
     @Inject
@@ -43,7 +42,7 @@ public class CertificatesResource {
             ExceptionFactory exceptionFactory,
             ConfigConfiguration configuration,
             OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker,
-            CertificateService<? extends CertificateConfigurable<?>> certificateService
+            CertificateService certificateService
     ) {
         this.exceptionFactory = exceptionFactory;
         this.configuration = configuration;

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/application/CertificateServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.config.data.ManagedEntityConfigRepository;
 import uk.gov.ida.hub.config.domain.Certificate;
-import uk.gov.ida.hub.config.domain.CertificateConfigurable;
 import uk.gov.ida.hub.config.domain.CertificateOrigin;
 import uk.gov.ida.hub.config.domain.CertificateUse;
 import uk.gov.ida.hub.config.domain.CertificateValidityChecker;
@@ -53,9 +52,7 @@ public class CertificateServiceTest {
 
     @Mock
     private CertificateValidityChecker certificateValidityChecker;
-
-
-    private CertificateService<? extends CertificateConfigurable<?>> certificateService;
+    private CertificateService certificateService;
     private ListAppender<ILoggingEvent> logsListAppender = null;
 
     @Before

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationServiceTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/application/OcspCertificateChainValidationServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.hub.config.domain.Certificate;
-import uk.gov.ida.hub.config.domain.CertificateConfigurable;
 import uk.gov.ida.hub.config.domain.CertificateOrigin;
 import uk.gov.ida.hub.config.domain.CertificateUse;
 import uk.gov.ida.hub.config.domain.OCSPCertificateChainValidityChecker;
@@ -29,7 +28,7 @@ public class OcspCertificateChainValidationServiceTest {
     private OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker;
 
     @Mock
-    private CertificateService<? extends CertificateConfigurable<?>> certificateService;
+    private CertificateService certificateService;
 
     @Test
     public void gaugesAreUpdatedForCertsWithValidChains() throws Exception {


### PR DESCRIPTION
CertificateService did not need to declare generic types. Refactored to remove them.

This was driven by Jersey logging warnings that a concrete type for CertificateService could not be found. This seems to an issue with Jersey and didn't cause any real problems, but simplifying the generics here resolved the issue anyway.