### PR TITLE
Add new level of assurance fields to event system emissions, v3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.1'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-76"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:0.0.1-77"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandler.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandler.java
@@ -36,6 +36,7 @@ import uk.gov.ida.saml.core.domain.AuthnResponseFromCountryContainerDto;
 
 import javax.inject.Inject;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,7 +78,14 @@ public class AuthnRequestFromTransactionHandler {
                 transactionSupportsEidas);
         final List<LevelOfAssurance> transactionLevelsOfAssurance = transactionsConfigProxy.getLevelsOfAssurance(samlResponse.getIssuer());
 
-        hubEventLogger.logSessionStartedEvent(samlResponse, ipAddress, sessionExpiryTimestamp, sessionId, transactionLevelsOfAssurance.get(0), transactionLevelsOfAssurance.get(transactionLevelsOfAssurance.size() -1));
+        hubEventLogger.logSessionStartedEvent(
+            samlResponse,
+            ipAddress,
+            sessionExpiryTimestamp,
+            sessionId,
+            Collections.min(transactionLevelsOfAssurance), // min LOA
+            Collections.max(transactionLevelsOfAssurance), // max LOA
+            transactionLevelsOfAssurance.get(0)); // preferred LOA
 
         return sessionRepository.createSession(sessionStartedState);
     }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/LevelOfAssurance.java
@@ -1,18 +1,10 @@
 package uk.gov.ida.hub.policy.domain;
 
-// Do not change the ordering of this enum
-public enum LevelOfAssurance {
+// do not reorder this enum - the ordinals are used for comparison
+public enum LevelOfAssurance implements Comparable<LevelOfAssurance> {
     LEVEL_X,
     LEVEL_1,
     LEVEL_2,
     LEVEL_3,
     LEVEL_4;
-
-    public boolean equalOrGreaterThan(LevelOfAssurance levelOfAssurance) {
-        return this.ordinal() >= levelOfAssurance.ordinal();
-    }
-
-    public boolean greaterThan(LevelOfAssurance levelOfAssurance) {
-        return this.ordinal()>levelOfAssurance.ordinal();
-    }
 }

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -157,9 +157,10 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 state.getRequestIssuerEntityId(),
                 new PersistentId(translatedResponse.getPersistentId().get()),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                translatedResponse.getLevelOfAssurance().get(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                translatedResponse.getLevelOfAssurance().get(), // provided LOA
                 Optional.empty(),
                 principalIpAddressAsSeenByHub,
                 analyticsSessionId,

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -33,6 +33,7 @@ import uk.gov.ida.hub.policy.proxy.MatchingServiceConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -171,9 +172,10 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
                 state.getRequestIssuerEntityId(),
                 successFromIdp.getPersistentId(),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                successFromIdp.getLevelOfAssurance(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                successFromIdp.getLevelOfAssurance(), // provided LOA
                 successFromIdp.getPrincipalIpAddressAsSeenByIdp(),
                 successFromIdp.getPrincipalIpAddressAsSeenByHub(),
                 successFromIdp.getAnalyticSessionId(),

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandlerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/controllogic/AuthnRequestFromTransactionHandlerTest.java
@@ -93,8 +93,14 @@ public class AuthnRequestFromTransactionHandlerTest {
 
         authnRequestFromTransactionHandler.handleRequestFromTransaction(samlResponseWithAuthnRequestInformationDto, relayState, PRINCIPAL_IP_ADDRESS, ASSERTION_CONSUMER_SERVICE_URI, false);
 
-        verify(hubEventLogger, times(1)).logSessionStartedEvent(any(), anyString(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
-
+        verify(hubEventLogger, times(1)).logSessionStartedEvent(
+            any(),
+            anyString(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any());
     }
 
     @Test

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -36,6 +36,7 @@ import uk.gov.ida.hub.policy.proxy.MatchingServiceConfigProxy;
 import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 import uk.gov.ida.saml.core.domain.CountrySignedResponseContainer;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -256,9 +257,10 @@ public class EidasCountrySelectedStateControllerTest {
             state.getRequestIssuerEntityId(),
             eidasAttributeQueryRequestDto.getPersistentId(),
             state.getRequestId(),
-            state.getLevelsOfAssurance().get(0),
-            state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-            eidasAttributeQueryRequestDto.getLevelOfAssurance(),
+            Collections.min(state.getLevelsOfAssurance()), // min LOA
+            Collections.max(state.getLevelsOfAssurance()), // max LOA
+            state.getLevelsOfAssurance().get(0), // preferred LOA
+            eidasAttributeQueryRequestDto.getLevelOfAssurance(), // provided LOA
             Optional.empty(),
             IP_ADDRESS,
             ANALYTICS_SESSION_ID,
@@ -291,9 +293,10 @@ public class EidasCountrySelectedStateControllerTest {
                 state.getRequestIssuerEntityId(),
                 eidasAttributeQueryRequestDto.getPersistentId(),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                eidasAttributeQueryRequestDto.getLevelOfAssurance(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                eidasAttributeQueryRequestDto.getLevelOfAssurance(), // provided LOA
                 Optional.empty(),
                 IP_ADDRESS,
                 ANALYTICS_SESSION_ID,
@@ -346,9 +349,10 @@ public class EidasCountrySelectedStateControllerTest {
                 state.getRequestIssuerEntityId(),
                 eidasAttributeQueryRequestDto.getPersistentId(),
                 state.getRequestId(),
-                state.getLevelsOfAssurance().get(0),
-                state.getLevelsOfAssurance().get(state.getLevelsOfAssurance().size() - 1),
-                eidasAttributeQueryRequestDto.getLevelOfAssurance(),
+                Collections.min(state.getLevelsOfAssurance()), // min LOA
+                Collections.max(state.getLevelsOfAssurance()), // max LOA
+                state.getLevelsOfAssurance().get(0), // preferred LOA
+                eidasAttributeQueryRequestDto.getLevelOfAssurance(), // provided LOA
                 Optional.empty(),
                 IP_ADDRESS,
                 ANALYTICS_SESSION_ID,

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
@@ -37,6 +37,7 @@ import uk.gov.ida.hub.policy.proxy.TransactionsConfigProxy;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -384,8 +385,9 @@ public class IdpSelectedStateControllerTest {
                 TRANSACTION_ENTITY_ID,
                 persistentId,
                 REQUEST_ID,
+                Collections.min(LEVELS_OF_ASSURANCE), // min LOA
+                Collections.max(LEVELS_OF_ASSURANCE), // max LOA
                 LEVELS_OF_ASSURANCE.get(0),
-                LEVELS_OF_ASSURANCE.get(1),
                 PROVIDED_LOA,
                 Optional.ofNullable(PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_IDP),
                 PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB,


### PR DESCRIPTION
_Previous branches have attempted to run CI tests from PR 447, even though it is closed. Hopefully this new branch will run its own. Travis confirms that this branch builds and tests green._

This PR is one part of several across Verify to be able to support billing for new special case `LOA2,LOA1/exact` requests. It uses two new details keys for events emitted by the hub.

* Update to latest `verify-event-emitter` library (build 77).
* Emit `minimum`, `maximum`, `preferred` LOAs when recording session events.
* Emit `minimum`, `maximum`, `preferred` and `provided` LOAs when recording success events.
* Update tests to reflect the new fields.

The full set of changes being made is laid out in:

* [ADR 36 billing changes plan](https://docs.google.com/document/d/1hblVU0wquj6Z3-b9V75z6jb1wt3Nnpjh2MNHxNGgTBE/edit?usp=sharing)

For context, please see:

* [ADR 35](https://github.com/alphagov/verify-architecture/blob/master/adr/0035-allow-specified-loa2-services-to-receive-loa1-identities.md) (sending LOA2,LOA1/exact requests to IDPs)
* [ADR 36](https://github.com/alphagov/verify-architecture/blob/master/adr/0036-support-billing-on-provided-loa.md) (changes to support billing for the new requests)