### PR TITLE
Revert "Swap policy, saml-engine, saml-proxy and saml-soap-proxy to using the new Fargated config service"

### DIFF
--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -41,7 +41,7 @@ samlSoapProxyClient:
     trustStorePath: /tmp/truststores/${DEPLOYMENT}/ca_certs.ts
     trustStorePassword: puppet
     verifyHostname: true
-configUri: https://config-fargate.${DOMAIN}:443
+configUri: https://config.${DOMAIN}:443
 serviceInfo:
   name: policy
 clientTrustStoreConfiguration:

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -38,7 +38,7 @@ httpClient:
 redis:
   recordTTL: PT120m
   uri: ${REDIS_HOST}
-configUri: https://config-fargate.${DOMAIN}
+configUri: https://config.${DOMAIN}
 certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}
 samlSoapProxyUri: https://saml-soap-proxy.${DOMAIN}
 serviceInfo:

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -25,7 +25,7 @@ httpClient:
     trustStorePassword: puppet
 frontendExternalUri: https://www.${DOMAIN}
 samlEngineUri: https://saml-engine.${DOMAIN}
-configUri: https://config-fargate.${DOMAIN}
+configUri: https://config.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
 certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}
 serviceInfo:

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -61,7 +61,7 @@ healthCheckSoapHttpClient:
     trustStorePassword: puppet
 
 samlEngineUri: https://saml-engine.${DOMAIN}
-configUri: https://config-fargate.${DOMAIN}
+configUri: https://config.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
 
 certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}


### PR DESCRIPTION
Reverts alphagov/verify-hub#461

Appears to have broken the build, not sure how yet.