### PR TITLE
HUB-866: Make sure hub sub projects have a description

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -36,7 +36,7 @@ subprojects.findAll { it.name in ['hub-saml', 'hub-saml-test-utils'] }.each {pro
                     from components.java
                     pom {
                         name = proj.name
-                        description = proj.description
+                        description = 'Library for ' + project.name
                         packaging = 'jar'
                         url = 'https://github.com/alphagov/verify-hub'
                         artifactId = proj.name


### PR DESCRIPTION
The `proj.description` property was blank. This resulted in the
description not being set in the POM. Sonatype was refusing to close
because of this.

Have published this to Sonatype and confirmed that the description is
now set in the POM.