### PR TITLE
Allow an RP to have config where LOA2 is followed by LOA1

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidator.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidator.java
@@ -61,8 +61,9 @@ public class LevelsOfAssuranceConfigValidator {
                 .filter(x -> {
                     List<LevelOfAssurance> levelsOfAssurance = x.getLevelsOfAssurance();
                     boolean isLoa1 = levelsOfAssurance.equals(asList(LEVEL_1, LEVEL_2));
+                    boolean isLoa2And1 = levelsOfAssurance.equals(asList(LEVEL_2, LEVEL_1));
                     boolean isLoa2 = levelsOfAssurance.equals(singletonList(LEVEL_2));
-                    return !(isLoa1 || isLoa2);
+                    return !(isLoa1 || isLoa2 || isLoa2And1);
                 })
                 .collect(Collectors.toList());
         if(!badTransactionConfigs.isEmpty()) {

--- a/hub/config/src/test/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidatorTest.java
+++ b/hub/config/src/test/java/uk/gov/ida/hub/config/data/LevelsOfAssuranceConfigValidatorTest.java
@@ -83,6 +83,16 @@ public class LevelsOfAssuranceConfigValidatorTest {
     }
 
     @Test
+    public void shouldAllowLOA2AndLOA1TransactionConfiguration() {
+        Set<TransactionConfig> transactionsConfig = Set.of(loa2And1Transaction);
+        try {
+            levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(transactionsConfig);
+        } catch (Exception e) {
+            fail("Expected exception not thrown");
+        }
+    }
+
+    @Test
     public void shouldAllowLOA2TransactionConfiguration() {
         Set<TransactionConfig> transactionsConfig = Set.of(loa2Transaction);
         try {
@@ -100,11 +110,6 @@ public class LevelsOfAssuranceConfigValidatorTest {
     @Test(expected = ConfigValidationException.class)
     public void shouldThrowWhenTransactionIsNotLoa1OrLoa2() {
         levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(Set.of(loa3OnlyTransaction));
-    }
-
-    @Test(expected = ConfigValidationException.class)
-    public void shouldThrowWhenTransactionLOAsAreInWrongOrder() {
-        levelsOfAssuranceConfigValidator.validateAllTransactionsAreLOA1OrLOA2(Set.of(loa2And1Transaction));
     }
 
     @Test(expected = ConfigValidationException.class)


### PR DESCRIPTION
- We now have an RP which has LOA2 first in config followed by LOA1. This will change the order in which the LOAs appear in the AuthnRequest so that LOA2 is first in the list. This is to show that the RP prefers LOA2 but will accept LOA1 if a user fails to get LOA2.
- Update the config validator to allow this ordering of LOAs in an RP's transaction config.