### PR TITLE
📈 BAU Use a single counter to record connector metrics

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/metrics/EidasConnectorMetrics.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/metrics/EidasConnectorMetrics.java
@@ -1,0 +1,47 @@
+package uk.gov.ida.hub.policy.metrics;
+
+import io.prometheus.client.Counter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Objects;
+
+public class EidasConnectorMetrics {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EidasConnectorMetrics.class);
+
+    public enum Direction {request, response}
+
+    public enum Status {ok, ko, error}
+
+    private static final Counter CONNECTOR_COUNTER = Counter.build(
+            "verify_eidas_connector_count",
+            "EIDAS Connector Journey counter with labels 'country', 'direction', 'status'")
+            .labelNames("country", "direction", "status")
+            .register();
+
+    public static void increment(String entityId, Direction direction, Status status) {
+        try {
+            String country = getCountryCode(Objects.requireNonNull(entityId));
+            CONNECTOR_COUNTER.labels(
+                    country.toLowerCase(),
+                    Objects.requireNonNull(direction.name()),
+                    Objects.requireNonNull(status.name()))
+                    .inc();
+        } catch (IllegalArgumentException | NullPointerException e) {
+            LOG.warn("Could not set counter for entityId '{}', direction '{}', status '{}'",
+                    entityId,
+                    direction,
+                    status,
+                    e);
+        }
+    }
+
+    private static String getCountryCode(String entityId) {
+        URI uri = URI.create(entityId.trim());
+        String country = uri.getHost();
+        String[] hostnameSegments = country.split("\\.");
+        return hostnameSegments.length == 0 ? country : hostnameSegments[hostnameSegments.length - 1];
+    }
+}

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/services/AuthnResponseFromCountryService.java
@@ -17,6 +17,7 @@ import uk.gov.ida.hub.policy.factories.SamlAuthnResponseTranslatorDtoFactory;
 import uk.gov.ida.hub.policy.proxy.AttributeQueryRequest;
 import uk.gov.ida.hub.policy.proxy.SamlEngineProxy;
 import uk.gov.ida.hub.policy.proxy.SamlSoapProxyProxy;
+import uk.gov.ida.hub.policy.metrics.EidasConnectorMetrics;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -70,12 +71,15 @@ public class AuthnResponseFromCountryService {
         switch (translatedResponse.getStatus()) {
             case Success:
                 responseAction = handleSuccessResponse(translatedResponse, responseFromCountry, sessionId, matchingJourney, stateController);
+                EidasConnectorMetrics.increment(translatedResponse.getIssuer(), EidasConnectorMetrics.Direction.response, EidasConnectorMetrics.Status.ok);
                 break;
             case Failure:
                 responseAction = handleAuthenticationFailedResponse(responseFromCountry, sessionId, stateController);
+                EidasConnectorMetrics.increment(translatedResponse.getIssuer(), EidasConnectorMetrics.Direction.response, EidasConnectorMetrics.Status.error);
                 break;
             default:
                 responseAction = nonSuccessResponse(sessionId);
+                EidasConnectorMetrics.increment(translatedResponse.getIssuer(), EidasConnectorMetrics.Direction.response, EidasConnectorMetrics.Status.ko);
                 break;
         }
 

--- a/hub/policy/src/test/java/uk/gov/ida/hub/policy/metrics/EidasConnectorMetricsTest.java
+++ b/hub/policy/src/test/java/uk/gov/ida/hub/policy/metrics/EidasConnectorMetricsTest.java
@@ -1,0 +1,75 @@
+package uk.gov.ida.hub.policy.metrics;
+
+import io.prometheus.client.Counter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import uk.gov.ida.hub.policy.metrics.EidasConnectorMetrics.Direction;
+import uk.gov.ida.hub.policy.metrics.EidasConnectorMetrics.Status;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class EidasConnectorMetricsTest {
+
+    @Parameterized.Parameter(0)
+    public String entityId;
+
+    @Parameterized.Parameter(1)
+    public Direction direction;
+
+    @Parameterized.Parameter(2)
+    public Status status;
+
+    @Parameterized.Parameter(3)
+    public String expectedCountryCode;
+
+    @Parameterized.Parameter(4)
+    public boolean incrementsCounter;
+
+    @Parameterized.Parameters
+    public static Collection testParams() {
+        return Arrays.asList(new Object[][]{
+                {"https://test.gov.uk" + "/" + URLEncoder.encode("test.gov.uk", Charset.defaultCharset()), Direction.response, Status.ko, "uk", true},
+                {"http://localhost", Direction.request, Status.ok, "localhost", true},
+                {"https://proxy-node.gov.uk/ServiceMetadata.de", Direction.request, Status.ok, "uk", true},
+                {"https://apple.com ", Direction.response, Status.ko, "com", true},
+                {"http://⌘.com", Direction.response, Status.ko, "n/a", false},
+                {"http://.com", Direction.response, Status.ko, "n/a", false},
+                {"http://test.gov.uk", null, Status.ko, "n/a", false},
+                {"http://test.gov.uk", Direction.response, null, "n/a", false},
+        });
+    }
+
+    @Test
+    public void testIncrementingCounterWithParameters() throws Exception {
+        Counter counter = mock(Counter.class);
+        Counter.Child counterChild = mock(Counter.Child.class);
+        setFinalStatic(EidasConnectorMetrics.class.getDeclaredField("CONNECTOR_COUNTER"), counter);
+        when(counter.labels(expectedCountryCode, direction != null ? direction.name() : null, status != null ? status.name() : null)).thenReturn(counterChild);
+        EidasConnectorMetrics.increment(entityId, direction, status);
+        if (incrementsCounter) {
+            verify(counterChild).inc();
+        } else {
+            verifyNoInteractions(counter, counterChild);
+        }
+    }
+
+    private static void setFinalStatic(Field field, Object newValue) throws Exception {
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, newValue);
+    }
+}


### PR DESCRIPTION
Use a single counter to record prometheus metrics on SAML requests and responses to EU Proxy Nodes, and classify the responses we receive.

The counter has the labels `country`, `direction` and `status`. We do not experience much traffic through the Connector Node, so the amount of data collected across all labels should be modest.

These metric will make it easier to create alerts and SLOs on questions like:

* is the OK response ratio acceptable per country
* is the request/response ratio acceptable per country
* are these ratios acceptable across countries