### PR TITLE
EID-1763 Bump SAML lib to 227

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def dependencyVersions = [
         ida_test_utils:"2.0.0-46",
         opensaml:"$opensaml_version",
         dev_pki: '1.1.0-37',
-        saml_lib:"$opensaml_version-226"
+        saml_lib:"$opensaml_version-227"
 ]
 
 subprojects {


### PR DESCRIPTION
See this PR for the changes being brought in: https://github.com/alphagov/verify-saml-libs/pull/101

It fixes a bug with retrieving decryption keys from encrypted
assertions, when dealing with unsigned assertions.