### PR TITLE
HUB-675 Fixes for verify-local-startup

### DIFF
--- a/hub/stub-event-sink/build.gradle
+++ b/hub/stub-event-sink/build.gradle
@@ -11,3 +11,7 @@ dependencies {
 apply plugin: 'application'
 ext.mainclass = 'uk.gov.ida.stub.event.sink.StubEventSinkApplication'
 mainClassName = ext.mainclass
+
+apply from: "${rootDir}/inttest.gradle"
+
+tasks.check.dependsOn(intTest)


### PR DESCRIPTION
In trying to get the docker stuff to work reliably I have modified the build.gradle file to have an integration test target as the verify-local-startup script requires it.  I have also added the empty file for the configuration of stub-event-sink.  This is also required by verify-local-startup.