### PR TITLE
Start recording the IDP entity ID for failed events

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateController.java
@@ -193,7 +193,8 @@ public class EidasCountrySelectedStateController implements ErrorResponsePrepare
                 state.getRequestId(),
                 principalIpAddressAsSeenByHub,
                 analyticsSessionId,
-                journeyType
+                journeyType,
+                state.getCountryEntityId()
         );
 
         stateTransitionAction.transitionTo(createEidasAuthnFailedErrorState());

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateController.java
@@ -117,7 +117,8 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
 
     public void handleNoAuthenticationContextResponseFromIdp(AuthenticationErrorResponse authenticationErrorResponse) {
         validateIdpIsEnabledAndWasIssuedWithRequest(authenticationErrorResponse.getIssuer(), state.isRegistering(), state.getRequestedLoa(), state.getRequestIssuerEntityId());
-        hubEventLogger.logNoAuthnContextEvent(state.getSessionId(), state.getRequestIssuerEntityId(), state.getSessionExpiryTimestamp(), state.getRequestId(), authenticationErrorResponse.getPrincipalIpAddressAsSeenByHub(), authenticationErrorResponse.getAnalyticsSessionId(), authenticationErrorResponse.getJourneyType());
+        hubEventLogger.logNoAuthnContextEvent(state.getSessionId(), state.getRequestIssuerEntityId(), state.getSessionExpiryTimestamp(), state.getRequestId(), authenticationErrorResponse.getPrincipalIpAddressAsSeenByHub(), authenticationErrorResponse.getAnalyticsSessionId(), authenticationErrorResponse.getJourneyType(),
+                state.getIdpEntityId());
         if (state.isRegistering()) {
             stateTransitionAction.transitionTo(createAuthnFailedErrorState());
         } else {
@@ -127,13 +128,14 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
 
     public void handlePausedRegistrationResponseFromIdp(String requestIssuerEntityId, String principalIdAsSeenByHub, Optional<LevelOfAssurance> responseLoa, String analyticsSessionId, String journeyType) {
         validateIdpIsEnabledAndWasIssuedWithRequest(requestIssuerEntityId, state.isRegistering(), responseLoa.orElseGet(state::getRequestedLoa), state.getRequestIssuerEntityId());
-        hubEventLogger.logPausedRegistrationEvent(state.getSessionId(), state.getRequestIssuerEntityId(), state.getSessionExpiryTimestamp(), state.getRequestId(), principalIdAsSeenByHub, analyticsSessionId, journeyType);
+        hubEventLogger.logPausedRegistrationEvent(state.getSessionId(), state.getRequestIssuerEntityId(), state.getSessionExpiryTimestamp(), state.getRequestId(), principalIdAsSeenByHub, analyticsSessionId, journeyType, state.getIdpEntityId());
         stateTransitionAction.transitionTo(createPausedRegistrationState());
     }
 
     public void handleAuthenticationFailedResponseFromIdp(AuthenticationErrorResponse authenticationErrorResponse) {
         validateIdpIsEnabledAndWasIssuedWithRequest(authenticationErrorResponse.getIssuer(), state.isRegistering(), state.getRequestedLoa(), state.getRequestIssuerEntityId());
-        hubEventLogger.logIdpAuthnFailedEvent(state.getSessionId(), state.getRequestIssuerEntityId(), state.getSessionExpiryTimestamp(), state.getRequestId(), authenticationErrorResponse.getPrincipalIpAddressAsSeenByHub(), authenticationErrorResponse.getAnalyticsSessionId(), authenticationErrorResponse.getJourneyType());
+        hubEventLogger.logIdpAuthnFailedEvent(state.getSessionId(), state.getRequestIssuerEntityId(), state.getSessionExpiryTimestamp(), state.getRequestId(), authenticationErrorResponse.getPrincipalIpAddressAsSeenByHub(), authenticationErrorResponse.getAnalyticsSessionId(), authenticationErrorResponse.getJourneyType(),
+                state.getIdpEntityId());
         stateTransitionAction.transitionTo(createAuthnFailedErrorState());
     }
 
@@ -147,7 +149,8 @@ public class IdpSelectedStateController implements ErrorResponsePreparedStateCon
                 requesterErrorResponseDto.getErrorMessage(),
                 requesterErrorResponseDto.getPrincipalIpAddressAsSeenByHub(),
                 requesterErrorResponseDto.getAnalyticsSessionId(),
-                requesterErrorResponseDto.getJourneyType());
+                requesterErrorResponseDto.getJourneyType(),
+                state.getIdpEntityId());
         stateTransitionAction.transitionTo(createRequesterErrorState());
     }
 

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/logging/HubEventLogger.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/logging/HubEventLogger.java
@@ -103,15 +103,12 @@ public class HubEventLogger {
         logSessionEvent(sessionId, samlResponse.getIssuer(), sessionExpiryTimestamp, samlResponse.getId(), SESSION_STARTED, details);
     }
 
-    public void logIdpAuthnFailedEvent(SessionId sessionId,
-                                       String transactionEntityId,
-                                       DateTime sessionExpiryTimestamp,
-                                       String requestId,
-                                       String principalIpAddressSeenByHub,
-                                       String analyticsSessionId,
-                                       String journeyType) {
+    public void logIdpAuthnFailedEvent(SessionId sessionId, String transactionEntityId, DateTime sessionExpiryTimestamp,
+                                       String requestId, String principalIpAddressSeenByHub, String analyticsSessionId,
+                                       String journeyType, String idpEntityID) {
         Map<EventDetailsKey, String> details = new HashMap<>();
         details.put(principal_ip_address_as_seen_by_hub, principalIpAddressSeenByHub);
+        details.put(idp_entity_id, idpEntityID);
         details.put(analytics_session_id, analyticsSessionId);
         details.put(journey_type, journeyType);
         logSessionEvent(sessionId, transactionEntityId, sessionExpiryTimestamp, requestId, IDP_AUTHN_FAILED, details);
@@ -141,26 +138,28 @@ public class HubEventLogger {
         logSessionEvent(sessionId, transactionEntityId, sessionExpiryTimestamp, requestId, USER_ACCOUNT_CREATION_FAILED, new HashMap<>());
     }
 
-    public void logNoAuthnContextEvent(SessionId sessionId, String transactionEntityId, DateTime sessionExpiryTimestamp, String requestId, String principalIpAddressAsSeenByHub, String analyticsSessionId, String journeyType) {
+    public void logNoAuthnContextEvent(SessionId sessionId, String transactionEntityId, DateTime sessionExpiryTimestamp, String requestId, String principalIpAddressAsSeenByHub, String analyticsSessionId, String journeyType, String idpEntityID) {
         Map<EventDetailsKey, String> details = new HashMap<>();
+        details.put(idp_entity_id, idpEntityID);
         details.put(principal_ip_address_as_seen_by_hub, principalIpAddressAsSeenByHub);
         details.put(analytics_session_id, analyticsSessionId);
         details.put(journey_type, journeyType);
         logSessionEvent(sessionId, transactionEntityId, sessionExpiryTimestamp, requestId, NO_AUTHN_CONTEXT, details);
     }
 
-    public void logPausedRegistrationEvent(SessionId sessionId, String transactionEntityId, DateTime sessionExpiryTimestamp, String requestId, String principalIdAsSeenByHub, String analyticsSessionId, String journeyType) {
+    public void logPausedRegistrationEvent(SessionId sessionId, String transactionEntityId, DateTime sessionExpiryTimestamp, String requestId, String principalIdAsSeenByHub, String analyticsSessionId, String journeyType, String idpEntityID) {
         Map<EventDetailsKey, String> details = new HashMap<>();
         details.put(principal_ip_address_as_seen_by_hub, principalIdAsSeenByHub);
+        details.put(idp_entity_id, idpEntityID);
         details.put(analytics_session_id, analyticsSessionId);
         details.put(journey_type, journeyType);
         logSessionEvent(sessionId, transactionEntityId, sessionExpiryTimestamp, requestId, IDP_AUTHN_PENDING, details);
     }
 
-    public void logIdpFraudEvent(SessionId sessionId, String transactionEntityId, String idpEntityId, PersistentId persistentId, DateTime sessionExpiryTimestamp, FraudDetectedDetails fraudDetectedDetails,
+    public void logIdpFraudEvent(SessionId sessionId, String idpEntityID, String requestIssuerEntityID, PersistentId persistentId, DateTime sessionExpiryTimestamp, FraudDetectedDetails fraudDetectedDetails,
                                  Optional<String> principalIpAddressSeenByIdp, String principalIpAddressSeenByHub, String requestId, String analyticsSessionId, String journeyType) {
         Map<EventDetailsKey, String> details = new HashMap<>();
-        details.put(idp_entity_id, transactionEntityId);
+        details.put(idp_entity_id, idpEntityID);
         details.put(pid, persistentId.getNameId());
         details.put(idp_fraud_event_id, fraudDetectedDetails.getIdpFraudEventId());
         details.put(gpg45_status, fraudDetectedDetails.getFraudIndicator());
@@ -172,7 +171,7 @@ public class HubEventLogger {
         }
         details.put(principal_ip_address_as_seen_by_hub, principalIpAddressSeenByHub);
 
-        logSessionEvent(sessionId, idpEntityId, sessionExpiryTimestamp, requestId, FRAUD_DETECTED, details);
+        logSessionEvent(sessionId, requestIssuerEntityID, sessionExpiryTimestamp, requestId, FRAUD_DETECTED, details);
     }
 
     public void logWaitingForCycle3AttributesEvent(SessionId sessionId, String transactionEntityId, String requestId, DateTime sessionExpiryTimestamp) {
@@ -189,13 +188,15 @@ public class HubEventLogger {
         logSessionEvent(sessionId, transactionEntityId, sessionExpiryTimestamp, requestId, CYCLE3_CANCEL, new HashMap<>());
     }
 
-    public void logIdpRequesterErrorEvent(SessionId sessionId, String transactionEntityId, DateTime sessionExpiryTimestamp, String requestId, Optional<String> errorMessage, String principalIpAddressSeenByHub, String analyticsSessionId, String journeyType) {
+    public void logIdpRequesterErrorEvent(SessionId sessionId, String transactionEntityId, DateTime sessionExpiryTimestamp, String requestId, Optional<String> errorMessage, String principalIpAddressSeenByHub, String analyticsSessionId, String journeyType,
+  String idpEntityId) {
         EnumMap<EventDetailsKey, String> details = new EnumMap<>(EventDetailsKey.class);
         if (errorMessage.isPresent()) {
             details.put(message, errorMessage.get());
         }
         details.put(principal_ip_address_as_seen_by_hub, principalIpAddressSeenByHub);
         details.put(analytics_session_id, analyticsSessionId);
+        details.put(idp_entity_id, idpEntityId);
         details.put(journey_type, journeyType);
         logSessionEvent(sessionId, transactionEntityId, sessionExpiryTimestamp, requestId, REQUESTER_ERROR, details);
     }

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/EidasCountrySelectedStateControllerTest.java
@@ -409,7 +409,8 @@ public class EidasCountrySelectedStateControllerTest {
                 state.getRequestId(),
                 IP_ADDRESS,
                 ANALYTICS_SESSION_ID,
-                JOURNEY_TYPE);
+                JOURNEY_TYPE,
+                state.getCountryEntityId());
 
         verify(stateTransitionAction).transitionTo(capturedState.capture());
         assertThat(capturedState.getValue()).isInstanceOf(EidasAuthnFailedErrorState.class);

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/domain/controller/IdpSelectedStateControllerTest.java
@@ -409,7 +409,8 @@ public class IdpSelectedStateControllerTest {
                 REQUEST_ID,
                 PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB,
                 ANALYTICS_SESSION_ID,
-                JOURNEY_TYPE);
+                JOURNEY_TYPE,
+                IDP_ENTITY_ID);
     }
 
     @Test
@@ -433,7 +434,8 @@ public class IdpSelectedStateControllerTest {
                 Optional.ofNullable(errorMessage),
                 PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB,
                 ANALYTICS_SESSION_ID,
-                JOURNEY_TYPE);
+                JOURNEY_TYPE,
+                IDP_ENTITY_ID);
     }
 
     @Test
@@ -454,7 +456,8 @@ public class IdpSelectedStateControllerTest {
                 REQUEST_ID,
                 PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB,
                 ANALYTICS_SESSION_ID,
-                JOURNEY_TYPE);
+                JOURNEY_TYPE,
+                IDP_ENTITY_ID);
     }
 
     @Test
@@ -475,7 +478,8 @@ public class IdpSelectedStateControllerTest {
                 REQUEST_ID,
                 PRINCIPAL_IP_ADDRESS_AS_SEEN_BY_HUB,
                 ANALYTICS_SESSION_ID,
-                JOURNEY_TYPE);
+                JOURNEY_TYPE,
+                IDP_ENTITY_ID);
     }
 
     @Test

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/logging/HubEventLoggerTest.java
@@ -283,7 +283,8 @@ public class HubEventLoggerTest {
             Optional.ofNullable(errorMessage),
             PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
             ANALYTICS_SESSION_ID,
-            JOURNEY_TYPE
+            JOURNEY_TYPE,
+            IDP_ENTITY_ID
         );
 
         final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
@@ -291,7 +292,8 @@ public class HubEventLoggerTest {
                 principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
                 session_event_type, REQUESTER_ERROR,
                 analytics_session_id, ANALYTICS_SESSION_ID,
-                journey_type, JOURNEY_TYPE));
+                journey_type, JOURNEY_TYPE,
+                idp_entity_id, IDP_ENTITY_ID));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -307,14 +309,15 @@ public class HubEventLoggerTest {
             REQUEST_ID,
             PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
             ANALYTICS_SESSION_ID,
-            JOURNEY_TYPE
+            JOURNEY_TYPE,
+            IDP_ENTITY_ID
         );
 
         final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
                 session_event_type, IDP_AUTHN_FAILED,
                 principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
                 analytics_session_id, ANALYTICS_SESSION_ID,
-                journey_type, JOURNEY_TYPE));
+                journey_type, JOURNEY_TYPE, idp_entity_id, IDP_ENTITY_ID));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -329,14 +332,15 @@ public class HubEventLoggerTest {
             REQUEST_ID,
             PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
             ANALYTICS_SESSION_ID,
-            JOURNEY_TYPE
+            JOURNEY_TYPE,
+            IDP_ENTITY_ID
         );
 
         final EventSinkHubEvent expectedEvent = createExpectedEventSinkHubEvent(Map.of(
                 principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
                 session_event_type, IDP_AUTHN_PENDING,
                 analytics_session_id, ANALYTICS_SESSION_ID,
-                journey_type, JOURNEY_TYPE));
+                journey_type, JOURNEY_TYPE, idp_entity_id, IDP_ENTITY_ID));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));
@@ -351,7 +355,8 @@ public class HubEventLoggerTest {
             REQUEST_ID,
             PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
             ANALYTICS_SESSION_ID,
-            JOURNEY_TYPE
+            JOURNEY_TYPE,
+            IDP_ENTITY_ID
         );
 
 
@@ -359,7 +364,7 @@ public class HubEventLoggerTest {
                 session_event_type, NO_AUTHN_CONTEXT,
                 principal_ip_address_as_seen_by_hub, PRINCIPAL_IP_ADDRESS_SEEN_BY_HUB,
                 analytics_session_id, ANALYTICS_SESSION_ID,
-                journey_type, JOURNEY_TYPE));
+                journey_type, JOURNEY_TYPE, idp_entity_id, IDP_ENTITY_ID));
 
         verify(eventSinkProxy).logHubEvent(argThat(new EventMatching(expectedEvent)));
         verify(eventEmitter).record(argThat(new EventMatching(expectedEvent)));


### PR DESCRIPTION
- For entries where we are recording the journey time in the event system we want to ensure the IDP entity ID is being used as well so that the reports will be correctly populated. This will ensure that the conformance tests in the event system will run successfully. 
- The failed events would be useful in the event reports so we want to keep them in there before thinking about if there is any other additional information we want to add. 