### PR TITLE
ps34 [DO NOT MERGE] Add new level of assurance fields to event system emissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-67"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-77"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandler.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandler.java
@@ -36,6 +36,7 @@ import uk.gov.ida.saml.core.domain.AuthnResponseFromCountryContainerDto;
 
 import javax.inject.Inject;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,7 +78,14 @@ public class AuthnRequestFromTransactionHandler {
                 transactionSupportsEidas);
         final List<LevelOfAssurance> transactionLevelsOfAssurance = transactionsConfigProxy.getLevelsOfAssurance(samlResponse.getIssuer());
 
-        hubEventLogger.logSessionStartedEvent(samlResponse, ipAddress, sessionExpiryTimestamp, sessionId, transactionLevelsOfAssurance.get(0), transactionLevelsOfAssurance.get(transactionLevelsOfAssurance.size() -1));
+        hubEventLogger.logSessionStartedEvent(
+            samlResponse,
+            ipAddress,
+            sessionExpiryTimestamp,
+            sessionId,
+            Collections.min(transactionLevelsOfAssurance), // min LOA
+            Collections.max(transactionLevelsOfAssurance), // max LOA
+            transactionLevelsOfAssurance.get(0)); // preferred LOA
 
         return sessionRepository.createSession(sessionStartedState);
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
@@ -1,18 +1,10 @@
 package uk.gov.ida.hub.policy.domain;
 
-// Do not change the ordering of this enum
-public enum LevelOfAssurance {
+// do not reorder this enum - the ordinals are used for comparison
+public enum LevelOfAssurance implements Comparable<LevelOfAssurance> {
     LEVEL_X,
     LEVEL_1,
     LEVEL_2,
     LEVEL_3,
     LEVEL_4;
-
-    public boolean equalOrGreaterThan(LevelOfAssurance levelOfAssurance) {
-        return this.ordinal() >= levelOfAssurance.ordinal();
-    }
-
-    public boolean greaterThan(LevelOfAssurance levelOfAssurance) {
-        return this.ordinal()>levelOfAssurance.ordinal();
-    }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -157,9 +157,10 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 state.getRequestIssuerEntityId(),
                 new PersistentId(translatedResponse.getPersistentId().get()),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                translatedResponse.getLevelOfAssurance().get(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                translatedResponse.getLevelOfAssurance().get(), // provided LOA
                 Optional.empty(),
                 principalIpAddressAsSeenByHub,
                 analyticsSessionId,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -33,6 +33,7 @@ import uk.gov.ida.hub.policy.proxy.MatchingServiceConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -171,9 +172,10 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
                 state.getRequestIssuerEntityId(),
                 successFromIdp.getPersistentId(),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                successFromIdp.getLevelOfAssurance(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                successFromIdp.getLevelOfAssurance(), // provided LOA
                 successFromIdp.getPrincipalIpAddressAsSeenByIdp(),
                 successFromIdp.getPrincipalIpAddressAsSeenByHub(),
                 successFromIdp.getAnalyticSessionId(),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/logging/HubEventLogger.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/logging/HubEventLogger.java
@@ -20,6 +20,7 @@ import uk.gov.ida.hub.shared.eventsink.EventSinkProxy;
 
 import javax.inject.Inject;
 import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -36,15 +37,16 @@ import static uk.gov.ida.eventemitter.EventDetailsKey.hub_event_type;
 import static uk.gov.ida.eventemitter.EventDetailsKey.idp_entity_id;
 import static uk.gov.ida.eventemitter.EventDetailsKey.idp_fraud_event_id;
 import static uk.gov.ida.eventemitter.EventDetailsKey.journey_type;
+import static uk.gov.ida.eventemitter.EventDetailsKey.maximum_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.message;
 import static uk.gov.ida.eventemitter.EventDetailsKey.message_id;
 import static uk.gov.ida.eventemitter.EventDetailsKey.minimum_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.pid;
+import static uk.gov.ida.eventemitter.EventDetailsKey.preferred_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.principal_ip_address_as_seen_by_hub;
 import static uk.gov.ida.eventemitter.EventDetailsKey.principal_ip_address_as_seen_by_idp;
 import static uk.gov.ida.eventemitter.EventDetailsKey.provided_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.request_id;
-import static uk.gov.ida.eventemitter.EventDetailsKey.required_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.session_event_type;
 import static uk.gov.ida.eventemitter.EventDetailsKey.session_expiry_time;
 import static uk.gov.ida.eventemitter.EventDetailsKey.transaction_entity_id;
@@ -89,12 +91,13 @@ public class HubEventLogger {
         this.eventEmitter = eventEmitter;
     }
 
-    public void logSessionStartedEvent(SamlResponseWithAuthnRequestInformationDto samlResponse, String ipAddress, DateTime sessionExpiryTimestamp, SessionId sessionId, LevelOfAssurance minimum, LevelOfAssurance required) {
+    public void logSessionStartedEvent(SamlResponseWithAuthnRequestInformationDto samlResponse, String ipAddress, DateTime sessionExpiryTimestamp, SessionId sessionId, LevelOfAssurance minimum, LevelOfAssurance maximum, LevelOfAssurance preferred) {
         Map<EventDetailsKey, String> details = new HashMap<>();
         details.put(principal_ip_address_as_seen_by_hub, ipAddress);
         details.put(message_id, samlResponse.getId());
         details.put(minimum_level_of_assurance, minimum.name());
-        details.put(required_level_of_assurance, required.name());
+        details.put(maximum_level_of_assurance, maximum.name());
+        details.put(preferred_level_of_assurance, preferred.name());
 
         logSessionEvent(sessionId, samlResponse.getIssuer(), sessionExpiryTimestamp, samlResponse.getId(), SESSION_STARTED, details);
     }
@@ -203,7 +206,8 @@ public class HubEventLogger {
                                           PersistentId persistentId,
                                           String requestId,
                                           LevelOfAssurance minimumLevelOfAssurance,
-                                          LevelOfAssurance requiredLevelOfAssurance,
+                                          LevelOfAssurance maximumLevelOfAssurance,
+                                          LevelOfAssurance preferredLevelOfAssurance,
                                           LevelOfAssurance providedLevelOfAssurance,
                                           Optional<String> principalIpAddress,
                                           String principalIpAddressAsSeenByHub,
@@ -214,7 +218,8 @@ public class HubEventLogger {
         details.put(idp_entity_id, idpEntityId);
         details.put(pid, persistentId.getNameId());
         details.put(minimum_level_of_assurance, minimumLevelOfAssurance.name());
-        details.put(required_level_of_assurance, requiredLevelOfAssurance.name());
+        details.put(maximum_level_of_assurance, maximumLevelOfAssurance.name());
+        details.put(preferred_level_of_assurance, preferredLevelOfAssurance.name());
         details.put(provided_level_of_assurance, providedLevelOfAssurance.name());
         if (principalIpAddress.isPresent()) {
             details.put(principal_ip_address_as_seen_by_idp, principalIpAddress.get());
@@ -267,12 +272,19 @@ public class HubEventLogger {
         Map<EventDetailsKey, String> details = new HashMap<>();
         details.put(idp_entity_id, idpSelectedState.getIdpEntityId());
         details.put(principal_ip_address_as_seen_by_hub, principalIpAddress);
-        details.put(minimum_level_of_assurance, levelsOfAssurance.get(0).name());
-        details.put(required_level_of_assurance, levelsOfAssurance.get(levelsOfAssurance.size() - 1).name());
+        details.put(minimum_level_of_assurance, Collections.min(levelsOfAssurance).name());
+        details.put(maximum_level_of_assurance, Collections.max(levelsOfAssurance).name());
+        details.put(preferred_level_of_assurance, levelsOfAssurance.get(0).name());
         details.put(analytics_session_id, analyticsSessionId);
         details.put(journey_type, journeyType);
 
-        logSessionEvent(idpSelectedState.getSessionId(), idpSelectedState.getRequestIssuerEntityId(), idpSelectedState.getSessionExpiryTimestamp(), idpSelectedState.getRequestId(), IDP_SELECTED, details);
+        logSessionEvent(
+            idpSelectedState.getSessionId(),
+            idpSelectedState.getRequestIssuerEntityId(),
+            idpSelectedState.getSessionExpiryTimestamp(),
+            idpSelectedState.getRequestId(),
+            IDP_SELECTED,
+            details);
     }
 
     public void logSessionMovedToStartStateEvent(SessionStartedState state) {

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandlerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandlerTest.java
@@ -93,8 +93,14 @@ public class AuthnRequestFromTransactionHandlerTest {
 
         authnRequestFromTransactionHandler.handleRequestFromTransaction(samlResponseWithAuthnRequestInformationDto, relayState, PRINCIPAL_IP_ADDRESS, ASSERTION_CONSUMER_SERVICE_URI, false);
 
-        verify(hubEventLogger, times(1)).logSessionStartedEvent(any(), anyString(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
-
+        verify(hubEventLogger, times(1)).logSessionStartedEvent(
+            any(),
+            anyString(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any());
     }
 
     @Test

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -36,6 +36,7 @@ import uk.gov.ida.hub.policy.proxy.MatchingServiceConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -256,9 +257,10 @@ public class EidasCountrySelectedStateControllerTest {
             state.getRequestIssuerEntityId(),
             eidasAttributeQueryRequestDto.getPersistentId(),
             state.getRequestId(),
-            state.getLevelsOfAssurance().get(0),
-            state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-            eidasAttributeQueryRequestDto.getLevelOfAssurance(),
+            Collections.min(state.getLevelsOfAssurance()), // min LOA
+            Collections.max(state.getLevelsOfAssurance()), // max LOA
+            state.getLevelsOfAssurance().get(0), // preferred LOA
+            eidasAttributeQueryRequestDto.getLevelOfAssurance(), // provided LOA
             Optional.empty(),
             IP_ADDRESS,
             ANALYTICS_SESSION_ID,
@@ -291,9 +293,10 @@ public class EidasCountrySelectedStateControllerTest {
                 state.getRequestIssuerEntityId(),
                 eidasAttributeQueryRequestDto.getPersistentId(),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                eidasAttributeQueryRequestDto.getLevelOfAssurance(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                eidasAttributeQueryRequestDto.getLevelOfAssurance(), // provided LOA
                 Optional.empty(),
                 IP_ADDRESS,
                 ANALYTICS_SESSION_ID,
@@ -346,9 +349,10 @@ public class EidasCountrySelectedStateControllerTest {
                 state.getRequestIssuerEntityId(),
                 eidasAttributeQueryRequestDto.getPersistentId(),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                eidasAttributeQueryRequestDto.getLevelOfAssurance(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                eidasAttributeQueryRequestDto.getLevelOfAssurance(), // provided LOA
                 Optional.empty(),
                 IP_ADDRESS,
                 ANALYTICS_SESSION_ID,

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
@@ -37,6 +37,7 @@ import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -384,8 +385,9 @@ public class IdpSelectedStateControllerTest {
                 TRANSACTION_ENTITY_ID,
                 persistentId,
                 REQUEST_ID,
+                Collections.min(LEVELS_OF_ASSURANCE), // min LOA
+                Collections.max(LEVELS_OF_ASSURANCE), // max LOA
                 LEVELS_OF_ASSURANCE.get(0),
-                LEVELS_OF_ASSURANCE.get(1),
                 PROVIDED_LOA,
                 Optional.ofNullable(PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_IDP),
                 PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB,

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
@@ -41,15 +41,16 @@ import static uk.gov.ida.eventemitter.EventDetailsKey.hub_event_type;
 import static uk.gov.ida.eventemitter.EventDetailsKey.idp_entity_id;
 import static uk.gov.ida.eventemitter.EventDetailsKey.idp_fraud_event_id;
 import static uk.gov.ida.eventemitter.EventDetailsKey.journey_type;
+import static uk.gov.ida.eventemitter.EventDetailsKey.maximum_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.message;
 import static uk.gov.ida.eventemitter.EventDetailsKey.message_id;
 import static uk.gov.ida.eventemitter.EventDetailsKey.minimum_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.pid;
+import static uk.gov.ida.eventemitter.EventDetailsKey.preferred_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.principal_ip_address_as_seen_by_hub;
 import static uk.gov.ida.eventemitter.EventDetailsKey.principal_ip_address_as_seen_by_idp;
 import static uk.gov.ida.eventemitter.EventDetailsKey.provided_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.request_id;
-import static uk.gov.ida.eventemitter.EventDetailsKey.required_level_of_assurance;
 import static uk.gov.ida.eventemitter.EventDetailsKey.session_event_type;
 import static uk.gov.ida.eventemitter.EventDetailsKey.session_expiry_time;
 import static uk.gov.ida.eventemitter.EventDetailsKey.transaction_entity_id;
@@ -80,8 +81,10 @@ public class HubEventLoggerTest {
     private static final String TRANSACTION_ENTITY_ID = "transaction-entity-id";
     private static final String IDP_ENTITY_ID = "idp entity id";
     private static final LevelOfAssurance MINIMUM_LEVEL_OF_ASSURANCE = LevelOfAssurance.LEVEL_1;
-    private static final LevelOfAssurance REQUIRED_LEVEL_OF_ASSURANCE = LevelOfAssurance.LEVEL_2;
+    private static final LevelOfAssurance MAXIMUM_LEVEL_OF_ASSURANCE = LevelOfAssurance.LEVEL_2;
+    private static final LevelOfAssurance PREFERRED_LEVEL_OF_ASSURANCE = LevelOfAssurance.LEVEL_1;
     private static final LevelOfAssurance PROVIDED_LEVEL_OF_ASSURANCE = LevelOfAssurance.LEVEL_2;
+
     private static final String REQUEST_ID = "requestId";
     private static final SessionId SESSION_ID = aSessionId().build();
     private static final String PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB = "some-ip-address";
@@ -119,13 +122,21 @@ public class HubEventLoggerTest {
                 .withIssuer(TRANSACTION_ENTITY_ID)
                 .build();
 
-        eventLogger.logSessionStartedEvent(samlResponse, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB, SESSION_EXPIRY_TIMESTAMP, SESSION_ID, MINIMUM_LEVEL_OF_ASSURANCE, REQUIRED_LEVEL_OF_ASSURANCE);
+        eventLogger.logSessionStartedEvent(
+            samlResponse,
+            PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+            SESSION_EXPIRY_TIMESTAMP,
+            SESSION_ID,
+            MINIMUM_LEVEL_OF_ASSURANCE,
+            MAXIMUM_LEVEL_OF_ASSURANCE,
+            PREFERRED_LEVEL_OF_ASSURANCE);
 
         final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
                 principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
                 message_id, samlResponse.getId(),
                 minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name(),
-                required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name(),
+                maximum_level_of_assurance, MAXIMUM_LEVEL_OF_ASSURANCE.name(),
+                preferred_level_of_assurance, PREFERRED_LEVEL_OF_ASSURANCE.name(),
                 session_event_type, SESSION_STARTED));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
@@ -154,7 +165,8 @@ public class HubEventLoggerTest {
             PERSISTENT_ID,
             REQUEST_ID,
             MINIMUM_LEVEL_OF_ASSURANCE,
-            REQUIRED_LEVEL_OF_ASSURANCE,
+            MAXIMUM_LEVEL_OF_ASSURANCE,
+            PREFERRED_LEVEL_OF_ASSURANCE,
             PROVIDED_LEVEL_OF_ASSURANCE,
             Optional.ofNullable(PRINCIPAL_IP_ADDRESS_SEEN_BY_IDP),
             PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
@@ -162,17 +174,18 @@ public class HubEventLoggerTest {
             JOURNEY_TYPE
         );
 
-        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
-                idp_entity_id, IDP_ENTITY_ID,
-                pid, PERSISTENT_ID.getNameId(),
-                minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name(),
-                required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name(),
-                provided_level_of_assurance, PROVIDED_LEVEL_OF_ASSURANCE.name(),
-                principal_ip_address_as_seen_by_idp, PRINCIPAL_IP_ADDRESS_SEEN_BY_IDP,
-                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
-                session_event_type, IDP_AUTHN_SUCCEEDED,
-                analytics_session_id, ANALYTICS_SESSION_ID,
-                journey_type, JOURNEY_TYPE));
+        final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.ofEntries(
+            Map.entry(idp_entity_id, IDP_ENTITY_ID),
+            Map.entry(pid, PERSISTENT_ID.getNameId()),
+            Map.entry(minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name()),
+            Map.entry(maximum_level_of_assurance, MAXIMUM_LEVEL_OF_ASSURANCE.name()),
+            Map.entry(preferred_level_of_assurance, PREFERRED_LEVEL_OF_ASSURANCE.name()),
+            Map.entry(provided_level_of_assurance, PROVIDED_LEVEL_OF_ASSURANCE.name()),
+            Map.entry(principal_ip_address_as_seen_by_idp, PRINCIPAL_IP_ADDRESS_SEEN_BY_IDP),
+            Map.entry(principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB),
+            Map.entry(session_event_type, IDP_AUTHN_SUCCEEDED),
+            Map.entry(analytics_session_id, ANALYTICS_SESSION_ID),
+            Map.entry(journey_type, JOURNEY_TYPE)));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -242,13 +255,14 @@ public class HubEventLoggerTest {
         eventLogger.logIdpSelectedEvent(state, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB, ANALYTICS_SESSION_ID, JOURNEY_TYPE);
 
         final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
-                session_event_type, IDP_SELECTED,
-                idp_entity_id, IDP_ENTITY_ID,
-                principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
-                minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name(),
-                required_level_of_assurance, REQUIRED_LEVEL_OF_ASSURANCE.name(),
-                analytics_session_id, ANALYTICS_SESSION_ID,
-                journey_type, JOURNEY_TYPE));
+            session_event_type, IDP_SELECTED,
+            idp_entity_id, IDP_ENTITY_ID,
+            principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
+            minimum_level_of_assurance, MINIMUM_LEVEL_OF_ASSURANCE.name(),
+            maximum_level_of_assurance, MAXIMUM_LEVEL_OF_ASSURANCE.name(),
+            preferred_level_of_assurance, PREFERRED_LEVEL_OF_ASSURANCE.name(),
+            analytics_session_id, ANALYTICS_SESSION_ID,
+            journey_type, JOURNEY_TYPE));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));


### PR DESCRIPTION
This PR is one part of several across Verify to be able to support billing for new special case `LOA2,LOA1/exact` requests. It uses two new details keys for events emitted by the hub.

* Update to latest `verify-event-emitter` library (build 77).
* Emit `minimum`, `maximum`, `preferred` LOAs when recording session events.
* Emit `minimum`, `maximum`, `preferred` and `provided` LOAs when recording success events.
* Update tests to reflect the new fields.

The full set of changes being made is laid out in:

* [ADR 36 billing changes plan](https://docs.google.com/document/d/1hblVU0wquj6Z3-b9V75z6jb1wt3Nnpjh2MNHxNGgTBE/edit?usp=sharing)

For context, please see:

* [ADR 35](https://github.com/alphagov/verify-architecture/blob/master/adr/0035-allow-specified-loa2-services-to-receive-loa1-identities.md) (sending LOA2,LOA1/exact requests to IDPs)
* [ADR 36](https://github.com/alphagov/verify-architecture/blob/master/adr/0036-support-billing-on-provided-loa.md) (changes to support billing for the new requests)