### PR TITLE
AUT-817: Update to use SAML SOAP Proxy on Fargate

### DIFF
--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -15,7 +15,7 @@ sessionStore:
     recordTTL: PT150m
     uri: ${REDIS_HOST}
 samlEngineUri: https://saml-engine-fargate.${DOMAIN}:443
-samlSoapProxyUri: https://saml-soap-proxy.${DOMAIN}:443
+samlSoapProxyUri: https://saml-soap-proxy-fargate.${DOMAIN}:443
 enableRetryTimeOutConnections: true
 httpClient:
   timeout: 26s

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -40,7 +40,7 @@ redis:
   uri: ${REDIS_HOST}
 configUri: https://config-v2-fargate.${DOMAIN}
 certificatesConfigCacheExpiry: ${CERTIFICATES_CONFIG_CACHE_EXPIRY:-5m}
-samlSoapProxyUri: https://saml-soap-proxy.${DOMAIN}
+samlSoapProxyUri: https://saml-soap-proxy-fargate.${DOMAIN}
 serviceInfo:
   name: saml-engine
 featureFlagConfiguration: {}


### PR DESCRIPTION
SAML SOAP Proxy is up and running on Fargate. This change updates Policy and SAML Engine to use SAML SOAP Proxy on Fargate instead of SAML SOAP Proxy on EC2 instances.

Author: @adityapahuja