### PR TITLE
BAU: Remove Ben Maines versions versions plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,12 @@ buildscript {
         classpath 'com.github.spullara.mustache.java:compiler:0.8.10',
                 'org.yaml:snakeyaml:1.10',
                 'uk.gov.ida:ida-gradle:1.1.0-24',
-                'com.google.guava:guava:23.0',
-                'com.github.ben-manes:gradle-versions-plugin:0.20.0'
+                'com.google.guava:guava:23.0'
     }
 }
 
 apply from: 'idea.gradle'
 apply plugin: 'java'
-apply plugin: 'com.github.ben-manes.versions'
 
 allprojects {
     apply plugin: 'jacoco'

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -52,12 +52,6 @@ echo "Running tests"
 ./shutdown.sh
 
 if ./gradlew --parallel --daemon clean build intTest installDist 2>/dev/null; then
-  echo "Checking for dependency updates:"
-  tput setaf 3
-  ./gradlew -q dependencyUpdates -Drevision=release \
-    | sed -n 's/uk.gov.ida:\(.*\) \[\(.*\)\]/\1 \2/p' 
-  tput sgr0
-
   echo "Running services"
   if ./startup.sh skip-build; then
     funky_pass_banner


### PR DESCRIPTION
We don't seem to be using it anywhere other than the pre-commit.sh
script. We don't use pre-commit anywhere apart from locally.

The version we were using was from the Jenkins plugins repo, which has
now been removed (we no longer use Jenkins). Rather than doing the work
to add the version we want to our artifactory, we'd rather just remove
the plugin.