### PR TITLE
AUT-517: Fix pre-commit script and provide more details on exception

### DIFF
--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckService.java
@@ -57,8 +57,7 @@ public class MatchingServiceHealthCheckService implements Runnable {
                         .collect(Collectors.toList());
             matchingServiceHealthCheckTaskManager.invokeAll(callables, timeout.toSeconds() + WAIT_FOR_THREAD_TO_MARK_TIMEOUT_MATCHING_SERVICE_UNHEALTHY, TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOG.warn(e.getMessage());
+            LOG.error("Failed to perform Matching Health Service Task on all Matching Services.", e);
         }
     }
-
 }

--- a/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckTask.java
+++ b/hub/saml-soap-proxy/src/main/java/uk/gov/ida/hub/samlsoapproxy/service/MatchingServiceHealthCheckTask.java
@@ -9,6 +9,7 @@ import uk.gov.ida.hub.samlsoapproxy.contract.MatchingServiceConfigEntityDataDto;
 import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthCheckResult;
 import uk.gov.ida.hub.samlsoapproxy.healthcheck.MatchingServiceHealthChecker;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 public class MatchingServiceHealthCheckTask implements Callable<String> {
@@ -44,7 +45,11 @@ public class MatchingServiceHealthCheckTask implements Callable<String> {
             healthStatusLastUpdatedGauge.labels(matchingServiceHealthCheckResult.getDetails().getMatchingService().toString())
                     .set(timestamp);
         } catch (Exception e) {
-            LOG.warn(e.getMessage());
+            if (Objects.isNull(matchingServiceConfig)) {
+                LOG.error("Failed to update Matching Service Health Metrics.", e);
+            } else {
+                LOG.error(String.format("Failed to update Matching Service Health Metrics for %s.", matchingServiceConfig.getEntityId()), e);
+            }
         }
         return DateTime.now(DateTimeZone.UTC) + matchingServiceConfig.getEntityId();
     }

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -58,6 +58,14 @@ if ./gradlew --parallel --daemon clean build intTest installDist 2>/dev/null; th
     | sed -n 's/uk.gov.ida:\(.*\) \[\(.*\)\]/\1 \2/p' 
   tput sgr0
 
+  # redis required for policy & saml-engine
+  if ! docker ps | grep hub-redis >/dev/null
+  then
+    printf "$(tput setaf 3)Redis is required for policy and saml-engine, attempting to start redis using docker.\\n$(tput sgr0)"
+    # deliberately avoiding the normal redis port in case there's another redis running
+    docker run --rm -d -p 6378:6379 --name hub-redis redis >/dev/null
+  fi
+
   echo "Running services"
   if ./startup.sh skip-build; then
     funky_pass_banner

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -6,5 +6,10 @@ for service in $services; do
   pkill -9 -f "${service}.jar"
 done
 
+if docker ps | grep hub-redis >/dev/null ; then
+    docker stop hub-redis
+    docker rm hub-redis
+fi
+
 exit 0
 


### PR DESCRIPTION
This pull request contains two commits.

1. Since Redis is no longer optional (https://github.com/alphagov/verify-hub/pull/422), pre-commit.sh fails to start policy and saml-engine because Redis service is not running or available. This change updates the script to start Redis service before starting Policy and SAML Engine applications. This will avoid throwing "failed to start" error messages.

2.  This change

    - updates "OCSP Certificate Chain Validation Service" to catch exception inside the loop and to provide more details on the exception and certificate if it is available. This is to ensure that the service can continue to set OCSP Certificate Revocation Status metrics for the remaining certificates.
    - updates "Matching Service Health Check Service" to provide more details on the exception.
    - updates a logger in OCSP Certificate Chain Validation Service" and "Matching Service Health Check Service" to log exceptions as error messages rather than warning messages so that Sentry can catch them and alert 2nd Verify Line Support team.
  This is similar to the previous pull request (https://github.com/alphagov/verify-hub/pull/417).

Author: @adityapahuja