### PR TITLE
HUB-774 Update the Dockerfile to use GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-ARG REGISTRY_IMAGE_GRADLE=gradle:6.7.0-jdk11
-ARG REGISTRY_IMAGE_JDK=openjdk:11.0.9.1-jre
-
-FROM ${REGISTRY_IMAGE_GRADLE} as base-image
+FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as base-image
 
 USER root
 ENV GRADLE_USER_HOME /usr/gradle/.gradle
@@ -25,7 +22,7 @@ RUN gradle --console=plain \
     :hub:shared:build \
     :hub:shared:test
 
-FROM ${REGISTRY_IMAGE_GRADLE} as build-app
+FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as build-app
 ARG hub_app
 USER root
 ENV GRADLE_USER_HOME /usr/gradle/.gradle
@@ -60,7 +57,7 @@ RUN gradle --console=plain \
     -x :hub-saml:jar \
     -x :hub-saml-test-utils:jar
 
-FROM ${REGISTRY_IMAGE_JDK}
+FROM ghcr.io/alphagov/verify/java:openjdk-11
 ARG hub_app
 ARG release=local-dev
 ARG conf_dir=configuration


### PR DESCRIPTION
Update the Dockerfile to use Vendored containers in Github Container Registry to avoid issues with Docker Hub Rate limiting.