### PR TITLE
The end of Sentry release needs to be updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN echo "networkaddress.cache.ttl=5" >> /usr/local/openjdk-11/conf/security/jav
 # Name of app/app-config to run
 ENV HUB_APP $hub_app
 # Sentry release information
-ENV RELEASE $release
+ENV SENTRY_RELEASE $release
+ENV SENTRY_DIST x86
 
 CMD bin/$HUB_APP server /tmp/$HUB_APP.yml


### PR DESCRIPTION
This hopefully will allow sentry to pick up the newly injected release
information.