### PR TITLE
HUB533 Give Sentry the git head sha for versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,10 @@ COPY --from=build-app /verify-hub/hub/$hub_app/build/install/$hub_app .
 # if left unset the default is to cache forever
 RUN echo "networkaddress.cache.ttl=5" >> /usr/local/openjdk-11/conf/security/java.security
 
+# Get the current git head reference and set it as
+# release for Sentry
+RUN export RELEASE_VER=$(git rev-parse HEAD)
+
 # ARG is not available at runtime so set an env var with
 # name of app/app-config to run
 ENV HUB_APP $hub_app

--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -19,6 +19,7 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
+      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "config"}
 # these DEPLOYMENT environment variables should get

--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -54,6 +54,7 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
+      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "policy"}
 eidas: true

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -66,6 +66,7 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
+      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "saml-engine"}
 authnRequestIdExpirationDuration: 90m

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -43,6 +43,7 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
+      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "saml-proxy"}
 metadata:

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -88,6 +88,7 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
+      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "saml-soap-proxy"}
 


### PR DESCRIPTION
If you give Sentry some release information this can tie things up
with git hub to show us additional information about errors and
exceptions.