### PR TITLE
Test Flakiness: Increase timeout to wait for a response to policy

### DIFF
--- a/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceRequestSenderTest.java
+++ b/hub/saml-soap-proxy/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlsoapproxy/apprule/MatchingServiceRequestSenderTest.java
@@ -320,7 +320,7 @@ public class MatchingServiceRequestSenderTest {
     }
 
     private void andPolicyShouldReceiveTheResult(SessionId sessionId, String resultPath) {
-        await().atMost(5, TimeUnit.SECONDS).until(() -> !policyStubRule.getRecordedRequest().isEmpty());
+        await().atMost(10, TimeUnit.SECONDS).until(() -> !policyStubRule.getRecordedRequest().isEmpty());
         RecordedRequest recordedRequest = policyStubRule.getLastRequest();
         String path = UriBuilder.fromPath(resultPath).build(sessionId).getPath();
         ExpectedRequest expectedRequest = ExpectedRequestBuilder.expectRequest().withPath(path).build();


### PR DESCRIPTION
There is a [single integration test that is being flaky on big concourse with ~ 50% chance of passing](https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-verify-hub/jobs/build-verify-hub-microservices/builds/8).

Increase the timeout to wait for a response from stub MSA -> saml-soap-proxy -> policy, guessing that CPU/network are slower on this new concourse environment.