### PR TITLE
BAU: Update SAML Engine and Policy Redis's default timeout

### DIFF
--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/PolicyModule.java
@@ -66,6 +66,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.security.KeyStore;
+import java.time.Duration;
 
 import static java.util.Collections.singletonList;
 
@@ -149,6 +150,7 @@ public class PolicyModule extends AbstractModule {
 
     private RedisSessionStore getRedisSessionStore(RedisConfiguration config) {
         RedisClient redisClient = RedisClient.create();
+        redisClient.setDefaultTimeout(config.getTimeout());
         StatefulRedisMasterSlaveConnection<SessionId, State> redisConnection = MasterSlave.connect(
                 redisClient,
                 new SessionStoreRedisCodec(getRedisObjectMapper()),

--- a/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/RedisConfiguration.java
+++ b/hub/policy/src/main/java/uk/gov/ida/hub/policy/configuration/RedisConfiguration.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.SECONDS;
 
 public class RedisConfiguration {
 
@@ -19,11 +20,19 @@ public class RedisConfiguration {
     @JsonProperty
     private URI uri;
 
+    @Valid
+    @JsonProperty
+    private Duration timeout = Duration.of(20L, SECONDS);
+
     public Long getRecordTTL() {
         return recordTTL.getSeconds();
     }
 
     public RedisURI getUri() {
-        return RedisURI.Builder.redis(uri.getHost(), uri.getPort()).withTimeout(Duration.ofSeconds(20L)).build();
+        return RedisURI.create(uri);
+    }
+
+    public Duration getTimeout() {
+        return timeout;
     }
 }

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -641,6 +641,7 @@ public class SamlEngineModule extends AbstractModule {
                                                           RedisCodec<T, DateTime> codec,
                                                           int dbIndex) {
         RedisClient redisClient = RedisClient.create();
+        redisClient.setDefaultTimeout(config.getTimeout());
         RedisURI uri = config.getUri();
         uri.setDatabase(dbIndex);
 

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/RedisConfiguration.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/config/RedisConfiguration.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.SECONDS;
 
 public class RedisConfiguration {
 
@@ -19,11 +20,19 @@ public class RedisConfiguration {
     @JsonProperty
     private URI uri;
 
+    @Valid
+    @JsonProperty
+    private Duration timeout = Duration.of(20L, SECONDS);
+
     public Long getRecordTTL() {
         return recordTTL.getSeconds();
     }
 
     public RedisURI getUri() {
         return RedisURI.create(uri);
+    }
+
+    public Duration getTimeout() {
+        return timeout;
     }
 }


### PR DESCRIPTION
According to the Lettuce (Redis Client) documentation, it says

```
 All connections inherit a default timeout from their {@link io.lettuce.core.RedisClient} and will throw a {@link io.lettuce.core.RedisException} when non-blocking commands fail to return a result before the timeout expires. The timeout defaults to 60 seconds and may be changed via {@link io.lettuce.core.RedisClient#setDefaultTimeout} or for each individual connection.
```

This change updates Redis client's default timeout from 60 seconds to 30 seconds so that SAML Engine and Policy can send exceptions back to the downstream applications when Redis client times out. Redis client's default timeout is configurable and is set to 20 seconds by default.

Author: @adityapahuja