### PR TITLE
HUB-576: Align the backend session timeout with frontend

### DIFF
--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -6,7 +6,7 @@ server:
     type: classic
     appenders:
       - type: access-logstash-console
-timeoutPeriod: 90m
+timeoutPeriod: 120m
 assertionLifetime: 60m
 acceptSelfSignedCerts: true
 matchingServiceResponseWaitPeriod: 60s


### PR DESCRIPTION
The frontend session lasts for 120 minutes, the backend one for 90 minutes.
This creates unexpected errors in the middle of user journeys