### PR TITLE
✅ EID-1977 eIDAS-Connectors MUST support isPassive

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestFromHubToAuthnRequestTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/outbound/EidasAuthnRequestFromHubToAuthnRequestTransformer.java
@@ -53,6 +53,7 @@ public class EidasAuthnRequestFromHubToAuthnRequestTransformer implements Functi
         authnRequest.setProtocolBinding(SAMLConstants.SAML2_POST_BINDING_URI);
         authnRequest.setConsent(StatusResponseType.UNSPECIFIED_CONSENT);
         authnRequest.setForceAuthn(true);
+        authnRequest.setIsPassive(false);
         authnRequest.setProviderName(originalRequestToCountry.getProviderName());
         authnRequest.setNameIDPolicy(getNameIDPolicy());
         authnRequest.setIssuer(samlObjectFactory.createIssuer(originalRequestToCountry.getIssuer()));


### PR DESCRIPTION
According to the EIDAS specification eIDAS Message Format v1.1-2, section 2.4.1, “eIDAS-Connectors MUST support `isPassive`. The attribute SHOULD be set to “false”.