### PR TITLE
HUB-1055-update-saml-lib-348-259

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def dependencyVersions = [
         ida_test_utils:"2.0.0-66",
         opensaml:"$opensaml_version",
         dev_pki: '2.0.0-46',
-        saml_lib:"$opensaml_version-258",
+        saml_lib:"$opensaml_version-259",
         glassfish_version:'2.6.1',
         glassfish_jersey_version:'2.34'
 ]


### PR DESCRIPTION
Update Verify-hub to use version 348-259, which uses `OutgoingKeySignatureTrustEngine`