### PR TITLE
Bau upgrade gradle base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:5.1.0-jdk11 as base-image
+FROM gradle:5.5.1-jdk11 as base-image
 USER root
 ENV GRADLE_USER_HOME /usr/gradle/.gradle
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Aug 15 13:18:37 BST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -28,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS='"-Xmx64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome


### PR DESCRIPTION
Gradle are decommissioning HTTP for Gradle services - see here for more
info: https://blog.gradle.org/decommissioning-http

A knock on effect of this is that if you're using an older version of
the JDK then there's a bug that'll kick a `peer not authenticated` error
when pulling dependencies.

This newer version of Gradle uses JDK 11.0.4. I didn't want to go beyond
this as we've seen issues in the hub with memory leaks when using 11.0.5
and are currently pinned at version 11.0.4, so this matches.