### PR TITLE
BAU - Bump s3mock dependency to the latest

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '11.0.16'
           distribution: 'adopt'
       - name: Run Build
         run: ./gradlew --parallel build -x test -x inttest
@@ -29,7 +29,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '11.0.16'
           distribution: 'adopt'
       - name: Run Tests
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ subprojects {
 
         awssdk 'com.amazonaws:aws-java-sdk-s3:1.12.293'
 
-        s3mock 'com.adobe.testing:s3mock-junit5:2.1.29'
+        s3mock 'com.adobe.testing:s3mock-junit5:2.8.0'
     }
 
     tasks.withType(Test) {


### PR DESCRIPTION
- Bump s3mock dependency to the latest version
- Bump the java version run in GA to the latest 11 version. This is to fix an error which happens when running the integration tests and is caued by the upgrade to s3mock https://github.com/adobe/S3Mock/issues/720