### PR TITLE
EID-1977 Validation of missing namespace uri on Assertion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def dependencyVersions = [
         ida_test_utils:"2.0.0-49",
         opensaml:"$opensaml_version",
         dev_pki: '1.1.0-37',
-        saml_lib:"$opensaml_version-240"
+        saml_lib:"$opensaml_version-241"
 ]
 
 subprojects {

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidator.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.hub.samlengine.validation.country;
 
 import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
 import uk.gov.ida.saml.core.errors.SamlTransformationErrorFactory;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
@@ -47,7 +48,7 @@ public class ResponseAssertionsFromCountryValidator {
             }
 
             authnStatementAssertionValidator.validate(validatedIdentityAssertion);
-            eidasAttributeStatementAssertionValidator.validate(validatedIdentityAssertion);
+            eidasAttributeStatementAssertionValidator.validate(validatedResponse, validatedIdentityAssertion);
             authnResponseIssuerValidator.validate(validatedResponse, validatedIdentityAssertion);
         }
     }

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/EidasAttributeStatementAssertionValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/EidasAttributeStatementAssertionValidatorTest.java
@@ -7,22 +7,30 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.core.xml.Namespace;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.AttributeValue;
+import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.IdaConstants.Eidas_Attributes;
 import uk.gov.ida.saml.core.extensions.eidas.CurrentFamilyName;
 import uk.gov.ida.saml.core.extensions.eidas.CurrentGivenName;
 import uk.gov.ida.saml.core.extensions.eidas.DateOfBirth;
 import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -31,6 +39,8 @@ public class EidasAttributeStatementAssertionValidatorTest {
     public ExpectedException exception = ExpectedException.none();
     @Mock
     private Assertion assertion;
+    @Mock
+    private ValidatedResponse validatedResponse;
     @Mock
     private AttributeStatement attributeStatement;
     private Attribute firstName;
@@ -42,7 +52,10 @@ public class EidasAttributeStatementAssertionValidatorTest {
 
     @Before
     public void setup() {
-        firstName = generateAttribute(Eidas_Attributes.FirstName.NAME, Eidas_Attributes.FirstName.FRIENDLY_NAME, CurrentGivenName.TYPE_NAME);
+        firstName = generateAttribute(Eidas_Attributes.FirstName.NAME, Eidas_Attributes.FirstName.FRIENDLY_NAME, new QName(
+                XMLConstants.NULL_NS_URI,
+                CurrentGivenName.TYPE_LOCAL_NAME,
+                IdaConstants.EIDAS_NATURUAL_PREFIX));
         lastName = generateAttribute(Eidas_Attributes.FamilyName.NAME, Eidas_Attributes.FamilyName.FRIENDLY_NAME, CurrentFamilyName.TYPE_NAME);
         dateOfBirth = generateAttribute(Eidas_Attributes.DateOfBirth.NAME, Eidas_Attributes.DateOfBirth.FRIENDLY_NAME, DateOfBirth.TYPE_NAME);
         personIdentifier = generateAttribute(Eidas_Attributes.PersonIdentifier.NAME, Eidas_Attributes.PersonIdentifier.FRIENDLY_NAME, PersonIdentifier.TYPE_NAME);
@@ -55,28 +68,28 @@ public class EidasAttributeStatementAssertionValidatorTest {
     public void shouldThrowIfNoAttributeStatements() {
         when(assertion.getAttributeStatements()).thenReturn(Collections.emptyList());
 
-        validator.validate(assertion);
+        validator.validate(validatedResponse, assertion);
     }
 
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldThrowIfMultipleAttributeStatements() {
         when(assertion.getAttributeStatements()).thenReturn(List.of(attributeStatement, attributeStatement));
 
-        validator.validate(assertion);
+        validator.validate(validatedResponse, assertion);
     }
 
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldThrowIfAttributeHasInvalidName() {
         when(firstName.getName()).thenReturn("invalid");
 
-        validator.validate(assertion);
+        validator.validate(validatedResponse, assertion);
     }
 
     @Test(expected = SamlTransformationErrorException.class)
     public void shouldThrowIfAttributeHasNoValues() {
         when(firstName.getAttributeValues()).thenReturn(Collections.emptyList());
 
-        validator.validate(assertion);
+        validator.validate(validatedResponse, assertion);
     }
 
     @Test(expected = SamlTransformationErrorException.class)
@@ -85,7 +98,7 @@ public class EidasAttributeStatementAssertionValidatorTest {
         when(firstName.getAttributeValues()).thenReturn(List.of(xmlObject));
         when(xmlObject.getSchemaType()).thenReturn(CurrentFamilyName.TYPE_NAME);
 
-        validator.validate(assertion);
+        validator.validate(validatedResponse, assertion);
     }
 
     @Test
@@ -95,15 +108,44 @@ public class EidasAttributeStatementAssertionValidatorTest {
 
         when(attributeStatement.getAttributes()).thenReturn(List.of(firstName, lastName, dateOfBirth));
 
-        validator.validate(assertion);
+        validator.validate(validatedResponse, assertion);
     }
+
+    @Test
+    public void validateCorrectNamespaceURIOnResponseAllowsValidMatchOnAttribute() {
+        when(validatedResponse.getNamespaces()).thenReturn(Set.of(new Namespace(
+                IdaConstants.EIDAS_NATURAL_PERSON_NS,
+                IdaConstants.EIDAS_NATURUAL_PREFIX)));
+
+        attributeStatement.getAttributes().forEach(a -> when(a.getNameFormat()).thenReturn(Attribute.URI_REFERENCE));
+
+        validator.validate(validatedResponse, assertion);
+
+        verify(validatedResponse, times(1)).getNamespaces();
+
+    }
+
+    @Test
+    public void validateIncorrectNamespaceURIOnResponseWhenNoneOnAttributeValueThrowsException() {
+        exception.expect(SamlTransformationErrorException.class);
+        exception.expectMessage("Attribute 'http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName' has incorrect type");
+
+        when(validatedResponse.getNamespaces()).thenReturn(Set.of(new Namespace(
+                "some other namespace uri",
+                IdaConstants.EIDAS_NATURUAL_PREFIX)));
+
+        validator.validate(validatedResponse, assertion);
+
+    }
+
 
     private Attribute generateAttribute(String name, String friendlyName, QName schemaType) {
         Attribute attribute = mock(Attribute.class);
-        XMLObject xmlObject = mock(XMLObject.class);
+        AttributeValue attributeValue = mock(AttributeValue.class);
         when(attribute.getName()).thenReturn(name);
         when(attribute.getFriendlyName()).thenReturn(friendlyName);
-        when(attribute.getAttributeValues()).thenReturn(List.of(xmlObject));
+        when(attribute.getAttributeValues()).thenReturn(List.of(attributeValue));
+        when(attributeValue.getSchemaType()).thenReturn(schemaType);
         return attribute;
     }
 

--- a/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
+++ b/hub/saml-engine/src/test/java/uk/gov/ida/hub/samlengine/validation/country/ResponseAssertionsFromCountryValidatorTest.java
@@ -65,7 +65,7 @@ public class ResponseAssertionsFromCountryValidatorTest {
 
         verify(assertionValidator).validateEidas(assertion, validatedResponse.getInResponseTo(), EXPECTED_RECIPIENT_ID);
         verify(authnStatementAssertionValidator).validate(assertion);
-        verify(eidasAttributeStatementAssertionValidator).validate(assertion);
+        verify(eidasAttributeStatementAssertionValidator).validate(validatedResponse, assertion);
     }
 
     @Test


### PR DESCRIPTION
## What
Given an Assertion AttributeValue missing its QName namespace uri, use the matching namespace uri declared in the parent Response element to build a new QName containing a uri.

A match is considered when the namespace prefix of the Assertion and Response match e.g. they both have value of `eidas-natural`.

The new derived QName is then evaluated against a set of expected AttributeValue QNames.

The parent Response object need to be carried through a series of classes in order to be available on the `EidasAttributeStatementAssertionValidator`.

## How to review
Review `EidasAttributeStatementAssertionValidator` first, and debug the new unit test on `EidasAttributeStatementAssertionValidatorTest`, which contains an eidas Response in the desired state.

## Why
We have an issue validating the qualified name (QName) of decrypted AttributeValue received from the EU Validator Proxy Node, as they do not contain the namespace uri, which is required for evaluation against a set of expected QNames.

For example, given the AttributeValue below:
````
<saml2:Assertion>
......
    <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
        xsi:type="eidas-natural:CurrentFamilyNameType">...
......
````
There is no definition for `eidas-natural` within the Assertion document.

The parent SAML Response XML document *does* contain the namespace uri i.e.
````
  <saml2p:Response .... 
      xmlns:eidas-natural="http://eidas.europa.eu/attributes/naturalperson" 
````
When evaluating assertions, we are only checking the `<Assertion>` SAML document, and have no reference to the namespace uri defined on the outer `<Response>` document.