### PR TITLE
HUB-866: Publish to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,21 +17,29 @@ buildscript {
     }
 }
 
-apply from: 'idea.gradle'
-apply plugin: 'java'
-
-allprojects {
-    apply plugin: 'jacoco'
+plugins {
+    id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
-
-repositories {
-    jcenter()
-}
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 ext {
     opensaml_version = '3.4.3'
     dropwizard_version = '1.3.18'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
+}
+
+allprojects {
+    apply plugin: 'java'
+    apply plugin: 'jacoco'
+    group = "uk.gov.ida"
+    version = "$build_version"
+}
+
+apply from: 'idea.gradle'
+apply from: 'publish.gradle'
+
+repositories {
+    jcenter()
 }
 
 def dependencyVersions = [
@@ -45,11 +53,6 @@ def dependencyVersions = [
 ]
 
 subprojects {
-    apply plugin: 'java'
-
-    group = "uk.gov.ida"
-    version = "0.1.$version"
-
     repositories {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
             logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')

--- a/hub-saml-test-utils/build.gradle
+++ b/hub-saml-test-utils/build.gradle
@@ -1,35 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.4"
     id 'java-library'
-}
-
-apply plugin: 'maven-publish'
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            groupId = "uk.gov.ida"
-            version = "$build_version"
-        }
-    }
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-    publications = ['mavenJava']
-    publish = true
-    pkg {
-        repo = 'maven-test'
-        name = 'verify-hub-saml-test-utils'
-        userOrg = 'alphagov'
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/alphagov/verify-hub.git'
-        version {
-            name = "$build_version"
-        }
-    }
 }
 
 dependencies {

--- a/hub-saml/build.gradle
+++ b/hub-saml/build.gradle
@@ -1,35 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.4"
     id 'java-library'
-}
-
-apply plugin: 'maven-publish'
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            groupId = "uk.gov.ida"
-            version = "$build_version"
-        }
-    }
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-    publications = ['mavenJava']
-    publish = true
-    pkg {
-        repo = 'maven-test'
-        name = 'verify-hub-saml'
-        userOrg = 'alphagov'
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/alphagov/verify-hub.git'
-        version {
-            name = "$build_version"
-        }
-    }
 }
 
 dependencies {

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,68 @@
+nexusPublishing {
+    useStaging = true
+    repositories {
+        sonatype {
+            // because we registered in Sonatype after 24 Feb 2021, we provide these URIs
+            // see: https://github.com/gradle-nexus/publish-plugin/blob/master/README.md
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = System.getenv("SONATYPE_USERNAME")
+            password = System.getenv("SONATYPE_PASSWORD")
+        }
+    }
+}
+
+subprojects.findAll { it.name in ['hub-saml', 'hub-saml-test-utils'] }.each {proj ->
+    configure(proj) {
+        apply plugin: 'maven-publish'
+        apply plugin: 'signing'
+
+        java {
+            withJavadocJar()
+            withSourcesJar()
+        }
+
+        signing {
+            useInMemoryPgpKeys(
+                    System.getenv("MAVEN_CENTRAL_SIGNING_KEY"),
+                    System.getenv("MAVEN_CENTRAL_SIGNING_KEY_PASSWORD")
+            )
+            sign publishing.publications
+        }
+
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    from components.java
+                    pom {
+                        name = proj.name
+                        packaging = 'jar'
+                        url = 'https://github.com/alphagov/verify-hub'
+                        artifactId = proj.name
+
+                        scm {
+                            url = 'https://github.com/alphagov/verify-hub'
+                            connection = 'scm:git:git://github.com/alphagov/verify-hub.git'
+                            developerConnection = 'scm:git:ssh://git@github.com:alphagov/verify-hub.git'
+                        }
+
+                        licenses {
+                            license {
+                                name = 'MIT Licence'
+                                url = 'https://github.com/alphagov/verify-hub/blob/master/LICENCE'
+                                distribution = 'repo'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                name = 'GDS Developers'
+                            }
+                        }
+                    } // pom
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
**Pipeline changes here: https://github.com/alphagov/verify-infrastructure-config/pull/539**

Bintray is shutting down. This adds the gradle config to publish to
Sonatype, which is then mirrored to MavenCentral.

This has been run locally and is publishing as expected to Sonatype.