### PR TITLE
BAU: Pin OpenJDK JRE to 11.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN gradle --console=plain \
     -x :hub-saml:jar \
     -x :hub-saml-test-utils:jar
 
-FROM openjdk:11-jre
+FROM openjdk:11.0.4-jre
 ARG hub_app
 
 WORKDIR /verify-hub


### PR DESCRIPTION
After OpenJDK JRE v11.0.4 got upgraded to OpenJDK JRE v11.0.5 on 21st October 2019, Policy and SAML Proxy applications started using more memory over time. They became unresponsive when they hit their maximum heap memory sizes. Config, SAML SOAP Proxy and SAML Engine applications were not affected.

This commit downgrades OpenJDK JRE from v11.0.5 to v11.0.4 to stop Policy and SAML Proxy from becoming unresponsive for the time being. Policy and SAML Proxy will need to start managing the number of objects they store in their heap memory (e.g. once a user session is completed either successfully or unsuccessfully, the session information can be safely dropped from the heap memory to free up its space for a new user session). 

Task Memory Utilisation Graph
https://drive.google.com/file/d/18w0OG9muv_leKQ9y-tPN2O6HRd4AIF2Z/view?usp=sharing

Java Heap Memory Used Graph
https://drive.google.com/file/d/1xYr3ZQpk0Tg2V-ITax-mwRwJZqbxcB7G/view?usp=sharing

Author: @adityapahuja