### PR TITLE
BAU: Upgrade saml-libs to 249

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ def dependencyVersions = [
         ida_test_utils:"2.0.0-49",
         opensaml:"$opensaml_version",
         dev_pki: '1.1.0-37',
-        saml_lib:"$opensaml_version-241"
+        saml_lib:"$opensaml_version-249"
 ]
 
 subprojects {


### PR DESCRIPTION
This version includes a fix for a bug where metadata resolvers were not
picking up on changes to a countries trust-anchor.