### PR TITLE
HUB-733 Add environment to sentry config

### DIFF
--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -18,6 +18,7 @@ logging:
     - type: logstash-console
     - type: sentry
       dsn: ${SENTRY_DSN}
+      environment: ${SENTRY_ENV}
       threshold: ERROR
       tags: {"service-name": "config"}
 # these DEPLOYMENT environment variables should get

--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -53,6 +53,7 @@ logging:
     - type: logstash-console
     - type: sentry
       dsn: ${SENTRY_DSN}
+      environment: ${SENTRY_ENV}
       threshold: ERROR
       tags: {"service-name": "policy"}
 eidas: true

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -65,6 +65,7 @@ logging:
     - type: logstash-console
     - type: sentry
       dsn: ${SENTRY_DSN}
+      environment: ${SENTRY_ENV}
       threshold: ERROR
       tags: {"service-name": "saml-engine"}
 authnRequestIdExpirationDuration: 90m

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -42,6 +42,7 @@ logging:
     - type: logstash-console
     - type: sentry
       dsn: ${SENTRY_DSN}
+      environment: ${SENTRY_ENV}
       threshold: ERROR
       tags: {"service-name": "saml-proxy"}
 metadata:

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -87,6 +87,7 @@ logging:
     - type: logstash-console
     - type: sentry
       dsn: ${SENTRY_DSN}
+      environment: ${SENTRY_ENV}
       threshold: ERROR
       tags: {"service-name": "saml-soap-proxy"}
 


### PR DESCRIPTION
This small config change should hopefully allow the hub apps to report their correct sentry environment to sentry.