### PR TITLE
BAU: Don't error for dual-running encryption certs

### DIFF
--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/api/HubTransformersFactory.java
@@ -42,7 +42,6 @@ import uk.gov.ida.saml.hub.domain.HubAttributeQueryRequest;
 import uk.gov.ida.saml.hub.domain.HubEidasAttributeQueryRequest;
 import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.saml.hub.domain.InboundResponseFromIdp;
-import uk.gov.ida.saml.hub.domain.InboundResponseFromMatchingService;
 import uk.gov.ida.saml.hub.domain.MatchingServiceHealthCheckRequest;
 import uk.gov.ida.saml.hub.factories.AttributeFactory_1_1;
 import uk.gov.ida.saml.hub.factories.AttributeQueryAttributeFactory;
@@ -87,6 +86,7 @@ import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseF
 import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
 import uk.gov.ida.saml.hub.validators.response.matchingservice.EncryptedResponseFromMatchingServiceValidator;
 import uk.gov.ida.saml.hub.validators.response.matchingservice.HealthCheckResponseFromMatchingServiceValidator;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.MatchingServiceResponseValidator;
 import uk.gov.ida.saml.hub.validators.response.matchingservice.ResponseAssertionsFromMatchingServiceValidator;
 import uk.gov.ida.saml.metadata.domain.HubIdentityProviderMetadataDto;
 import uk.gov.ida.saml.metadata.transformers.HubIdentityProviderMetadataDtoToEntityDescriptorTransformer;
@@ -111,17 +111,23 @@ import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
 import uk.gov.ida.saml.serializers.XmlObjectToElementTransformer;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public class HubTransformersFactory {
 
     private final CoreTransformersFactory coreTransformersFactory;
+    private final DecrypterFactory decrypterFactory;
+    private final EncryptionAlgorithmValidator encryptionAlgorithmValidator;
 
     public HubTransformersFactory() {
         coreTransformersFactory = new CoreTransformersFactory();
+        decrypterFactory = new DecrypterFactory();
+        encryptionAlgorithmValidator = new EncryptionAlgorithmValidator();
     }
 
     public Function<OutboundResponseFromHub, String> getOutboundResponseFromHubToStringTransformer(
@@ -311,26 +317,30 @@ public class HubTransformersFactory {
 
     public DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer getResponseToInboundResponseFromMatchingServiceTransformer(
             SigningKeyStore signingKeyStore,
-            IdaKeyStore keyStore, String hubEntityId) {
-        return new DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer(
-                new InboundResponseFromMatchingServiceUnmarshaller(
-                        getAssertionToPassthroughAssertionTransformer(),
-                        new MatchingServiceIdaStatusUnmarshaller()
-                ),
-                getSamlResponseSignatureValidator(getSignatureValidator(signingKeyStore)),
-                this.<InboundResponseFromMatchingService>getSamlResponseAssertionDecrypter(keyStore),
-                getSamlAssertionsSignatureValidator(getSignatureValidator(signingKeyStore)),
-                new EncryptedResponseFromMatchingServiceValidator(),
-                new ResponseAssertionsFromMatchingServiceValidator(
-                        new AssertionValidator(
-                                new IssuerValidator(),
-                                new AssertionSubjectValidator(),
-                                new AssertionAttributeStatementValidator(),
-                                new BasicAssertionSubjectConfirmationValidator()
-                        ),
-                        hubEntityId
-                )
+            IdaKeyStore keyStore,
+            String hubEntityId) {
+        ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator = new ResponseAssertionsFromMatchingServiceValidator(
+            new AssertionValidator(
+                new IssuerValidator(),
+                new AssertionSubjectValidator(),
+                new AssertionAttributeStatementValidator(),
+                new BasicAssertionSubjectConfirmationValidator()
+            ),
+            hubEntityId
         );
+        InboundResponseFromMatchingServiceUnmarshaller inboundResponseFromMatchingServiceUnmarshaller = new InboundResponseFromMatchingServiceUnmarshaller(
+            getAssertionToPassthroughAssertionTransformer(),
+            new MatchingServiceIdaStatusUnmarshaller()
+        );
+        SignatureValidator signatureValidator = getSignatureValidator(signingKeyStore);
+        MatchingServiceResponseValidator matchingServiceResponseValidator = new MatchingServiceResponseValidator(
+            new EncryptedResponseFromMatchingServiceValidator(),
+            getSamlResponseSignatureValidator(signatureValidator),
+            getSamlResponseAssertionDecrypters(keyStore),
+            getSamlAssertionsSignatureValidator(signatureValidator),
+            responseAssertionsFromMatchingServiceValidator
+        );
+        return new DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer(matchingServiceResponseValidator, inboundResponseFromMatchingServiceUnmarshaller);
     }
 
     /**
@@ -411,7 +421,7 @@ public class HubTransformersFactory {
             IdExpirationCache<String> assertionIdCache,
             String hubEntityId) {
         IdpResponseValidator validator = new IdpResponseValidator(this.getSamlResponseSignatureValidator(idpSignatureValidator),
-            this.getSamlResponseAssertionDecrypter(keyStore),
+            this.getSamlResponseAssertionDecrypters(keyStore),
                 getSamlAssertionsSignatureValidator(idpSignatureValidator),
                 new EncryptedResponseFromIdpValidator<>(new SamlStatusToIdaStatusCodeMapper()),
             new DestinationValidator(expectedDestinationHost, expectedEndpoint),
@@ -435,7 +445,7 @@ public class HubTransformersFactory {
         final SamlAuthnRequestValidityDurationConfiguration samlAuthnRequestValidityDurationConfiguration
     ) {
         List<Credential> credential = new IdaKeyStoreCredentialRetriever(decryptionKeyStore).getDecryptingCredentials();
-        Decrypter decrypter = new DecrypterFactory().createDecrypter(credential);
+        Decrypter decrypter = decrypterFactory.createDecrypter(credential);
 
         return new AuthnRequestToIdaRequestFromRelyingPartyTransformer(
             new AuthnRequestFromRelyingPartyUnmarshaller(decrypter),
@@ -568,11 +578,18 @@ public class HubTransformersFactory {
         );
     }
 
-    private AssertionDecrypter getSamlResponseAssertionDecrypter(IdaKeyStore keyStore) {
+    private List<AssertionDecrypter> getSamlResponseAssertionDecrypters(IdaKeyStore keyStore) {
         IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
-        DecrypterFactory decrypterFactory = new DecrypterFactory();
-        Decrypter decrypter = decrypterFactory.createDecrypter(idaKeyStoreCredentialRetriever.getDecryptingCredentials());
-        return new AssertionDecrypter(new EncryptionAlgorithmValidator(), decrypter);
+        return idaKeyStoreCredentialRetriever.getDecryptingCredentials().stream()
+            .map(this::getAssertionDecrypter)
+            .collect(Collectors.toList());
+    }
+
+    private AssertionDecrypter getAssertionDecrypter(Credential credential) {
+        return new AssertionDecrypter(
+            encryptionAlgorithmValidator,
+            decrypterFactory.createDecrypter(Collections.singletonList(credential))
+        );
     }
 
     private SignatureValidator getSignatureValidator(SigningKeyStore signingKeyStore) {

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer.java
@@ -13,6 +13,7 @@ import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
 
+import java.util.List;
 import java.util.function.Function;
 
 public class DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer implements Function<Response, InboundResponseFromIdp> {
@@ -24,7 +25,7 @@ public class DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer implements
     public DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer(
             IdaResponseFromIdpUnmarshaller idaResponseUnmarshaller,
             SamlResponseSignatureValidator samlResponseSignatureValidator,
-            AssertionDecrypter assertionDecrypter,
+            List<AssertionDecrypter> assertionDecrypters,
             SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
             EncryptedResponseFromIdpValidator responseFromIdpValidator,
             DestinationValidator responseDestinationValidator,
@@ -32,7 +33,7 @@ public class DecoratedSamlResponseToIdaResponseIssuedByIdpTransformer implements
 
         this(new IdpResponseValidator(
             samlResponseSignatureValidator,
-            assertionDecrypter,
+            assertionDecrypters,
             samlAssertionsSignatureValidator,
             responseFromIdpValidator,
             responseDestinationValidator,

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/transformers/inbound/providers/DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer.java
@@ -1,14 +1,13 @@
 package uk.gov.ida.saml.hub.transformers.inbound.providers;
 
-import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
-import org.opensaml.saml.saml2.metadata.AttributeAuthorityDescriptor;
-import uk.gov.ida.saml.hub.validators.response.matchingservice.EncryptedResponseFromMatchingServiceValidator;
-import uk.gov.ida.saml.security.AssertionDecrypter;
-import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.hub.domain.InboundResponseFromMatchingService;
 import uk.gov.ida.saml.hub.transformers.inbound.InboundResponseFromMatchingServiceUnmarshaller;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.EncryptedResponseFromMatchingServiceValidator;
+import uk.gov.ida.saml.hub.validators.response.matchingservice.MatchingServiceResponseValidator;
 import uk.gov.ida.saml.hub.validators.response.matchingservice.ResponseAssertionsFromMatchingServiceValidator;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
@@ -18,39 +17,38 @@ import java.util.List;
 public class DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer {
 
     private final InboundResponseFromMatchingServiceUnmarshaller responseUnmarshaller;
-    private final SamlResponseSignatureValidator samlResponseSignatureValidator;
-    private final AssertionDecrypter samlResponseAssertionDecrypter;
-    private final SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
-    private final EncryptedResponseFromMatchingServiceValidator responseFromMatchingServiceValidator;
-    private final ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator;
+    private final MatchingServiceResponseValidator matchingServiceResponseValidator;
+
+    @Deprecated
+    public DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer(
+        InboundResponseFromMatchingServiceUnmarshaller responseUnmarshaller,
+        SamlResponseSignatureValidator samlResponseSignatureValidator,
+        List<AssertionDecrypter> samlResponseAssertionDecrypters,
+        SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
+        EncryptedResponseFromMatchingServiceValidator responseFromMatchingServiceValidator,
+        ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator) {
+
+        this(new MatchingServiceResponseValidator(
+            responseFromMatchingServiceValidator,
+            samlResponseSignatureValidator,
+            samlResponseAssertionDecrypters,
+            samlAssertionsSignatureValidator,
+            responseAssertionsFromMatchingServiceValidator
+        ), responseUnmarshaller);
+    }
 
     public DecoratedSamlResponseToInboundResponseFromMatchingServiceTransformer(
-            InboundResponseFromMatchingServiceUnmarshaller responseUnmarshaller,
-            SamlResponseSignatureValidator samlResponseSignatureValidator,
-            AssertionDecrypter samlResponseAssertionDecrypter,
-            SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
-            EncryptedResponseFromMatchingServiceValidator responseFromMatchingServiceValidator,
-            ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator) {
-
+        MatchingServiceResponseValidator matchingServiceResponseValidator,
+        InboundResponseFromMatchingServiceUnmarshaller responseUnmarshaller
+        ) {
         this.responseUnmarshaller = responseUnmarshaller;
-        this.samlResponseSignatureValidator = samlResponseSignatureValidator;
-        this.samlResponseAssertionDecrypter = samlResponseAssertionDecrypter;
-        this.samlAssertionsSignatureValidator = samlAssertionsSignatureValidator;
-        this.responseFromMatchingServiceValidator = responseFromMatchingServiceValidator;
-        this.responseAssertionsFromMatchingServiceValidator = responseAssertionsFromMatchingServiceValidator;
+        this.matchingServiceResponseValidator = matchingServiceResponseValidator;
     }
 
     public InboundResponseFromMatchingService transform(Response response) {
-        responseFromMatchingServiceValidator.validate(response);
-
-        /* Decrypt and validate assertions independently. */
-        ValidatedResponse validatedResponse = samlResponseSignatureValidator.validate(response, AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
-        /* Decrypt and validate assertions independently. */
-        List<Assertion> decryptedAssertions = samlResponseAssertionDecrypter.decryptAssertions(validatedResponse);
-        ValidatedAssertions validatedAssertions = samlAssertionsSignatureValidator.validate(decryptedAssertions, AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
-
-        responseAssertionsFromMatchingServiceValidator.validate(validatedResponse, validatedAssertions);
-
+        matchingServiceResponseValidator.validate(response);
+        ValidatedResponse validatedResponse = matchingServiceResponseValidator.getValidatedResponse();
+        ValidatedAssertions validatedAssertions = matchingServiceResponseValidator.getValidatedAssertions();
         return responseUnmarshaller.fromSaml(validatedResponse, validatedAssertions);
     }
 }

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/idp/IdpResponseValidator.java
@@ -3,11 +3,15 @@ package uk.gov.ida.saml.hub.validators.response.idp;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 import uk.gov.ida.saml.core.validators.DestinationValidator;
 import uk.gov.ida.saml.hub.validators.response.idp.components.EncryptedResponseFromIdpValidator;
 import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.exception.SamlFailedToDecryptException;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
 import uk.gov.ida.saml.security.validators.ValidatedResponse;
 import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
@@ -15,8 +19,10 @@ import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValida
 import java.util.List;
 
 public class IdpResponseValidator {
+    private static final Logger log = LoggerFactory.getLogger(IdpResponseValidator.class.getSimpleName());
+
     private final SamlResponseSignatureValidator samlResponseSignatureValidator;
-    private final AssertionDecrypter assertionDecrypter;
+    private final List<AssertionDecrypter> assertionDecrypters;
     private final SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
     private final EncryptedResponseFromIdpValidator responseFromIdpValidator;
     private final DestinationValidator responseDestinationValidator;
@@ -25,13 +31,13 @@ public class IdpResponseValidator {
     private ValidatedAssertions validatedAssertions;
 
     public IdpResponseValidator(SamlResponseSignatureValidator samlResponseSignatureValidator,
-                                AssertionDecrypter assertionDecrypter,
+                                List<AssertionDecrypter> assertionDecrypters,
                                 SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
                                 EncryptedResponseFromIdpValidator responseFromIdpValidator,
                                 DestinationValidator responseDestinationValidator,
                                 ResponseAssertionsFromIdpValidator responseAssertionsFromIdpValidator) {
         this.samlResponseSignatureValidator = samlResponseSignatureValidator;
-        this.assertionDecrypter = assertionDecrypter;
+        this.assertionDecrypters = assertionDecrypters;
         this.samlAssertionsSignatureValidator = samlAssertionsSignatureValidator;
         this.responseFromIdpValidator = responseFromIdpValidator;
         this.responseDestinationValidator = responseDestinationValidator;
@@ -51,8 +57,20 @@ public class IdpResponseValidator {
         responseDestinationValidator.validate(response.getDestination());
 
         validatedResponse = samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        List<Assertion> decryptedAssertions = null;
 
-        List<Assertion> decryptedAssertions = assertionDecrypter.decryptAssertions(validatedResponse);
+        for (AssertionDecrypter assertionDecrypter : assertionDecrypters) {
+            try {
+                decryptedAssertions = assertionDecrypter.decryptAssertions(validatedResponse);
+            } catch(SamlFailedToDecryptException e) {
+                log.warn("Failed to decrypt IDP assertions with one of the decrypters", e);
+            }
+        }
+
+        if (decryptedAssertions == null) {
+            throw new SamlFailedToDecryptException("Could not decrypt IDP assertions with any of the decrypters", Level.ERROR);
+        }
+
         validatedAssertions = samlAssertionsSignatureValidator.validate(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
         responseAssertionsFromIdpValidator.validate(validatedResponse, validatedAssertions);

--- a/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/MatchingServiceResponseValidator.java
+++ b/hub-saml/src/main/java/uk/gov/ida/saml/hub/validators/response/matchingservice/MatchingServiceResponseValidator.java
@@ -1,0 +1,74 @@
+package uk.gov.ida.saml.hub.validators.response.matchingservice;
+
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.AttributeAuthorityDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.exception.SamlFailedToDecryptException;
+import uk.gov.ida.saml.security.validators.ValidatedAssertions;
+import uk.gov.ida.saml.security.validators.ValidatedResponse;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+import java.util.List;
+
+public class MatchingServiceResponseValidator {
+    private static final Logger log = LoggerFactory.getLogger(MatchingServiceResponseValidator.class.getSimpleName());
+
+    private final EncryptedResponseFromMatchingServiceValidator responseFromMatchingServiceValidator;
+    private final SamlResponseSignatureValidator samlResponseSignatureValidator;
+    private final List<AssertionDecrypter> assertionDecrypters;
+    private final SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+    private final ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator;
+    private ValidatedResponse validatedResponse;
+    private ValidatedAssertions validatedAssertions;
+
+    public MatchingServiceResponseValidator(
+        EncryptedResponseFromMatchingServiceValidator responseFromMatchingServiceValidator,
+        SamlResponseSignatureValidator samlResponseSignatureValidator,
+        List<AssertionDecrypter> assertionDecrypters,
+        SamlAssertionsSignatureValidator samlAssertionsSignatureValidator,
+        ResponseAssertionsFromMatchingServiceValidator responseAssertionsFromMatchingServiceValidator) {
+        this.responseFromMatchingServiceValidator = responseFromMatchingServiceValidator;
+        this.samlResponseSignatureValidator = samlResponseSignatureValidator;
+        this.assertionDecrypters = assertionDecrypters;
+        this.samlAssertionsSignatureValidator = samlAssertionsSignatureValidator;
+        this.responseAssertionsFromMatchingServiceValidator = responseAssertionsFromMatchingServiceValidator;
+    }
+
+    public ValidatedResponse getValidatedResponse() {
+        return validatedResponse;
+    }
+
+    public ValidatedAssertions getValidatedAssertions() {
+        return validatedAssertions;
+    }
+
+    public void validate(Response response) {
+        responseFromMatchingServiceValidator.validate(response);
+
+        validatedResponse = samlResponseSignatureValidator.validate(response, AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
+
+        /* Decrypt and validate assertions independently. */
+        List<Assertion> decryptedAssertions = null;
+
+        for (AssertionDecrypter assertionDecrypter : assertionDecrypters) {
+            try {
+                decryptedAssertions = assertionDecrypter.decryptAssertions(validatedResponse);
+            } catch(SamlFailedToDecryptException e) {
+                log.warn("Failed to decrypt MSA assertions with one of the decrypters", e);
+            }
+        }
+
+        if (decryptedAssertions == null) {
+            throw new SamlFailedToDecryptException("Could not decrypt MSA assertions with any of the decrypters", Level.ERROR);
+        }
+
+        validatedAssertions = samlAssertionsSignatureValidator.validate(decryptedAssertions, AttributeAuthorityDescriptor.DEFAULT_ELEMENT_NAME);
+
+        responseAssertionsFromMatchingServiceValidator.validate(validatedResponse, validatedAssertions);
+    }
+}


### PR DESCRIPTION
Currently, the Hub makes a lot of noise when dual running its old and
new SAML encryption certificates. This shows up in Sentry and floods the
logs. We should only be raising an exception if decryption has failed for all the
certificates.

The main change involves passing a `List<AssertionDecrypter>` to the
`IdpResponseValidator` and `MatchingServiceResponseValidator` who
(despite their name) are also responsible for decrypting the assertions
in the IDP response and MSA response, respectively. The validator tries
to decrypt with each `AssertionDecrypter` in turn, logging a warning on
failure. If the validator can't decrypt with any of the
`AssertionDecrypter`s, it throws a `SamlFailedToDecryptException` which
should appear in our Sentry alerting as usual.