### PR TITLE
BAU Update logback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,13 @@ subprojects {
         s3mock
     }
 
+    configurations.all {
+        resolutionStrategy {
+            force "ch.qos.logback:logback-classic:1.2.9"
+            force "ch.qos.logback:logback-access:1.2.9"
+        }
+    }
+
     dependencies {
         common 'joda-time:joda-time:2.3',
                 'com.google.inject:guice:5.0.1',


### PR DESCRIPTION
Update logback to 1.2.9 to mitigate CVE-2021-42550

See the article "16th of December, 2021, Release of version 1.2.9" at http://logback.qos.ch/news.html