### PR TITLE
Fix for broken release information

### DIFF
--- a/configuration/config.yml
+++ b/configuration/config.yml
@@ -19,7 +19,6 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
-      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "config"}
 # these DEPLOYMENT environment variables should get

--- a/configuration/policy.yml
+++ b/configuration/policy.yml
@@ -54,7 +54,6 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
-      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "policy"}
 eidas: true

--- a/configuration/saml-engine.yml
+++ b/configuration/saml-engine.yml
@@ -66,7 +66,6 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
-      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "saml-engine"}
 authnRequestIdExpirationDuration: 90m

--- a/configuration/saml-proxy.yml
+++ b/configuration/saml-proxy.yml
@@ -43,7 +43,6 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
-      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "saml-proxy"}
 metadata:

--- a/configuration/saml-soap-proxy.yml
+++ b/configuration/saml-soap-proxy.yml
@@ -88,7 +88,6 @@ logging:
     - type: sentry
       dsn: ${SENTRY_DSN}
       environment: ${SENTRY_ENV}
-      release: ${RELEASE_VER}
       threshold: ERROR
       tags: {"service-name": "saml-soap-proxy"}
 


### PR DESCRIPTION
This should fix the broken release infromation we're seeing in Sentry