### PR TITLE
BAU: Pin JRE in Dockerfile to 11.0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG registry_image_gradle=gradle:6.7.0-jdk11
-ARG registry_image_jdk=openjdk@sha256:e12869c3edad94f2c23a40d0fe21b307a1a9177a621c9b902ecfa02897ba93f7 #11.0.11-jre
+ARG registry_image_jdk=openjdk:11.0.11-jre@sha256:e12869c3edad94f2c23a40d0fe21b307a1a9177a621c9b902ecfa02897ba93f7
 
 FROM ${registry_image_gradle} as base-image
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG registry_image_gradle=gradle:6.7.0-jdk11
-ARG registry_image_jdk=openjdk:11.0.9.1-jre
+ARG registry_image_jdk=openjdk@sha256:e12869c3edad94f2c23a40d0fe21b307a1a9177a621c9b902ecfa02897ba93f7 #11.0.11-jre
 
 FROM ${registry_image_gradle} as base-image
 


### PR DESCRIPTION
We saw a memory leak when using 11.0.9, so this may help.

You can check the SHA here: https://hub.docker.com/layers/openjdk/library/openjdk/11.0.11-jre/images/sha256-e12869c3edad94f2c23a40d0fe21b307a1a9177a621c9b902ecfa02897ba93f7?context=explore

Keeps the Dockerfile in line with https://github.com/alphagov/verify-infrastructure-config/pull/571