### PR TITLE
HUB-613: adjust timeouts between Microservices

### DIFF
--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -18,7 +18,7 @@ samlEngineUri: https://saml-engine.${DOMAIN}:443
 samlSoapProxyUri: https://saml-soap-proxy.${DOMAIN}:443
 enableRetryTimeOutConnections: true
 httpClient:
-  timeout: 60s
+  timeout: 26s
   timeToLive: 10m
   connectionTimeout: 4s
   keepAlive: 10s
@@ -30,7 +30,7 @@ httpClient:
     trustStorePassword: puppet
     verifyHostname: false
 samlSoapProxyClient:
-  timeout: 60s
+  timeout: 26s
   timeToLive: 10m
   connectionTimeout: 4s
   keepAlive: 10s

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -22,7 +22,7 @@ saml:
   expectedDestination: https://www.${DOMAIN}
 enableRetryTimeOutConnections: true
 httpClient:
-  timeout: 60s
+  timeout: 24s
   timeToLive: 10m
   connectionTimeout: 4s
   keepAlive: 10s

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -11,7 +11,7 @@ saml:
   expectedDestination: https://www.${DOMAIN}
 enableRetryTimeOutConnections: true
 httpClient:
-  timeout: 60s
+  timeout: 28s
   timeToLive: 10m
   connectionTimeout: 4s
   retries: 3

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -12,7 +12,7 @@ saml:
   eidasEntityId: https://www.${DOMAIN}/SAML2/metadata/connector
 enableRetryTimeOutConnections: true
 httpClient:
-  timeout: 60s
+  timeout: 24s
   timeToLive: 10m
   connectionTimeout: 4s
   retries: 3
@@ -26,7 +26,7 @@ httpClient:
     trustStorePassword: puppet
 
 soapHttpClient:
-  timeout: 50s
+  timeout: 24s
   timeToLive: 10m
   connectionTimeout: 50s
   keepAlive: 10s

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/RedisConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/RedisConfiguration.java
@@ -24,6 +24,6 @@ public class RedisConfiguration {
     }
 
     public RedisURI getUri() {
-        return RedisURI.create(uri);
+        return RedisURI.Builder.redis(uri.getHost(), uri.getPort()).withTimeout(Duration.ofSeconds(20L)).build();
     }
 }


### PR DESCRIPTION
See : https://govukverify.atlassian.net/browse/HUB-613

Redis client's timeout will need to change to something smaller than 30 seconds. The timeout among hub services would be 
Redis client = 20s, saml-engine=24 < policy = 26 < saml-proxy = 28 < frontend = 30secs

MSA is also a bottleneck with maximum timeout of about 13 seconds. It timeout is set at 24 seconds in this PR
also see https://github.com/alphagov/verify-frontend/compare/HUB-613-adjust-timeouts-between-microservices