### PR TITLE
HUB-545: Include the `provide registration until` timestamp in the IDP DTO list from config

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfig.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/domain/IdentityProviderConfig.java
@@ -125,6 +125,10 @@ public class IdentityProviderConfig implements EntityIdentifiable {
         return enabledForSingleIdp;
     }
 
+    public String getProvideRegistrationUntil() {
+        return provideRegistrationUntil;
+    }
+
     public List<String> getOnboardingTransactionEntityIds() {
         return onboardingTransactionEntityIds;
     }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
@@ -10,6 +10,7 @@ public class IdpDto {
 
     private final String simpleId;
     private final String entityId;
+    private final String provideRegistrationUntil;
     private final List<LevelOfAssurance> levelsOfAssurance;
     private final boolean authenticationEnabled;
     private final boolean temporarilyUnavailable;
@@ -18,11 +19,13 @@ public class IdpDto {
     public IdpDto(
             @JsonProperty("simpleId") String simpleId,
             @JsonProperty("entityId") String entityId,
+            @JsonProperty("provideRegistrationUntil") String provideRegistrationUntil,
             @JsonProperty("supportedLevelsOfAssurance") List<LevelOfAssurance> levelsOfAssurance,
             @JsonProperty("authenticationEnabled") boolean authenticationEnabled,
             @JsonProperty("temporarilyUnavailable") boolean temporarilyUnavailable) {
         this.simpleId = simpleId;
         this.entityId = entityId;
+        this.provideRegistrationUntil = provideRegistrationUntil;
         this.levelsOfAssurance = levelsOfAssurance;
         this.authenticationEnabled = authenticationEnabled;
         this.temporarilyUnavailable = temporarilyUnavailable;
@@ -34,6 +37,10 @@ public class IdpDto {
 
     public String getEntityId() {
         return entityId;
+    }
+
+    public String getProvideRegistrationUntil() {
+        return provideRegistrationUntil;
     }
 
     public List<LevelOfAssurance> getLevelsOfAssurance() {

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
@@ -63,6 +63,7 @@ public class IdentityProviderResource {
                         new IdpDto(
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
+                                configData.getProvideRegistrationUntil(),
                                 configData.getSupportedLevelsOfAssurance(),
                                 configData.isAuthenticationEnabled(),
                                 configData.isTemporarilyUnavailable()))
@@ -79,6 +80,7 @@ public class IdentityProviderResource {
                         new IdpDto(
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
+                                configData.getProvideRegistrationUntil(),
                                 configData.getSupportedLevelsOfAssurance(),
                                 configData.isAuthenticationEnabled(),
                                 configData.isTemporarilyUnavailable()))
@@ -139,6 +141,7 @@ public class IdentityProviderResource {
                         new IdpDto(
                                 configData.getSimpleId(),
                                 configData.getEntityId(),
+                                configData.getProvideRegistrationUntil(),
                                 configData.getSupportedLevelsOfAssurance(),
                                 configData.isAuthenticationEnabled(),
                                 configData.isTemporarilyUnavailable()))


### PR DESCRIPTION
This is so the frontend can decide to hide disconnecting IDPs at an appropriate time to avoid a timing issue where the button to select an IDP get rendered shortly before the cut-off time and the user fails to press is before that cut-off time. In that case the user will see an error for a reason completely outside of their control.

Hiding IDPs disconnecting for registration a short period of time before the cut-off time is a crude solution to this as the Hub will still accept requests for those IDPs until the actual cut-off time. This doesn't eliminate the problem completely but given an appropriate time interval it reduces it greatly as most people are not likely to spend more than a few minutes on the picker.