### PR TITLE
BAU - Rejecting unrecognised entityIds should come with a warning

### DIFF
--- a/hub/config/src/main/java/uk/gov/ida/hub/config/exceptions/ExceptionFactory.java
+++ b/hub/config/src/main/java/uk/gov/ida/hub/config/exceptions/ExceptionFactory.java
@@ -23,7 +23,7 @@ public class ExceptionFactory {
 
     public NotFoundException createNoDataForEntityException(String entityId) {
         final String message = format("''{0}'' - No data is configured for this entity.", entityId);
-        LOG.error(message);
+        LOG.warn(message);
         return new NotFoundException(message);
     }
     

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/NoKeyConfiguredForEntityExceptionMapper.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/exceptions/NoKeyConfiguredForEntityExceptionMapper.java
@@ -34,7 +34,7 @@ public class NoKeyConfiguredForEntityExceptionMapper extends AbstractContextExce
     @Override
     public Response handleException(NoKeyConfiguredForEntityException exception) {
         UUID errorId = UUID.randomUUID();
-        levelLogger.log(Level.ERROR, exception);
+        levelLogger.log(Level.WARN, exception);
         eventSinkMessageSender.audit(exception, errorId, getSessionId().orElse(SessionId.NO_SESSION_CONTEXT_IN_ERROR));
 
         return Response.status(Response.Status.BAD_REQUEST)

--- a/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/NoKeyConfiguredForEntityExceptionMapperTest.java
+++ b/hub/saml-proxy/src/test/java/uk/gov/ida/hub/samlproxy/exceptions/NoKeyConfiguredForEntityExceptionMapperTest.java
@@ -54,7 +54,7 @@ public class NoKeyConfiguredForEntityExceptionMapperTest {
     public void assertThatLogIsCreatedAtErrorLevelAndAuditIsSentToEventSink() {
         mapper.toResponse(exception);
 
-        verify(levelLogger).log(Level.ERROR, exception);
+        verify(levelLogger).log(Level.WARN, exception);
         verify(eventSinkMessageSender).audit(any(NoKeyConfiguredForEntityException.class), any(UUID.class), any(SessionId.class));
     }
 


### PR DESCRIPTION
Rejecting unrecognised `entityId`s is a correct behaviour. It should be logged as a warning, rather than an error.

This change alters logging behaviour for uncaught `NoKeyConfiguredForEntityException`s in `saml-proxy`, and when logging the creation of a `NotFoundException` when there's no data for a given `entityId` in `config`. In both cases, switching down from `ERROR` to `WARN` log entries.

FYI - I do not intend to merge this change until I've checked that cyber don't care. (ie. They _might_ consider unrecognised `entityId`s as some kind of indicator of malicious behaviour, and so they _might_ need to know that we're downgrading those logs from `ERROR` to `WARN`.)