### PR TITLE
#️⃣EID-1980 log request id, rm pid in eidas hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def dependencyVersions = [
         ida_test_utils:"2.0.0-49",
         opensaml:"$opensaml_version",
         dev_pki: '1.1.0-37',
-        saml_lib:"$opensaml_version-232"
+        saml_lib:"$opensaml_version-240"
 ]
 
 subprojects {
@@ -151,7 +151,8 @@ subprojects {
         test_utils "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizard",
                 "org.junit.jupiter:junit-jupiter-api:5.5.2",
                 "org.mockito:mockito-junit-jupiter:3.2.0",
-                'org.assertj:assertj-core:3.14.0'
+                'org.assertj:assertj-core:3.14.0',
+                'commons-io:commons-io:2.5'
 
         def test_deps_deps = [
                 'org.json:json:20170516',


### PR DESCRIPTION
[DO NOT MERGE PLS]

Use v. 240 of saml-libs which will log request id instead of pid, see https://github.com/alphagov/verify-saml-libs/pull/114

Its correct that the only change is the saml-libs version.