### PR TITLE
BAU: Upgrade saml-libs to 248

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def dependencyVersions = [
         ida_test_utils:"2.0.0-49",
         opensaml:"$opensaml_version",
         dev_pki: '1.1.0-37',
-        saml_lib:"$opensaml_version-241"
+        saml_lib:"$opensaml_version-248"
 ]
 
 subprojects {

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -108,6 +108,7 @@ country:
   metadata:
     trustAnchorUri: https://www.${DOMAIN}/SAML2/metadata/trust-anchor
     metadataSourceUri: https://www.${DOMAIN}/SAML2/metadata/aggregator
+    trustAnchorMaxRefreshDelay: 300000
     trustStore:
       store: /tmp/truststores/${DEPLOYMENT}/metadata_ca_certs.ts
       trustStorePassword: puppet


### PR DESCRIPTION
This version includes a fix for a bug where metadata resolvers were not
picking up on changes to a countries trust-anchor.

Also reduces the period in which trust-anchors are polled.