### PR TITLE
HUB-813 Update run.Dockerfile to use Java 11

### DIFF
--- a/run.Dockerfile
+++ b/run.Dockerfile
@@ -1,4 +1,4 @@
-FROM govukverify/java8
+FROM ghcr.io/alphagov/verify/java:openjdk-11
 
 ARG config_location
 ARG app_name


### PR DESCRIPTION
This uodates the run.Dockerfile to use the same image as our other Dockerfiles