### PR TITLE
Make sure the journey type and analytic session ID exist when we log it

### DIFF
--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
@@ -33,7 +33,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
-import static uk.gov.ida.eventemitter.EventDetailsKey.ab_test_variant;
 import static uk.gov.ida.eventemitter.EventDetailsKey.analytics_session_id;
 import static uk.gov.ida.eventemitter.EventDetailsKey.downstream_uri;
 import static uk.gov.ida.eventemitter.EventDetailsKey.error_id;

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/CountryMetadataConsumerTest.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/CountryMetadataConsumerTest.java
@@ -24,6 +24,8 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import java.util.UUID;
+
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.samlproxy.domain.LevelOfAssurance.LEVEL_2;
@@ -42,7 +44,10 @@ public class CountryMetadataConsumerTest {
     private static final String anotherIdpSigningCert = STUB_IDP_PUBLIC_SECONDARY_CERT;
     private static final String anotherIdpSigningKey = STUB_IDP_PUBLIC_SECONDARY_PRIVATE_KEY;
 
+
     private static Client client;
+    private String analyticsSessionId = UUID.randomUUID().toString();
+    private String journeyType = "some-journey-type";
     private AuthnResponseFactory authnResponseFactory;
 
     @ClassRule
@@ -82,7 +87,7 @@ public class CountryMetadataConsumerTest {
         final String samlResponseString = new XmlObjectToBase64EncodedStringTransformer<>().apply(samlResponse);
 
         // When
-        ResponseActionDto post = postSAML(new SamlRequestDto(samlResponseString, sessionId.getSessionId(), "127.0.0.1"))
+        ResponseActionDto post = postSAML(new SamlRequestDto(samlResponseString, sessionId.getSessionId(), "127.0.0.1", analyticsSessionId, journeyType))
                 .readEntity(ResponseActionDto.class);
 
         // Then
@@ -104,7 +109,7 @@ public class CountryMetadataConsumerTest {
         final String samlResponseString = new XmlObjectToBase64EncodedStringTransformer<>().apply(samlResponse);
 
         // When
-        Response responseFromSamlProxy = postSAML(new SamlRequestDto(samlResponseString, sessionId.getSessionId(), "127.0.0.1"));
+        Response responseFromSamlProxy = postSAML(new SamlRequestDto(samlResponseString, sessionId.getSessionId(), "127.0.0.1", analyticsSessionId, journeyType));
 
         // Then
         assertThat(responseFromSamlProxy.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/DenialOfServiceAttacksIntegrationTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/DenialOfServiceAttacksIntegrationTests.java
@@ -20,6 +20,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,11 +67,13 @@ public class DenialOfServiceAttacksIntegrationTests {
                 "          ".repeat(80);
         String samlAuthnRequest = StringEncoding.toBase64Encoded(xmlString);
         String relayState = "aRelayState";
+        String analyticsSessionId = UUID.randomUUID().toString();
+        String journeyType = "some-journey-type";
 
         final URI ssoUri = samlProxyAppRule.getUri(Urls.SamlProxyUrls.SAML2_SSO_RECEIVER_API_ROOT);
         Response response = client.target(ssoUri)
                 .request(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.json(new SamlRequestDto(samlAuthnRequest, relayState, "12.23.34.45")));
+                .post(Entity.json(new SamlRequestDto(samlAuthnRequest, relayState, "12.23.34.45", analyticsSessionId, journeyType)));
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
     }

--- a/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/MetadataConsumerTests.java
+++ b/hub/saml-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlproxy/apprule/MetadataConsumerTests.java
@@ -29,6 +29,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.hub.samlproxy.domain.LevelOfAssurance.LEVEL_2;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT;
@@ -38,6 +40,8 @@ public class MetadataConsumerTests {
 
     private static final SignatureAlgorithm SIGNATURE_ALGORITHM = new SignatureRSASHA1();
     private static final DigestAlgorithm DIGEST_ALGORITHM = new DigestSHA256();
+    private static final String ANALYTICS_SESSION_ID = UUID.randomUUID().toString();
+    private static final String JOURNEY_TYPE = "some-journey-type";
 
     private static Client client;
     private AuthnResponseFactory authnResponseFactory;
@@ -72,7 +76,7 @@ public class MetadataConsumerTests {
                 DIGEST_ALGORITHM);
         final String samlResponseString = new XmlObjectToBase64EncodedStringTransformer<>().apply(samlResponse);
 
-        ResponseActionDto post = postSAML(new SamlRequestDto(samlResponseString, sessionId.getSessionId(), "127.0.0.1"))
+        ResponseActionDto post = postSAML(new SamlRequestDto(samlResponseString, sessionId.getSessionId(), "127.0.0.1", ANALYTICS_SESSION_ID, JOURNEY_TYPE))
                 .readEntity(ResponseActionDto.class);
 
         assertThat(post.getSessionId()).isEqualTo(sessionId);
@@ -93,7 +97,7 @@ public class MetadataConsumerTests {
                 DIGEST_ALGORITHM);
         final String samlResponseString = new XmlObjectToBase64EncodedStringTransformer<>().apply(samlResponse);
         SamlRequestDto samlRequestDto = new SamlRequestDto(samlResponseString,
-                sessionId.getSessionId(), "127.0.0.1");
+                sessionId.getSessionId(), "127.0.0.1", ANALYTICS_SESSION_ID, JOURNEY_TYPE);
 
         assertThat(postSAML(samlRequestDto).getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode
                 ());

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/contracts/SamlRequestDto.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/contracts/SamlRequestDto.java
@@ -4,11 +4,15 @@ public class SamlRequestDto {
     private String samlRequest;
     private String relayState;
     private String principalIpAsSeenByFrontend;
+    private String analyticsSessionId;
+    private String journeyType;
 
-    public SamlRequestDto(String samlRequest, String relayState, final String principalIpAsSeenByFrontend) {
+    public SamlRequestDto(String samlRequest, String relayState, String principalIpAsSeenByFrontend, String analyticsSessionId, String journeyType) {
         this.samlRequest = samlRequest;
         this.relayState = relayState;
         this.principalIpAsSeenByFrontend = principalIpAsSeenByFrontend;
+        this.analyticsSessionId = analyticsSessionId;
+        this.journeyType = journeyType;
     }
 
     //Needed for JAXB
@@ -24,5 +28,13 @@ public class SamlRequestDto {
 
     public String getPrincipalIpAsSeenByFrontend() {
         return principalIpAsSeenByFrontend;
+    }
+
+    public String getAnalyticsSessionId() {
+        return analyticsSessionId;
+    }
+
+    public String getJourneyType() {
+        return journeyType;
     }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/domain/SamlAuthnResponseContainerDto.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/domain/SamlAuthnResponseContainerDto.java
@@ -7,15 +7,19 @@ public class SamlAuthnResponseContainerDto {
     private String samlResponse;
     private SessionId sessionId;
     private String principalIPAddressAsSeenByHub;
+    private String analyticsSessionId;
+    private String journeyType;
 
     @SuppressWarnings("unused") //Needed for JAXB
     private SamlAuthnResponseContainerDto() {
     }
 
-    public SamlAuthnResponseContainerDto(String samlResponse, SessionId sessionId, String principalIPAddressAsSeenByHub) {
+    public SamlAuthnResponseContainerDto(String samlResponse, SessionId sessionId, String principalIPAddressAsSeenByHub, String analyticsSessionId, String journeyType) {
         this.samlResponse = samlResponse;
         this.sessionId = sessionId;
         this.principalIPAddressAsSeenByHub = principalIPAddressAsSeenByHub;
+        this.analyticsSessionId = analyticsSessionId;
+        this.journeyType = journeyType;
     }
 
     public String getSamlResponse() {
@@ -27,4 +31,12 @@ public class SamlAuthnResponseContainerDto {
     }
 
     public String getPrincipalIPAddressAsSeenByHub() { return principalIPAddressAsSeenByHub; }
+
+    public String getAnalyticsSessionId() {
+        return analyticsSessionId;
+    }
+
+    public String getJourneyType() {
+        return journeyType;
+    }
 }

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApi.java
@@ -139,7 +139,9 @@ public class SamlMessageReceiverApi {
         final SamlAuthnResponseContainerDto authnResponseDto = new SamlAuthnResponseContainerDto(
                 samlRequestDto.getSamlRequest(),
                 sessionId,
-                samlRequestDto.getPrincipalIpAsSeenByFrontend()
+                samlRequestDto.getPrincipalIpAsSeenByFrontend(),
+                samlRequestDto.getAnalyticsSessionId(),
+                samlRequestDto.getJourneyType()
         );
 
         return Response.ok(sessionProxy.receiveAuthnResponseFromIdp(authnResponseDto, sessionId)).build();
@@ -172,7 +174,9 @@ public class SamlMessageReceiverApi {
             final SamlAuthnResponseContainerDto authnResponseDto = new SamlAuthnResponseContainerDto(
                 samlRequestDto.getSamlRequest(),
                 sessionId,
-                samlRequestDto.getPrincipalIpAsSeenByFrontend()
+                samlRequestDto.getPrincipalIpAsSeenByFrontend(),
+                samlRequestDto.getAnalyticsSessionId(),
+                samlRequestDto.getJourneyType()
             );
             return Response.ok(sessionProxy.receiveAuthnResponseFromCountry(authnResponseDto, sessionId)).build();
         }

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/resources/SamlMessageReceiverApiTest.java
@@ -76,7 +76,7 @@ public class SamlMessageReceiverApiTest {
 
     private SamlMessageReceiverApi samlMessageReceiverApi;
     private org.opensaml.saml.saml2.core.Response validSamlResponse;
-    private SamlRequestDto SAML_REQUEST_DTO = new SamlRequestDto(SAML_REQUEST, SESSION_ID.getSessionId(), IP);
+    private SamlRequestDto SAML_REQUEST_DTO = new SamlRequestDto(SAML_REQUEST, SESSION_ID.getSessionId(), IP, null, null);
 
     @Before
     public void setUp() throws MarshallingException, SignatureException {


### PR DESCRIPTION
**What**
- Add the analytic session id and journey type to the saml proxy dto so it is able to receive them from the frontend before logging them in policy.
- Make the necessary changes to the unit tests.

**Why**
- This is half of the change to ensure we log the analytic session id and journey type when we receive a response from an idp. The other half will be in verify-frontend.
- Currently we log the journey type and analytic session id when we receive a response from a country or IDP. However these attributes are always null. This is because the frontend should be adding these attributes to the response before passing it onto saml proxy.

This will work for IDPs. I'm not sure if we need to log either of these attributes for countries on the response. We're not currently logging an analytic session ID for countries on the request either. If we don't need to do this then we can stop trying to log it for countries and code can be removed. 
