### PR TITLE
BAU Provide a registry image ARG to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM gradle:6.7.0-jdk11 as base-image
+ARG REGISTRY_IMAGE_GRADLE=gradle:6.7.0-jdk11
+FROM ${REGISTRY_IMAGE_GRADLE} as base-image
 
 USER root
 ENV GRADLE_USER_HOME /usr/gradle/.gradle
@@ -22,7 +23,8 @@ RUN gradle --console=plain \
     :hub:shared:build \
     :hub:shared:test
 
-FROM gradle:6.7.0-jdk11 as build-app
+ARG REGISTRY_IMAGE_GRADLE=gradle:6.7.0-jdk11
+FROM ${REGISTRY_IMAGE_GRADLE} as build-app
 ARG hub_app
 USER root
 ENV GRADLE_USER_HOME /usr/gradle/.gradle
@@ -57,7 +59,8 @@ RUN gradle --console=plain \
     -x :hub-saml:jar \
     -x :hub-saml-test-utils:jar
 
-FROM openjdk:11.0.9.1-jre
+ARG REGISTRY_IMAGE_JDK=openjdk:11.0.9.1-jre
+FROM ${REGISTRY_IMAGE_JDK}
 ARG hub_app
 ARG release=local-dev
 ARG conf_dir=configuration


### PR DESCRIPTION
## What
The ability to supply an image for gradle and jdk to Hub Build. The intent is to supply the [gradle](https://github.com/alphagov/verify-terraform/blob/ee016785f7a9ee3a2f60a95109143b8747100e49/environments/tools/platform/files/pipelines/vendor.yml#L268) and [jdk](https://github.com/alphagov/verify-terraform/blob/ee016785f7a9ee3a2f60a95109143b8747100e49/environments/tools/platform/files/pipelines/vendor.yml#L232) images vendored to our ECR registry. DockerHub images are set by default.
## Why
Avoid DockerHub rate limits [we are experiencing](https://cd.gds-reliability.engineering/teams/verify/pipelines/deploy-verify-hub/jobs/build-verify-hub-microservices/builds/195) on pulling gradle and jdk11.

Also see https://github.com/alphagov/verify-infrastructure-config/pull/427 which follows.