### PR TITLE
BAU Make REGISTRY_IMAGE_JDK a global build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 ARG REGISTRY_IMAGE_GRADLE=gradle:6.7.0-jdk11
+ARG REGISTRY_IMAGE_JDK=openjdk:11.0.9.1-jre
+
 FROM ${REGISTRY_IMAGE_GRADLE} as base-image
 
 USER root
@@ -23,7 +25,6 @@ RUN gradle --console=plain \
     :hub:shared:build \
     :hub:shared:test
 
-ARG REGISTRY_IMAGE_GRADLE=gradle:6.7.0-jdk11
 FROM ${REGISTRY_IMAGE_GRADLE} as build-app
 ARG hub_app
 USER root
@@ -59,7 +60,6 @@ RUN gradle --console=plain \
     -x :hub-saml:jar \
     -x :hub-saml-test-utils:jar
 
-ARG REGISTRY_IMAGE_JDK=openjdk:11.0.9.1-jre
 FROM ${REGISTRY_IMAGE_JDK}
 ARG hub_app
 ARG release=local-dev


### PR DESCRIPTION
Ensure image build args like `REGISTRY_IMAGE_JDK` have "global" scope in a multi-stage build.

This has been tested to work with both:
 `docker build -t se --build-arg hub_app=saml-engine .` 
   and
`docker build -t se --build-arg hub_app=saml-engine --build-arg REGISTRY_IMAGE_GRADLE=gradle:6.7.0-jdk14 .`