### PR TITLE
BAU Reverse evaluation order to avoid a NullPointerException

### DIFF
--- a/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/security/AuthnRequestKeyStore.java
+++ b/hub/saml-engine/src/main/java/uk/gov/ida/hub/samlengine/security/AuthnRequestKeyStore.java
@@ -28,7 +28,7 @@ public class AuthnRequestKeyStore implements SigningKeyStore {
         try {
             return configServiceKeyStore.getVerifyingKeysForEntity(entityId);
         } catch (ApplicationException e) {
-            if (e.getExceptionType().equals(ExceptionType.CLIENT_ERROR)) {
+            if (ExceptionType.CLIENT_ERROR.equals(e.getExceptionType())) {
                 throw new NoKeyConfiguredForEntityException(entityId);
             }
             throw new RuntimeException(e);

--- a/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/security/AuthnRequestKeyStore.java
+++ b/hub/saml-proxy/src/main/java/uk/gov/ida/hub/samlproxy/security/AuthnRequestKeyStore.java
@@ -28,7 +28,7 @@ public class AuthnRequestKeyStore implements SigningKeyStore {
         try {
             return configServiceKeyStore.getVerifyingKeysForEntity(entityId);
         } catch (ApplicationException e) {
-            if (e.getExceptionType().equals(ExceptionType.CLIENT_ERROR)) {
+            if (ExceptionType.CLIENT_ERROR.equals(e.getExceptionType())) {
                 throw new NoKeyConfiguredForEntityException(entityId);
             }
             throw new RuntimeException(e);


### PR DESCRIPTION
[Sentry has reported some NullPointerExceptions](https://sentry.io/organizations/gds-verify/issues/2499432728/?environment=production&project=5494398&query=is%3Aunresolved), which are occuring within a catch block.

These are due to `ApplicationException`s being constructed with a null `ExceptionType`. 

The `ApplicationException` is being created due to a call to the config service, and the [underlying cause seems to be an invalid entityid](https://gds.splunkcloud.com/en-GB/app/search/search?sid=1629878890.37579).

Sentry reports 42 of these events, first occuring after our upgrade to DropWizard 2. 

This PR reverses the evaluation of ExceptionType to avoid a NullPointerException.The outcome for the user will still be an error page.