### PR TITLE
fix hub-saml-test-utils bintray config

### DIFF
--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -32,7 +32,7 @@ bintray {
     publish = true
     pkg {
         repo = 'maven-test'
-        name = 'verify-hub-saml'
+        name = 'verify-hub-saml-test-utils'
         userOrg = 'alphagov'
         licenses = ['MIT']
         vcsUrl = 'https://github.com/alphagov/verify-hub.git'


### PR DESCRIPTION
hub-saml and hub-saml-test-utils have identical bintray configuration,
which means they're trying to upload to the same package location.
This seems like a bad idea and that hub-saml-test-utils should have a
different name.