### PR TITLE
[HUB-841] Update Dockerfiles to use Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as base-image
+ARG REGISTRY_IMAGE_GRADLE=gradle:6.7.0-jdk11
+ARG REGISTRY_IMAGE_JDK=openjdk:11.0.9.1-jre
+
+FROM ${REGISTRY_IMAGE_GRADLE} as base-image
 
 USER root
 ENV GRADLE_USER_HOME /usr/gradle/.gradle
@@ -23,7 +26,7 @@ RUN gradle --console=plain \
     :hub:shared:build \
     :hub:shared:test
 
-FROM ghcr.io/alphagov/verify/gradle:gradle-jdk11 as build-app
+FROM ${REGISTRY_IMAGE_GRADLE} as build-app
 ARG hub_app
 USER root
 ENV GRADLE_USER_HOME /usr/gradle/.gradle
@@ -60,7 +63,7 @@ RUN gradle --console=plain \
     -x :hub-saml:jar \
     -x :hub-saml-test-utils:jar
 
-FROM ghcr.io/alphagov/verify/java:openjdk-11
+FROM ${REGISTRY_IMAGE_JDK}
 ARG hub_app
 ARG release=local-dev
 ARG conf_dir=configuration

--- a/run.Dockerfile
+++ b/run.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/java:openjdk-11
+FROM  openjdk:11.0.9.1-jre
 
 ARG config_location
 ARG app_name


### PR DESCRIPTION
Following the decision to use a paid Docker Hub account in the pipeline we'll need to update all our Docker images again to go back to pulling from Docker Hub instead of from GitHub Container Registry.

I've moved the references back to what they originally were when changed here https://github.com/alphagov/verify-hub/commit/db7f531958f2c65f8c26786cda4de40ca8b47d39