### PR TITLE
HUB-413 Sentry event grouping is wrong

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ subprojects {
                 "io.dropwizard:dropwizard-metrics-graphite:$dependencyVersions.dropwizard",
                 'com.hubspot.dropwizard:dropwizard-guicier:1.0.0.6',
                 'org.reflections:reflections:0.9.10',
-                'com.tradier:dropwizard-raven:1.0.0-1'
+                'org.dhatim:dropwizard-sentry:1.3.9-2'
 
         config 'commons-io:commons-io:2.1'
 

--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -15,10 +15,10 @@ logging:
   level: INFO
   appenders:
     - type: logstash-console
-    - type: raven
+    - type: sentry
       dsn: ${SENTRY_DSN}
       threshold: ERROR
-      tags: service-name:config
+      tags: {"service-name": "config"}
 # these DEPLOYMENT environment variables should get
 # interpolated by dropwizard
 clientTrustStoreConfiguration:

--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -5,7 +5,7 @@ server:
   requestLog:
     type: classic
     appenders:
-      - type: access-logstash-console
+      - type: {access-logstash-console}
 timeoutPeriod: 90m
 assertionLifetime: 60m
 acceptSelfSignedCerts: true
@@ -51,7 +51,7 @@ logging:
   level: INFO
   appenders:
     - type: logstash-console
-    - type: raven
+    - type: sentry
       dsn: ${SENTRY_DSN}
       threshold: ERROR
       tags: service-name:policy

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -63,10 +63,10 @@ logging:
   level: INFO
   appenders:
     - type: logstash-console
-    - type: raven
+    - type: sentry
       dsn: ${SENTRY_DSN}
       threshold: ERROR
-      tags: service-name:saml-engine
+      tags: {"service-name": "saml-engine"}
 authnRequestIdExpirationDuration: 90m
 authnRequestValidityDuration: 5m
 metadata:

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -40,10 +40,10 @@ logging:
   level: INFO
   appenders:
     - type: logstash-console
-    - type: raven
+    - type: sentry
       dsn: ${SENTRY_DSN}
       threshold: ERROR
-      tags: service-name:saml-proxy
+      tags: {"service-name": "saml-proxy"}
 metadata:
   uri: https://www.${DOMAIN}/SAML2/metadata/federation
   trustStorePath: /tmp/truststores/${DEPLOYMENT}/metadata_ca_certs.ts

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -85,10 +85,10 @@ logging:
   level: INFO
   appenders:
     - type: logstash-console
-    - type: raven
+    - type: sentry
       dsn: ${SENTRY_DSN}
       threshold: ERROR
-      tags: service-name:saml-soap-proxy
+      tags: {"service-name": "saml-soap-proxy"}
 
 metadata:
   uri: https://www.${DOMAIN}/SAML2/metadata/federation


### PR DESCRIPTION
We have been using an old library to integrate DropWizard and Sentry.  Before we fine tune the way Dropwizard and Sentry work together, we're updating to the newer code that Sentry recommends.  Ideally this will solve all of our problems on its own and we won't have to do any further tweaking.  It probably won't but we definitely want to be using this before tweaking.

Change appender types from `raven` to `sentry`

Change format of `tags` configuration from `key:value` to `{"key": "value"}`.