### PR TITLE
BAU Bump openjdk jre to 11.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_cache:
 
 before_install:
   - sudo apt-get install jq
-  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url') -o codacy-coverage-reporter-assembly.jar
+  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | contains("codacy-coverage-reporter-assembly"))) | .[0].browser_download_url') -o codacy-coverage-reporter-assembly.jar
 
 cache:
   directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN gradle --console=plain \
     -x :hub-saml:jar \
     -x :hub-saml-test-utils:jar
 
-FROM openjdk:11.0.4-jre
+FROM openjdk:11.0.6-jre
 ARG hub_app
 
 WORKDIR /verify-hub


### PR DESCRIPTION
Upgrade from openjdk jre `11.0.4` to `11.0.6` for latest security updates.

We previously pinned to 11.04 from 11.0.5, in order to avoid a memory issue.
We have doubled memory so believe this will no longer be an issue.

Eyes will be on memory usage when this propagates.