### PR TITLE
6n6H8nhi -Make cache expiry for certs configurable

### DIFF
--- a/configuration/local/saml-engine.yml
+++ b/configuration/local/saml-engine.yml
@@ -40,6 +40,8 @@ infinispan:
 
 configUri: ${CONFIG_URL}
 
+certificatesConfigCacheExpiry: 1m
+
 serviceInfo:
   name: saml-engine
 

--- a/configuration/local/saml-proxy.yml
+++ b/configuration/local/saml-proxy.yml
@@ -35,6 +35,8 @@ frontendExternalUri: ${FRONTEND_URL}
 
 configUri: ${CONFIG_URL}
 
+certificatesConfigCacheExpiry: 1m
+
 eventSinkUri: ${EVENT_SINK_URL}
 
 policyUri: ${POLICY_URL}

--- a/configuration/local/saml-soap-proxy.yml
+++ b/configuration/local/saml-soap-proxy.yml
@@ -64,6 +64,8 @@ eventSinkUri: ${EVENT_SINK_URL}
 
 policyUri: ${POLICY_URL}
 
+certificatesConfigCacheExpiry: 1m
+
 serviceInfo:
   name: saml-soap-proxy
 

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -39,6 +39,7 @@ redis:
   recordTTL: PT120m
   uri: ${REDIS_HOST}
 configUri: https://config.${DOMAIN}
+certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-1m}
 samlSoapProxyUri: https://saml-soap-proxy.${DOMAIN}
 serviceInfo:
   name: saml-engine

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -39,7 +39,7 @@ redis:
   recordTTL: PT120m
   uri: ${REDIS_HOST}
 configUri: https://config.${DOMAIN}
-certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-1m}
+certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}
 samlSoapProxyUri: https://saml-soap-proxy.${DOMAIN}
 serviceInfo:
   name: saml-engine

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -27,7 +27,7 @@ frontendExternalUri: https://www.${DOMAIN}
 samlEngineUri: https://saml-engine.${DOMAIN}
 configUri: https://config.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
-certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-1m}
+certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}
 serviceInfo:
   name: saml-proxy
 rpTrustStoreConfiguration:

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -27,6 +27,7 @@ frontendExternalUri: https://www.${DOMAIN}
 samlEngineUri: https://saml-engine.${DOMAIN}
 configUri: https://config.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
+certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-1m}
 serviceInfo:
   name: saml-proxy
 rpTrustStoreConfiguration:

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -64,7 +64,7 @@ samlEngineUri: https://saml-engine.${DOMAIN}
 configUri: https://config.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
 
-certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-1m}
+certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}
 
 serviceInfo:
   name: saml-soap-proxy

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -64,6 +64,8 @@ samlEngineUri: https://saml-engine.${DOMAIN}
 configUri: https://config.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
 
+certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-1m}
+
 serviceInfo:
   name: saml-soap-proxy
 

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/SamlEngineAppRule.java
@@ -117,7 +117,8 @@ public class SamlEngineAppRule extends DropwizardAppRule<SamlEngineConfiguration
                 config("metadata.hubTrustStore.path", hubTrustStore.getAbsolutePath()),
                 config("metadata.hubTrustStore.password", hubTrustStore.getPassword()),
                 config("metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
-                config("metadata.idpTrustStore.password", idpTrustStore.getPassword())
+                config("metadata.idpTrustStore.password", idpTrustStore.getPassword()),
+                config("certificatesConfigCacheExpiry", "20s")
         ).collect(Collectors.toList());
 
         if (isCountryEnabled) {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -103,7 +103,7 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @Valid
     @NotNull
     @JsonProperty
-    protected Duration certificatesConfigCacheExpiry;
+    protected Duration certificatesConfigCacheExpiry = Duration.minutes(5);
 
     @Valid
     @NotNull

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -103,6 +103,11 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @Valid
     @NotNull
     @JsonProperty
+    protected Duration certificatesConfigCacheExpiry;
+
+    @Valid
+    @NotNull
+    @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     public SamlConfiguration getSamlConfiguration() {
@@ -158,6 +163,10 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
 
     public URI getConfigUri() {
         return configUri;
+    }
+
+    public Duration getCertificatesConfigCacheExpiry() {
+        return certificatesConfigCacheExpiry;
     }
 
     public ServiceInfoConfiguration getServiceInfo() {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineConfiguration.java
@@ -32,8 +32,6 @@ import static com.google.common.base.Optional.absent;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SamlEngineConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, InfinispanServiceConfiguration, SamlDuplicateRequestValidationConfiguration, SamlAuthnRequestValidityDurationConfiguration, PrometheusConfiguration {
 
-    protected SamlEngineConfiguration() {}
-
     @Valid
     @NotNull
     @JsonProperty
@@ -109,6 +107,8 @@ public class SamlEngineConfiguration extends Configuration implements RestfulCli
     @NotNull
     @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
+
+    protected SamlEngineConfiguration() {}
 
     public SamlConfiguration getSamlConfiguration() {
         return saml;

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -496,6 +496,13 @@ public class SamlEngineModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
+    @Config
+    private long certificatesConfigCacheExpiryInSeconds(SamlEngineConfiguration configuration) {
+        return configuration.getCertificatesConfigCacheExpiry().toSeconds();
+    }
+
+    @Provides
     @SuppressWarnings("unused")
     private OutboundLegacyResponseFromHubToStringFunction getOutboundLegacyResponseFromHubToSignedResponseTransformerProvider(
             EncryptionKeyStore encryptionKeyStore,

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -498,6 +498,7 @@ public class SamlEngineModule extends AbstractModule {
     @Provides
     @Singleton
     @Config
+    @SuppressWarnings("unused")
     private long certificatesConfigCacheExpiryInSeconds(SamlEngineConfiguration configuration) {
         return configuration.getCertificatesConfigCacheExpiry().toSeconds();
     }

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/CertificatesConfigProxy.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/CertificatesConfigProxy.java
@@ -26,31 +26,36 @@ public class CertificatesConfigProxy {
     private final JsonClient jsonClient;
     private final URI configUri;
 
-    private LoadingCache<URI, CertificateDto> encryptionCertificates = CacheBuilder.newBuilder()
-            .expireAfterWrite(5, TimeUnit.MINUTES)
-            .build(new CacheLoader<>() {
-                @Override
-                public CertificateDto load(URI key) {
-                    return jsonClient.get(key, CertificateDto.class);
-                }
-            });
-    private LoadingCache<URI, Collection<CertificateDto>> signingCertificates = CacheBuilder.newBuilder()
-            .expireAfterWrite(5, TimeUnit.MINUTES)
-            .build(new CacheLoader<URI, Collection<CertificateDto>>() {
-                @Override
-                public Collection<CertificateDto> load(URI key) {
-                    return jsonClient.get(key, new GenericType<Collection<CertificateDto>>() {
-                    });
-                }
-            });
+    private LoadingCache<URI, CertificateDto> encryptionCertificates;
+    private LoadingCache<URI, Collection<CertificateDto>> signingCertificates;
 
     @Inject
     public CertificatesConfigProxy(
             JsonClient jsonClient,
-            @Config URI configUri) {
+            @Config URI configUri,
+            @Config long certificatesConfigCacheExpiryInSeconds) {
 
         this.jsonClient = jsonClient;
         this.configUri = configUri;
+
+        encryptionCertificates = CacheBuilder.newBuilder()
+                .expireAfterWrite(certificatesConfigCacheExpiryInSeconds, TimeUnit.SECONDS)
+                .build(new CacheLoader<>() {
+                    @Override
+                    public CertificateDto load(URI key) {
+                        return jsonClient.get(key, CertificateDto.class);
+                    }
+                });
+
+        signingCertificates = CacheBuilder.newBuilder()
+                .expireAfterWrite(certificatesConfigCacheExpiryInSeconds, TimeUnit.SECONDS)
+                .build(new CacheLoader<URI, Collection<CertificateDto>>() {
+                    @Override
+                    public Collection<CertificateDto> load(URI key) {
+                        return jsonClient.get(key, new GenericType<Collection<CertificateDto>>() {
+                        });
+                    }
+                });
     }
 
     @Timed

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/support/SamlProxyAppRule.java
@@ -95,6 +95,7 @@ public class SamlProxyAppRule extends DropwizardAppRule<SamlProxyConfiguration> 
                 config("metadata.hubTrustStore.password", hubTrustStore.getPassword()),
                 config("metadata.idpTrustStore.path", idpTrustStore.getAbsolutePath()),
                 config("metadata.idpTrustStore.password", idpTrustStore.getPassword()),
+                config("certificatesConfigCacheExpiry", "20s"),
                 config("eventEmitterConfiguration.enabled", "false")
         ).collect(Collectors.toList());
 

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -84,6 +84,11 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @Valid
     @NotNull
     @JsonProperty
+    protected Duration certificatesConfigCacheExpiry;
+
+    @Valid
+    @NotNull
+    @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     @Valid
@@ -125,6 +130,10 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
 
     public URI getConfigUri() {
         return configUri;
+    }
+
+    public Duration getCertificatesConfigCacheExpiry() {
+        return certificatesConfigCacheExpiry;
     }
 
     public ServiceInfoConfiguration getServiceInfo() {

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -84,7 +84,7 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @Valid
     @NotNull
     @JsonProperty
-    protected Duration certificatesConfigCacheExpiry;
+    protected Duration certificatesConfigCacheExpiry = Duration.minutes(5);
 
     @Valid
     @NotNull

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyConfiguration.java
@@ -25,8 +25,6 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SamlProxyConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, PrometheusConfiguration {
 
-    protected SamlProxyConfiguration(){}
-
     @Valid
     @NotNull
     @JsonProperty
@@ -98,6 +96,8 @@ public class SamlProxyConfiguration extends Configuration implements RestfulClie
     @Valid
     @JsonProperty
     public EventEmitterConfiguration eventEmitterConfiguration;
+
+    protected SamlProxyConfiguration(){}
 
     public SamlConfiguration getSamlConfiguration() {
         return saml;

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/SamlProxyModule.java
@@ -386,6 +386,12 @@ public class SamlProxyModule extends AbstractModule {
     }
 
     @Provides
+    @Config
+    public long certificatesConfigCacheExpiryInSeconds(SamlProxyConfiguration configuration) {
+        return configuration.certificatesConfigCacheExpiry.toSeconds();
+    }
+
+    @Provides
     @Singleton
     public EventSinkProxy eventSinkProxy(JsonClient jsonClient, SamlProxyConfiguration samlProxyConfiguration, Environment environment) {
         URI eventSinkUri = samlProxyConfiguration.getEventSinkUri();

--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/support/SamlSoapProxyAppRule.java
@@ -57,6 +57,7 @@ public class SamlSoapProxyAppRule extends DropwizardAppRule<SamlSoapProxyConfigu
                 config("metadata.idpTrustStore.password", idpTrustStore.getPassword()),
                 config("metadata.uri", "http://localhost:" + verifyMetadataServer.getPort() + VERIFY_METADATA_PATH),
                 config("metadata.expectedEntityId", HUB_ENTITY_ID),
+                config("certificatesConfigCacheExpiry", "20s"),
                 config("eventEmitterConfiguration.enabled", "false")
         ).collect(Collectors.toList());
 

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -25,9 +25,6 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SamlSoapProxyConfiguration extends Configuration implements RestfulClientConfiguration, TrustStoreConfiguration, ServiceNameConfiguration, PrometheusConfiguration {
 
-    protected SamlSoapProxyConfiguration() {
-    }
-
     @Valid
     @NotNull
     @JsonProperty
@@ -104,6 +101,9 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Valid
     @JsonProperty
     private PrometheusClientServiceConfiguration matchingServiceHealthCheckServiceConfiguration = new PrometheusClientServiceConfiguration();
+
+    protected SamlSoapProxyConfiguration() {
+    }
 
     public SamlConfiguration getSamlConfiguration() {
         return saml;

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
 import uk.gov.ida.common.ServiceInfoConfiguration;
 import uk.gov.ida.configuration.JerseyClientWithRetryBackoffConfiguration;
 import uk.gov.ida.configuration.ServiceNameConfiguration;
@@ -88,6 +89,11 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Valid
     @NotNull
     @JsonProperty
+    protected Duration certificatesConfigCacheExpiry;
+
+    @Valid
+    @NotNull
+    @JsonProperty
     protected ClientTrustStoreConfiguration rpTrustStoreConfiguration;
 
     @Valid
@@ -138,6 +144,10 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
 
     public URI getConfigUri() {
         return configUri;
+    }
+
+    public Duration getCertificatesConfigCacheExpiry() {
+        return certificatesConfigCacheExpiry;
     }
 
     public ServiceInfoConfiguration getServiceInfo() {

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyConfiguration.java
@@ -89,7 +89,7 @@ public class SamlSoapProxyConfiguration extends Configuration implements Restful
     @Valid
     @NotNull
     @JsonProperty
-    protected Duration certificatesConfigCacheExpiry;
+    protected Duration certificatesConfigCacheExpiry = Duration.minutes(5);
 
     @Valid
     @NotNull

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/SamlSoapProxyModule.java
@@ -264,6 +264,13 @@ public class SamlSoapProxyModule extends AbstractModule {
     }
 
     @Provides
+    @Config
+    @Singleton
+    public long certificatesConfigCacheExpiryInSeconds(SamlSoapProxyConfiguration configuration) {
+        return configuration.getCertificatesConfigCacheExpiry().toSeconds();
+    }
+
+    @Provides
     @Singleton
     public EventSinkProxy eventSinkProxy(JsonClient jsonClient, SamlSoapProxyConfiguration samlSoapProxyConfiguration, Environment environment) {
         URI eventSinkUri = samlSoapProxyConfiguration.getEventSinkUri();


### PR DESCRIPTION
https://trello.com/c/6n6H8nhi/776-make-cache-expiry-for-certs-configurable-in-saml-engine-saml-soap-proxy-and-saml-proxy

Three of the Hub services (saml-proxy, saml-soap-proxy and saml-engine) read federation certs from the config service, and store them in a cache.  The cache was formerly hard-coded to have an expiry time of five minutes.  The self-service cert rotation app needs to wait for this cache to expire in some circumstances, so we want to reduce it to a shorter interval.  We'd prefer for it to be configurable rather than hard-coded (in particular, this should help facilitate testing).

The cache expiry time is set to one minute in the config files.

https://trello.com/c/6n6H8nhi/776-make-cache-expiry-for-certs-configurable-in-saml-engine-saml-soap-proxy-and-saml-proxy