### PR TITLE
Use saml-engine in fargate

### DIFF
--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -14,7 +14,7 @@ sessionStore:
   redis:
     recordTTL: PT150m
     uri: ${REDIS_HOST}
-samlEngineUri: https://saml-engine.${DOMAIN}:443
+samlEngineUri: https://saml-engine-fargate.${DOMAIN}:443
 samlSoapProxyUri: https://saml-soap-proxy.${DOMAIN}:443
 enableRetryTimeOutConnections: true
 httpClient:

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -24,7 +24,7 @@ httpClient:
     trustStorePath: /tmp/truststores/${DEPLOYMENT}/ca_certs.ts
     trustStorePassword: puppet
 frontendExternalUri: https://www.${DOMAIN}
-samlEngineUri: https://saml-engine.${DOMAIN}
+samlEngineUri: https://saml-engine-fargate.${DOMAIN}
 configUri: https://config-v2-fargate.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
 certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -60,7 +60,7 @@ healthCheckSoapHttpClient:
     trustStorePath: /tmp/truststores/${DEPLOYMENT}/ca_certs.ts
     trustStorePassword: puppet
 
-samlEngineUri: https://saml-engine.${DOMAIN}
+samlEngineUri: https://saml-engine-fargate.${DOMAIN}
 configUri: https://config-v2-fargate.${DOMAIN}
 policyUri: https://policy.${DOMAIN}
 


### PR DESCRIPTION
Similar to #461, where we switched to use config-in-fargate.