### PR TITLE
HUB-446: Fix eIDAS response attributes hash logging

### DIFF
--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -50,7 +50,7 @@ rpTrustStoreConfiguration:
   enabled: ${RP_TRUSTSTORE_ENABLED:-true}
 logging:
   loggers:
-    uk.gov.ida.eidas.logging.EidasResponseAttributesHashLogger:
+    uk.gov.ida.eidas.logging.EidasAuthnResponseAttributesHashLogger:
       level: INFO
       additive: true
       appenders:


### PR DESCRIPTION
The logger classpath has changed. Update saml-engine config to reflect that.