### PR TITLE
HUB-601: Extend hub session duration

### DIFF
--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -8,7 +8,7 @@ server:
       - type: access-logstash-console
 serviceInfo:
   name: config
-userHubSessionDuration: 90m
+userHubSessionDuration: 150m
 rootDataDirectory: ${CONFIG_DATA_PATH}
 # for whatever reason this path is relative to the one above
 translationsDirectory: ../../display-locales/transactions

--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -6,7 +6,7 @@ server:
     type: classic
     appenders:
       - type: access-logstash-console
-timeoutPeriod: 90m
+timeoutPeriod: 150m
 assertionLifetime: 60m
 acceptSelfSignedCerts: true
 matchingServiceResponseWaitPeriod: 60s

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CertificatesResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CertificatesResource.java
@@ -42,8 +42,7 @@ public class CertificatesResource {
             ExceptionFactory exceptionFactory,
             ConfigConfiguration configuration,
             OCSPCertificateChainValidityChecker ocspCertificateChainValidityChecker,
-            CertificateService certificateService
-    ) {
+            CertificateService certificateService) {
         this.exceptionFactory = exceptionFactory;
         this.configuration = configuration;
         this.ocspCertificateChainValidityChecker = ocspCertificateChainValidityChecker;
@@ -60,13 +59,13 @@ public class CertificatesResource {
 
             return certificate.getBase64Encoded()
                     .map(base64 -> aCertificateDto(
-                        entityId,
-                        base64Encoded.get(),
-                        CertificateDto.KeyUse.Encryption,
-                        certificate.getFederationEntityType()))
-                    .orElseThrow(() ->exceptionFactory.createNoDataForEntityException(entityId));
+                            entityId,
+                            base64Encoded.get(),
+                            CertificateDto.KeyUse.Encryption,
+                            certificate.getFederationEntityType()))
+                    .orElseThrow(() -> exceptionFactory.createNoDataForEntityException(entityId));
 
-        } catch(NoCertificateFoundException ncfe) {
+        } catch (NoCertificateFoundException ncfe) {
             throw exceptionFactory.createNoDataForEntityException(entityId);
         } catch (CertificateDisabledException cde) {
             throw exceptionFactory.createDisabledTransactionException(entityId);
@@ -117,5 +116,4 @@ public class CertificatesResource {
                 .map(cert -> new CertificateHealthCheckDto(cert, configuration.getCertificateWarningPeriod()))
                 .collect(toList());
     }
-
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CountriesResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/CountriesResource.java
@@ -4,7 +4,6 @@ import com.codahale.metrics.annotation.Timed;
 import uk.gov.ida.hub.config.Urls;
 import uk.gov.ida.hub.config.data.LocalConfigRepository;
 import uk.gov.ida.hub.config.domain.CountryConfig;
-import uk.gov.ida.hub.config.exceptions.ExceptionFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -18,21 +17,16 @@ import java.util.Collection;
 public class CountriesResource {
 
     private final LocalConfigRepository<CountryConfig> countryConfigRepository;
-    private final ExceptionFactory exceptionFactory;
 
     @Inject
     public CountriesResource(
-            LocalConfigRepository<CountryConfig> countryConfigRepository,
-            ExceptionFactory exceptionFactory
-    ) {
+            LocalConfigRepository<CountryConfig> countryConfigRepository) {
         this.countryConfigRepository = countryConfigRepository;
-        this.exceptionFactory = exceptionFactory;
     }
-
 
     @GET
     @Timed
-    public Collection<CountryConfig> getEidasCountries(){
+    public Collection<CountryConfig> getEidasCountries() {
         return countryConfigRepository.getAllData();
     }
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/IdentityProviderResource.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 public class IdentityProviderResource {
 
     private final LocalConfigRepository<IdentityProviderConfig> identityProviderConfigRepository;
-    private IdpPredicateFactory idpPredicateFactory;
+    private final IdpPredicateFactory idpPredicateFactory;
     private final ExceptionFactory exceptionFactory;
 
     @Inject

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/MatchingServiceResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/MatchingServiceResource.java
@@ -52,5 +52,4 @@ public class MatchingServiceResource {
                 config.getOnboarding(),
                 config.getUserAccountCreationUri());
     }
-
 }

--- a/hub/config/src/main/java/uk/gov/ida/hub/config/resources/TransactionsResource.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/resources/TransactionsResource.java
@@ -41,7 +41,6 @@ public class TransactionsResource {
             ManagedEntityConfigRepository<TransactionConfig> transactionConfigRepository,
             LocalConfigRepository<TranslationData> translationConfigRepository,
             ExceptionFactory exceptionFactory) {
-
         this.transactionConfigRepository = transactionConfigRepository;
         this.translationConfigRepository = translationConfigRepository;
         this.exceptionFactory = exceptionFactory;
@@ -58,8 +57,8 @@ public class TransactionsResource {
 
         final Optional<URI> assertionConsumerServiceUri = configData.getAssertionConsumerServiceUri(assertionConsumerServiceIndex);
         // we know that the index must be here because we will have pre-validated that there will be a default for the transaction
-        return new ResourceLocationDto(assertionConsumerServiceUri
-                .orElseThrow(() -> exceptionFactory.createInvalidAssertionConsumerServiceIndexException( entityId, assertionConsumerServiceIndex.get())));
+        return new ResourceLocationDto(assertionConsumerServiceUri.orElseThrow(() ->
+                exceptionFactory.createInvalidAssertionConsumerServiceIndexException(entityId, assertionConsumerServiceIndex.get())));
     }
 
     @GET
@@ -98,18 +97,18 @@ public class TransactionsResource {
     @GET
     @Path(Urls.ConfigUrls.ENABLED_TRANSACTIONS_PATH)
     @Timed
-    public List<TransactionDisplayData> getEnabledTransactions(){
+    public List<TransactionDisplayData> getEnabledTransactions() {
         Collection<TransactionConfig> allData = transactionConfigRepository.getAll();
         return allData.stream()
-            .filter(TransactionConfig::isEnabled)
-            .map(t -> new TransactionDisplayData(t.getSimpleId().orElse(null), t.getServiceHomepage(), t.getLevelsOfAssurance(), t.getHeadlessStartpage()))
-            .collect(Collectors.toList());
+                .filter(TransactionConfig::isEnabled)
+                .map(t -> new TransactionDisplayData(t.getSimpleId().orElse(null), t.getServiceHomepage(), t.getLevelsOfAssurance(), t.getHeadlessStartpage()))
+                .collect(Collectors.toList());
     }
 
     @GET
     @Path(Urls.ConfigUrls.SINGLE_IDP_ENABLED_LIST_PATH)
     @Timed
-    public List<TransactionSingleIdpData> getSingleIDPEnabledServiceListTransactions(){
+    public List<TransactionSingleIdpData> getSingleIDPEnabledServiceListTransactions() {
         Collection<TransactionConfig> allData = transactionConfigRepository.getAll();
         return allData.stream()
                 .filter(TransactionConfig::isEnabled)
@@ -177,7 +176,7 @@ public class TransactionsResource {
     @GET
     @Path(Urls.ConfigUrls.EIDAS_ENABLED_FOR_TRANSACTION_PATH)
     @Timed
-    public boolean isEidasEnabledForTransaction(@PathParam(Urls.SharedUrls.ENTITY_ID_PARAM) String entityId){
+    public boolean isEidasEnabledForTransaction(@PathParam(Urls.SharedUrls.ENTITY_ID_PARAM) String entityId) {
         final TransactionConfig configData = getTransactionConfigData(entityId);
         return configData.isEidasEnabled();
     }
@@ -185,7 +184,7 @@ public class TransactionsResource {
     @GET
     @Path(Urls.ConfigUrls.EIDAS_COUNTRIES_FOR_TRANSACTION_PATH)
     @Timed
-    public List<String> getEidasCountries(@PathParam(Urls.SharedUrls.ENTITY_ID_PARAM) String entityId){
+    public List<String> getEidasCountries(@PathParam(Urls.SharedUrls.ENTITY_ID_PARAM) String entityId) {
         return getTransactionConfigData(entityId)
                 .getEidasCountries()
                 .orElseGet(Collections::emptyList);
@@ -198,10 +197,11 @@ public class TransactionsResource {
         return getTransactionConfigData(entityId)
                 .getShouldSignWithSHA1();
     }
+
     @GET
     @Path(Urls.ConfigUrls.MATCHING_ENABLED_FOR_TRANSACTION_PATH)
     @Timed
-    public boolean isUsingMatching(@PathParam(Urls.SharedUrls.ENTITY_ID_PARAM) String entityId){
+    public boolean isUsingMatching(@PathParam(Urls.SharedUrls.ENTITY_ID_PARAM) String entityId) {
         return getTransactionConfigData(entityId)
                 .isUsingMatching();
     }

--- a/hub/config/src/test/resources/config.yml
+++ b/hub/config/src/test/resources/config.yml
@@ -34,7 +34,7 @@ logging:
 serviceInfo:
   name: config
 
-userHubSessionDuration: 90m
+userHubSessionDuration: 150m
 
 rootDataDirectory: configuration/config-service-data/local
 


### PR DESCRIPTION
Extend hub session duration to reduce the proportion of people timing out. According to our research, extending the session to 2.5h from the current 90 mins will allow 20.8% of users timing out to complete their journey. We will measure this hypothesis and confirm the impact of the extension once this change has been deployed for a bit.

Details in [HUB-601](https://govukverify.atlassian.net/browse/HUB-601?focusedCommentId=25535&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-25535)

Consider alongside alphagov/verify-frontend#872