### PR TITLE
HUB-866: Add publish.gradle to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY build.gradle build.gradle
 COPY settings.gradle settings.gradle
 COPY idea.gradle idea.gradle
 COPY inttest.gradle inttest.gradle
+COPY publish.gradle publish.gradle
 
 RUN gradle downloadDependencies
 


### PR DESCRIPTION
We've added a new gradle file (`publish.gradle`) which is referenced in
the `build.gradle` file. If we don't copy the new file into the image
gradle breaks when being run during the build.