### PR TITLE
HUB-545: Ignore unknown JSON properties in IdpDto class

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/dto/IdpDto.java
@@ -1,11 +1,13 @@
 package uk.gov.ida.hub.config.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.hub.config.domain.LevelOfAssurance;
 
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class IdpDto {
 
     private final String simpleId;


### PR DESCRIPTION
This annotation is required for ZDD so old version of this DTO can still be serialised from the new JSON

A new field was added to this class in #436 which will cause ZDD failures during deployment without this flag