### PR TITLE
HUB-814: Send VSP version info to Prometheus

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -17,6 +17,7 @@ import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.masterslave.MasterSlave;
 import io.lettuce.core.masterslave.StatefulRedisMasterSlaveConnection;
+import io.prometheus.client.Gauge;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import org.joda.time.DateTime;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
@@ -172,6 +173,8 @@ public class SamlEngineModule extends AbstractModule {
     public static final String VERIFY_METADATA_RESOLVER = "VerifyMetadataResolver";
     public static final String FED_METADATA_ENTITY_SIGNATURE_VALIDATOR = "verifySignatureValidator";
     public static final String VERIFY_METADATA_SIGNATURE_TRUST_ENGINE = "VerifyMetadataSignatureTrustEngine";
+    public static final String VSP_VERSION_METRIC = "verify_saml_engine_vsp_version";
+    public static final String VSP_VERSION_METRIC_HELP = "VSP version reported from incoming Authn requests";
     private HubTransformersFactory hubTransformersFactory = new HubTransformersFactory();
 
     @Override
@@ -826,6 +829,15 @@ public class SamlEngineModule extends AbstractModule {
     @Singleton
     private IdpAssertionMetricsCollector metricsCollector(Environment environment) {
         return new IdpAssertionMetricsCollector(environment.metrics());
+    }
+
+    @Provides
+    @Singleton
+    @Named("VspVersionGauge")
+    private Gauge vspVersionGauge() {
+        return Gauge.build(VSP_VERSION_METRIC, VSP_VERSION_METRIC_HELP)
+            .labelNames("entityId", "version")
+            .register();
     }
 
     private void registerEidasMetadataRefreshTask(Environment environment, EidasMetadataResolverRepository eidasMetadataResolverRepository, String name){

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/SamlEngineModule.java
@@ -174,7 +174,7 @@ public class SamlEngineModule extends AbstractModule {
     public static final String FED_METADATA_ENTITY_SIGNATURE_VALIDATOR = "verifySignatureValidator";
     public static final String VERIFY_METADATA_SIGNATURE_TRUST_ENGINE = "VerifyMetadataSignatureTrustEngine";
     public static final String VSP_VERSION_METRIC = "verify_saml_engine_vsp_version";
-    public static final String VSP_VERSION_METRIC_HELP = "VSP version reported from incoming Authn requests";
+    public static final String VSP_VERSION_METRIC_HELP = "VSP version by entityId, reported from incoming Authn requests";
     private HubTransformersFactory hubTransformersFactory = new HubTransformersFactory();
 
     @Override

--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpAuthnRequestTranslatorService.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/services/RpAuthnRequestTranslatorService.java
@@ -1,8 +1,7 @@
 package uk.gov.ida.hub.samlengine.services;
 
+import io.prometheus.client.Gauge;
 import org.opensaml.saml.saml2.core.AuthnRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.ida.hub.samlengine.contracts.SamlRequestWithAuthnRequestInformationDto;
 import uk.gov.ida.hub.samlengine.contracts.TranslatedAuthnRequestDto;
 import uk.gov.ida.hub.samlengine.logging.MdcHelper;
@@ -12,21 +11,23 @@ import uk.gov.ida.saml.hub.domain.AuthnRequestFromRelyingParty;
 import uk.gov.ida.saml.hub.transformers.inbound.AuthnRequestToIdaRequestFromRelyingPartyTransformer;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 public class RpAuthnRequestTranslatorService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RpAuthnRequestTranslatorService.class);
-
     private final StringToOpenSamlObjectTransformer<AuthnRequest> stringToAuthnRequestTransformer;
     private final AuthnRequestToIdaRequestFromRelyingPartyTransformer authnRequestToIdaRequestFromRelyingPartyTransformer;
+    private final Gauge vspVersionGauge;
 
     @Inject
     public RpAuthnRequestTranslatorService(
         StringToOpenSamlObjectTransformer<AuthnRequest> stringToAuthnRequestTransformer,
-        AuthnRequestToIdaRequestFromRelyingPartyTransformer authnRequestToIdaRequestFromRelyingPartyTransformer
+        AuthnRequestToIdaRequestFromRelyingPartyTransformer authnRequestToIdaRequestFromRelyingPartyTransformer,
+        @Named("VspVersionGauge") Gauge vspVersionGauge
     ) {
         this.stringToAuthnRequestTransformer = stringToAuthnRequestTransformer;
         this.authnRequestToIdaRequestFromRelyingPartyTransformer = authnRequestToIdaRequestFromRelyingPartyTransformer;
+        this.vspVersionGauge = vspVersionGauge;
     }
 
     public TranslatedAuthnRequestDto translate(SamlRequestWithAuthnRequestInformationDto samlRequestWithAuthnRequestInformationDto) {
@@ -37,12 +38,12 @@ public class RpAuthnRequestTranslatorService {
         AuthnRequestFromRelyingParty authnRequestFromRelyingParty = authnRequestToIdaRequestFromRelyingPartyTransformer.apply(authnRequest);
 
         if (authnRequestFromRelyingParty.getVerifyServiceProviderVersion().isPresent()) {
-            LOG.info(String.format(
-                "Issuer %s uses VSP version %s",
-                authnRequestFromRelyingParty.getIssuer(),
-                authnRequestFromRelyingParty.getVerifyServiceProviderVersion().get()
-            ));
-        }
+            vspVersionGauge
+                .labels(
+                        authnRequestFromRelyingParty.getIssuer(),
+                        authnRequestFromRelyingParty.getVerifyServiceProviderVersion().get())
+                .set(1.0);
+        };
 
         UnknownMethodAlgorithmLogger.probeAuthnRequestForMethodAlgorithm(authnRequestFromRelyingParty);
 


### PR DESCRIPTION
We want to be able to easily see what version of the VSP services are
using.

This takes the version provided in authn requests and provides it to
Prometheus as a gauge.

The metric value of 1.0 is not the interesting part, as is only used as
a vehicle for the labels which describe the entity ID and the version.
It's only provided as metrics must provide a double value.