### PR TITLE
[DO NOT MERGE] Event recording modification in anticipation of modifications to LOAs for some RPs

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.hub.policy.domain;
 
+import java.util.List;
+
 // Do not change the ordering of this enum
 public enum LevelOfAssurance {
     LEVEL_X,
@@ -20,24 +22,24 @@ public enum LevelOfAssurance {
         return this.ordinal()<levelOfAssurance.ordinal();
     }
 
-    public static LevelOfAssurance min(LevelOfAssurance... assurances) {
-        if (assurances == null || assurances.length == 0) { return null; }
-        if (assurances.length == 1) { return assurances[0]; }
+    public static LevelOfAssurance min(List<LevelOfAssurance> assurances) {
+        if (assurances == null || assurances.size() == 0) { return null; }
+        if (assurances.size() == 1) { return assurances.get(0); }
 
-        LevelOfAssurance min = assurances[0];
-        for (int i = 1; i < assurances.length; i++) {
-            if (assurances[i].lessThan(min)) { min = assurances[i]; }
+        LevelOfAssurance min = assurances.get(0);
+        for (int i = 1; i < assurances.size(); i++) {
+            if (assurances.get(i).lessThan(min)) { min = assurances.get(i); }
         }
         return min;
     }
 
-    public static LevelOfAssurance max(LevelOfAssurance... assurances) {
-        if (assurances == null || assurances.length == 0) { return null; }
-        if (assurances.length == 1) { return assurances[0]; }
+    public static LevelOfAssurance max(List<LevelOfAssurance> assurances) {
+        if (assurances == null || assurances.size() == 0) { return null; }
+        if (assurances.size() == 1) { return assurances.get(0); }
 
-        LevelOfAssurance max = assurances[0];
-        for (int i = 1; i < assurances.length; i++) {
-            if (assurances[i].greaterThan(max)) { max = assurances[i]; }
+        LevelOfAssurance max = assurances.get(0);
+        for (int i = 1; i < assurances.size(); i++) {
+            if (assurances.get(i).greaterThan(max)) { max = assurances.get(i); }
         }
         return max;
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
@@ -15,4 +15,30 @@ public enum LevelOfAssurance {
     public boolean greaterThan(LevelOfAssurance levelOfAssurance) {
         return this.ordinal()>levelOfAssurance.ordinal();
     }
+
+    public boolean lessThan(LevelOfAssurance levelOfAssurance) {
+        return this.ordinal()<levelOfAssurance.ordinal();
+    }
+
+    public static LevelOfAssurance min(LevelOfAssurance... assurances) {
+        if (assurances == null || assurances.length == 0) { return null; }
+        if (assurances.length == 1) { return assurances[0]; }
+
+        LevelOfAssurance min = assurances[0];
+        for (int i = 1; i < assurances.length; i++) {
+            if (assurances[i].lessThan(min)) { min = assurances[i]; }
+        }
+        return min;
+    }
+
+    public static LevelOfAssurance max(LevelOfAssurance... assurances) {
+        if (assurances == null || assurances.length == 0) { return null; }
+        if (assurances.length == 1) { return assurances[0]; }
+
+        LevelOfAssurance max = assurances[0];
+        for (int i = 1; i < assurances.length; i++) {
+            if (assurances[i].greaterThan(max)) { max = assurances[i]; }
+        }
+        return max;
+    }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -157,9 +157,9 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 state.getRequestIssuerEntityId(),
                 new PersistentId(translatedResponse.getPersistentId().get()),
                 state.getRequestId(),
-                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum LOA - was: state.getLevelsOfAssurance().get(0)
-                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required LOA - was: state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1)
-                translatedResponse.getLevelOfAssurance().get(), // provided LOA
+                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum
+                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required
+                translatedResponse.getLevelOfAssurance().get(), // provided
                 Optional.empty(),
                 principalIpAddressAsSeenByHub,
                 analyticsSessionId,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -157,8 +157,8 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 state.getRequestIssuerEntityId(),
                 new PersistentId(translatedResponse.getPersistentId().get()),
                 state.getRequestId(),
-                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum
-                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required
+                LevelOfAssurance.min(state.getLevelsOfAssurance()), // minimum
+                LevelOfAssurance.max(state.getLevelsOfAssurance()), // required
                 translatedResponse.getLevelOfAssurance().get(), // provided
                 Optional.empty(),
                 principalIpAddressAsSeenByHub,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -157,9 +157,9 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 state.getRequestIssuerEntityId(),
                 new PersistentId(translatedResponse.getPersistentId().get()),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                translatedResponse.getLevelOfAssurance().get(),
+                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum LOA - was: state.getLevelsOfAssurance().get(0)
+                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required LOA - was: state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1)
+                translatedResponse.getLevelOfAssurance().get(), // provided LOA
                 Optional.empty(),
                 principalIpAddressAsSeenByHub,
                 analyticsSessionId,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -171,9 +171,9 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
                 state.getRequestIssuerEntityId(),
                 successFromIdp.getPersistentId(),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                successFromIdp.getLevelOfAssurance(),
+                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum LOA - was: state.getLevelsOfAssurance().get(0)
+                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required LOA - was: state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1)
+                successFromIdp.getLevelOfAssurance(), // provided LOA
                 successFromIdp.getPrincipalIpAddressAsSeenByIdp(),
                 successFromIdp.getPrincipalIpAddressAsSeenByHub(),
                 successFromIdp.getAnalyticSessionId(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -171,8 +171,8 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
                 state.getRequestIssuerEntityId(),
                 successFromIdp.getPersistentId(),
                 state.getRequestId(),
-                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum
-                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required
+                LevelOfAssurance.min(state.getLevelsOfAssurance()), // minimum
+                LevelOfAssurance.max(state.getLevelsOfAssurance()), // required
                 successFromIdp.getLevelOfAssurance(), // provided
                 successFromIdp.getPrincipalIpAddressAsSeenByIdp(),
                 successFromIdp.getPrincipalIpAddressAsSeenByHub(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -171,9 +171,9 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
                 state.getRequestIssuerEntityId(),
                 successFromIdp.getPersistentId(),
                 state.getRequestId(),
-                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum LOA - was: state.getLevelsOfAssurance().get(0)
-                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required LOA - was: state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1)
-                successFromIdp.getLevelOfAssurance(), // provided LOA
+                LevelOfAssurance.min(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // minimum
+                LevelOfAssurance.max(state.getLevelsOfAssurance().toArray(new LevelOfAssurance[0])), // required
+                successFromIdp.getLevelOfAssurance(), // provided
                 successFromIdp.getPrincipalIpAddressAsSeenByIdp(),
                 successFromIdp.getPrincipalIpAddressAsSeenByHub(),
                 successFromIdp.getAnalyticSessionId(),

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/LevelOfAssuranceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/LevelOfAssuranceTest.java
@@ -2,6 +2,11 @@ package uk.gov.ida.hub.policy.domain;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LevelOfAssuranceTest {
@@ -29,51 +34,45 @@ public class LevelOfAssuranceTest {
 
     @Test
     public void testLevelOfAssuranceMinMax() {
-        LevelOfAssurance[] assurances;
+        List<LevelOfAssurance> assurances;
 
-        assurances = new LevelOfAssurance[] {
+        assurances = Arrays.asList(
             LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_2);
+
+        assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
+        assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_2);
+
+        assurances = Arrays.asList(
             LevelOfAssurance.LEVEL_2,
-        };
+            LevelOfAssurance.LEVEL_1);
 
         assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
         assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_2);
 
-        assurances = new LevelOfAssurance[] {
-            LevelOfAssurance.LEVEL_2,
+        assurances = Arrays.asList(
             LevelOfAssurance.LEVEL_1,
-        };
+            LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_2);
 
         assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
         assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_2);
 
-        assurances = new LevelOfAssurance[] {
-            LevelOfAssurance.LEVEL_1,
-            LevelOfAssurance.LEVEL_1,
-            LevelOfAssurance.LEVEL_1,
-            LevelOfAssurance.LEVEL_2
-        };
-
-        assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
-        assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_2);
-
-        assurances = new LevelOfAssurance[] {
+        assurances = Arrays.asList(
             LevelOfAssurance.LEVEL_3,
             LevelOfAssurance.LEVEL_1,
-            LevelOfAssurance.LEVEL_2
-        };
+            LevelOfAssurance.LEVEL_2);
 
         assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
         assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_3);
 
-        assurances = new LevelOfAssurance[]{
-            LevelOfAssurance.LEVEL_1
-        };
+        assurances = Collections.singletonList(LevelOfAssurance.LEVEL_1);
 
         assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
         assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
 
-        assurances = new LevelOfAssurance[0];
+        assurances = new ArrayList<>();
 
         assertThat(LevelOfAssurance.min(assurances)).isNull();
         assertThat(LevelOfAssurance.max(assurances)).isNull();

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/LevelOfAssuranceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/LevelOfAssuranceTest.java
@@ -15,4 +15,73 @@ public class LevelOfAssuranceTest {
         assertThat(LevelOfAssurance.LEVEL_4.ordinal()).isEqualTo(4);
     }
 
+    @Test
+    public void testLevelOfAssuranceComparisons() {
+        assertThat(LevelOfAssurance.LEVEL_1.lessThan(LevelOfAssurance.LEVEL_2)).isTrue();
+        assertThat(LevelOfAssurance.LEVEL_2.greaterThan(LevelOfAssurance.LEVEL_1)).isTrue();
+
+        assertThat(LevelOfAssurance.LEVEL_2.lessThan(LevelOfAssurance.LEVEL_3)).isTrue();
+        assertThat(LevelOfAssurance.LEVEL_3.greaterThan(LevelOfAssurance.LEVEL_2)).isTrue();
+
+        assertThat(LevelOfAssurance.LEVEL_1.lessThan(LevelOfAssurance.LEVEL_1)).isFalse();
+        assertThat(LevelOfAssurance.LEVEL_1.greaterThan(LevelOfAssurance.LEVEL_1)).isFalse();
+    }
+
+    @Test
+    public void testLevelOfAssuranceMinMax() {
+        LevelOfAssurance[] assurances;
+
+        assurances = new LevelOfAssurance[] {
+            LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_2,
+        };
+
+        assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
+        assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_2);
+
+        assurances = new LevelOfAssurance[] {
+            LevelOfAssurance.LEVEL_2,
+            LevelOfAssurance.LEVEL_1,
+        };
+
+        assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
+        assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_2);
+
+        assurances = new LevelOfAssurance[] {
+            LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_2
+        };
+
+        assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
+        assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_2);
+
+        assurances = new LevelOfAssurance[] {
+            LevelOfAssurance.LEVEL_3,
+            LevelOfAssurance.LEVEL_1,
+            LevelOfAssurance.LEVEL_2
+        };
+
+        assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
+        assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_3);
+
+        assurances = new LevelOfAssurance[]{
+            LevelOfAssurance.LEVEL_1
+        };
+
+        assertThat(LevelOfAssurance.min(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
+        assertThat(LevelOfAssurance.max(assurances)).isEqualTo(LevelOfAssurance.LEVEL_1);
+
+        assurances = new LevelOfAssurance[0];
+
+        assertThat(LevelOfAssurance.min(assurances)).isNull();
+        assertThat(LevelOfAssurance.max(assurances)).isNull();
+
+        assurances = null;
+
+        assertThat(LevelOfAssurance.min(assurances)).isNull();
+        assertThat(LevelOfAssurance.max(assurances)).isNull();
+    }
+
 }


### PR DESCRIPTION
**This change should not affect current behaviour.**

This change amends `Policy` to allow it to make a better decision about which of the LoAs in an RPs config should be reported as **minimum**, and which as **required** (in Verify, believed to mean 'preferred'). This is not expected to change the behaviour for any current RPs.

It removes the assumption that the list of LoAs is ordered, in anticipation of changes being planned to permit some services to make a request with a different ordering in order to satisfy different behaviours.

The key changes are in:

* `//hub/policy/domain/controller/EidasCountrySelectedStateController.java`
* `//hub/policy/domain/controller/IdpSelectedStateController.java`

In each, instead of assigning the first level in the list to **minimum**, and the last to **required**, the lowest and highest are assigned respectively.