### PR TITLE
HUB-866: Set description in publishing

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -36,6 +36,7 @@ subprojects.findAll { it.name in ['hub-saml', 'hub-saml-test-utils'] }.each {pro
                     from components.java
                     pom {
                         name = proj.name
+                        description = proj.description
                         packaging = 'jar'
                         url = 'https://github.com/alphagov/verify-hub'
                         artifactId = proj.name


### PR DESCRIPTION
Without this SonaType refuses to close the repo and so can't be mirrored
to Maven Central