### PR TITLE
BAU: Stop throwing 'allow incoming network connections' alerts

### DIFF
--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/PolicyAppRule.java
@@ -55,13 +55,8 @@ public class PolicyAppRule extends DropwizardAppRule<PolicyConfiguration> {
     @Override
     protected void before() {
         clientTrustStore.create();
-        try {
-            redis = new RedisServer(REDIS_PORT);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        redis = RedisServer.builder().setting("bind 127.0.0.1").port(REDIS_PORT).build();
         redis.start();
-
         super.before();
     }
 

--- a/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/RedisTestRule.java
+++ b/hub/policy/src/integration-test/java/uk/gov/ida/integrationtest/hub/policy/apprule/support/RedisTestRule.java
@@ -10,11 +10,7 @@ public class RedisTestRule extends ExternalResource {
     private Redis redis;
 
     public RedisTestRule(int port) {
-        try {
-            redis = new RedisServer(port);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        redis = RedisServer.builder().setting("bind 127.0.0.1").port(port).build();
     }
 
     @Override

--- a/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/RedisTestRule.java
+++ b/hub/saml-engine/src/integration-test/java/uk/gov/ida/integrationtest/hub/samlengine/apprule/support/RedisTestRule.java
@@ -10,11 +10,7 @@ public class RedisTestRule extends ExternalResource {
     private Redis redis;
 
     public RedisTestRule(int port) {
-        try {
-            redis = new RedisServer(port);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        redis = RedisServer.builder().setting("bind 127.0.0.1").port(port).build();
     }
 
     @Override

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -58,14 +58,6 @@ if ./gradlew --parallel --daemon clean build intTest installDist 2>/dev/null; th
     | sed -n 's/uk.gov.ida:\(.*\) \[\(.*\)\]/\1 \2/p' 
   tput sgr0
 
-  # redis required for policy & saml-engine
-  if ! docker ps | grep hub-redis >/dev/null
-  then
-    printf "$(tput setaf 3)Redis is required for policy and saml-engine, attempting to start redis using docker.\\n$(tput sgr0)"
-    # deliberately avoiding the normal redis port in case there's another redis running
-    docker run --rm -d -p 6378:6379 --name hub-redis redis >/dev/null
-  fi
-
   echo "Running services"
   if ./startup.sh skip-build; then
     funky_pass_banner

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -3,13 +3,17 @@
 services=${@:-"config stub-event-sink policy saml-engine saml-proxy saml-soap-proxy"}
 
 for service in $services; do
-  pkill -9 -f "${service}.jar"
+  pkill -9 -f "${service}.*.jar"
 done
 
 if docker ps | grep hub-redis >/dev/null ; then
     docker stop hub-redis
     docker rm hub-redis
 fi
+
+pushd ../verify-metadata > /dev/null
+./kill-service.sh
+popd > /dev/null
 
 exit 0
 

--- a/startup.sh
+++ b/startup.sh
@@ -8,6 +8,18 @@ pushd ../ida-hub-acceptance-tests >/dev/null
     source scripts/services.sh
     source scripts/env.sh
 
+    pushd ../verify-metadata >/dev/null
+    $(pwd)/startup.sh
+    popd >/dev/null
+
+    # redis required for policy & saml-engine
+    if ! docker ps | grep hub-redis >/dev/null
+    then
+      printf "$(tput setaf 3)Redis is required for policy and saml-engine, attempting to start redis using docker.\\n$(tput sgr0)"
+      # deliberately avoiding the normal redis port in case there's another redis running
+      docker run --rm -d -p 6378:6379 --name hub-redis redis >/dev/null
+    fi
+
     start_service stub-event-sink ../verify-hub/hub/stub-event-sink configuration/hub/stub-event-sink.yml $EVENT_SINK_PORT
     start_service config ../verify-hub/hub/config configuration/hub/config.yml $CONFIG_PORT
     start_service policy ../verify-hub/hub/policy configuration/hub/policy.yml $POLICY_PORT


### PR DESCRIPTION
This change updates embedded Redis server to bind to 127.0.0.1. This will stop Operating System (OS) from throwing 'allow incoming network connections' alerts. It updates startup.sh script to start verify-metadata (required by SAML Engine) before starting SAML Engine. It updates shutdown.sh script to shutdown all applications started by the startup.sh script properly.

I have tested pre-commit.sh, startup.sh and shutdown.sh scripts locally. They are working properly. There are no more "allow incoming network connections" alerts.

Author: @adityapahuja