### PR TITLE
java: set sensible default for java dns cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,10 @@ WORKDIR /verify-hub
 COPY configuration/$hub_app.yml /tmp/$hub_app.yml
 COPY --from=build-app /verify-hub/hub/$hub_app/build/install/$hub_app .
 
+# set a sensible default for java's DNS cache
+# if left unset the default is to cache forever
+RUN echo "networkaddress.cache.ttl=5" >> /usr/local/openjdk-11/conf/security/java.security
+
 # ARG is not available at runtime so set an env var with
 # name of app/app-config to run
 ENV HUB_APP $hub_app


### PR DESCRIPTION
by default java caches DNS (seperatly from the OS DNS cache) queries indefinitly. this is not a practical default when running in a cloud environment with dynamic addresses of load-balaners/applications/databases.

this changes the default java dns ttl to be 5s, leaving much of the caching up to the OS as is expected.