### PR TITLE
BAU: Upgrade dropwizard to 1.3.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,14 +32,14 @@ repositories {
 
 ext {
     opensaml_version = '3.4.3'
-    dropwizard_version = '1.3.17'
+    dropwizard_version = '1.3.18'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
 def dependencyVersions = [
         ida_utils:'374',
         dropwizard:"$dropwizard_version",
-        dropwizard_infinispan:"$dropwizard_version-52",
+        dropwizard_infinispan:"$dropwizard_version-53",
         pact:'3.5.6',
         ida_test_utils:"2.0.0-49",
         opensaml:"$opensaml_version",


### PR DESCRIPTION
To address [CVE-2019-20330](https://github.com/dropwizard/dropwizard/pull/3100)