### PR TITLE
Only send a [LOA2,LOA1] ordering of LOAs to IDPs that are enabled for registration.

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelector.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelector.java
@@ -8,6 +8,7 @@ import uk.gov.ida.hub.policy.domain.state.IdpSelectingState;
 import uk.gov.ida.hub.policy.proxy.IdentityProvidersConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,7 +35,17 @@ public class IdpSelector {
 
         IdpConfigDto idpConfig = identityProvidersConfigProxy.getIdpConfig(idpEntityId);
         final List<LevelOfAssurance> idpLevelsOfAssurance = idpConfig.getSupportedLevelsOfAssurance();
-        List<LevelOfAssurance> levelsOfAssuranceForTransactionSupportedByIdp = levelsOfAssuranceForTransaction.stream().filter(idpLevelsOfAssurance::contains).collect(Collectors.toList());
+
+        boolean idpEnabledForRegistration = identityProvidersConfigProxy.isIDPEnabledForRegistration(
+                idpEntityId,
+                state.getRequestIssuerEntityId(),
+                requestedLoa);
+
+        List<LevelOfAssurance> levelsOfAssuranceForTransactionSupportedByIdp =
+                getLevelsOfAssuranceForTransactionSupportedByIdp(
+                        idpEnabledForRegistration,
+                        idpLevelsOfAssurance,
+                        levelsOfAssuranceForTransaction);
 
         return new IdpSelectedState(
                 state.getRequestId(),
@@ -52,6 +63,24 @@ public class IdpSelector {
                 availableIdentityProviderEntityIdsForLoa,
                 state.getTransactionSupportsEidas()
         );
+    }
+
+    private static List<LevelOfAssurance> getLevelsOfAssuranceForTransactionSupportedByIdp(boolean idpEnabledForRegistration,
+                                                                                           List<LevelOfAssurance> idpLevelsOfAssurance,
+                                                                                           List<LevelOfAssurance> levelsOfAssuranceForTransaction) {
+        List<LevelOfAssurance> levelsOfAssuranceForTransactionSupportedByIdp;
+
+        if (!idpEnabledForRegistration
+                && levelsOfAssuranceForTransaction.size() == 2
+                && levelsOfAssuranceForTransaction.indexOf(LevelOfAssurance.LEVEL_2) == 0
+                && levelsOfAssuranceForTransaction.indexOf(LevelOfAssurance.LEVEL_1) == 1) {
+            levelsOfAssuranceForTransaction = Collections.singletonList(LevelOfAssurance.LEVEL_2);
+        }
+            levelsOfAssuranceForTransactionSupportedByIdp = levelsOfAssuranceForTransaction.stream()
+                    .filter(idpLevelsOfAssurance::contains)
+                    .collect(Collectors.toList());
+
+        return levelsOfAssuranceForTransactionSupportedByIdp;
     }
 
     private static void checkValidIdentityProvider(final String idpEntityId, List<String> availableIdentityProviderEntityIdsForLoa, IdpSelectingState state) {

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelector.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelector.java
@@ -74,6 +74,7 @@ public class IdpSelector {
                 && levelsOfAssuranceForTransaction.size() == 2
                 && levelsOfAssuranceForTransaction.indexOf(LevelOfAssurance.LEVEL_2) == 0
                 && levelsOfAssuranceForTransaction.indexOf(LevelOfAssurance.LEVEL_1) == 1) {
+            //See ADR 0035 in verify-architecture
             levelsOfAssuranceForTransaction = Collections.singletonList(LevelOfAssurance.LEVEL_2);
         }
             levelsOfAssuranceForTransactionSupportedByIdp = levelsOfAssuranceForTransaction.stream()

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/proxy/IdentityProvidersConfigProxy.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/proxy/IdentityProvidersConfigProxy.java
@@ -61,6 +61,13 @@ public class IdentityProvidersConfigProxy {
         return jsonClient.get(uri, IdpConfigDto.class);
     }
 
+    @Timed
+    public boolean isIDPEnabledForRegistration(String idpEntityID, String transactionEntityId, LevelOfAssurance levelOfAssurance) {
+        List<String> enabledIdentityProvidersForRegistration = getEnabledIdentityProvidersForRegistration(transactionEntityId, levelOfAssurance, false);
+
+        return enabledIdentityProvidersForRegistration.contains(idpEntityID);
+    }
+
     private List<String> getEnabledIdentityProvidersForRegistration(String transactionEntityId, LevelOfAssurance levelOfAssurance, boolean processingIdpResponse) {
         final String enabledIdpConfigServiceResourceUrl = processingIdpResponse ?
                 Urls.ConfigUrls.ENABLED_ID_PROVIDERS_FOR_REGISTRATION_AUTHN_RESPONSE_RESOURCE :

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/CountriesServiceTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/services/CountriesServiceTest.java
@@ -15,7 +15,6 @@ import uk.gov.ida.hub.policy.exception.EidasCountryNotSupportedException;
 import uk.gov.ida.hub.policy.exception.EidasNotSupportedException;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.asList;


### PR DESCRIPTION
We want IDPs which are enabled for receiving registration requests to be able to handle an Authn Request where the ordering of LOAs in the request is [LOA2, LOA1]. This is so that these IDPs will first attempt to achieve LOA2 for the User but failing that will try for LOA1. When a User is on the IDP in a sign-in journey they can switch to a registration journey, so it’s important that this ordering is used in both instances to ensure the IDP behaviour is consistent.

When a Service is configured with the [LOA2, LOA1] ordering of LOAs and they are sending a request to an IDP which is only configured for sign-in, then we want the request to contain just [LOA2]. This will be sent as a LOA2 request meaning a user who obtained LOA2 on registering can use the service. This will give the service the existing behaviour when sending requests to IDPs that are configured for only sign-in.

The change implemented here entails the following -

- Call config service to see if the IDP is enabled for registration.
- If it isn’t and the RP has the ordering of LOAs [LOA2, LOA1] then just use [LOA2].
- Add new tests to test this behaviour.