### PR TITLE
Stop publishing hub-saml{,-test-utils} to artifactory

### DIFF
--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -6,16 +6,6 @@ plugins {
 apply plugin: 'maven-publish'
 
 publishing {
-    repositories {
-        maven {
-            credentials {
-                username "${System.env.ARTIUSER}"
-                password "${System.env.ARTIPASSWORD}"
-            }
-            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
-        }
-    }
-
     publications {
         mavenJava(MavenPublication) {
             from components.java

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -6,16 +6,6 @@ plugins {
 apply plugin: 'maven-publish'
 
 publishing {
-    repositories {
-        maven {
-            credentials {
-                username "${System.env.ARTIUSER}"
-                password "${System.env.ARTIPASSWORD}"
-            }
-            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
-        }
-    }
-
     publications {
         mavenJava(MavenPublication) {
             from components.java


### PR DESCRIPTION
Bintray is the source of truth now.

Bintray is made available via whitelisted-repos on artifactory, so we
still pull dependencies down using artifactory, but we only need to
push dependencies to bintray.