### PR TITLE
BAU - Fix the version of snakeYaml to the latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def dependencyVersions = [
         ida_test_utils:"2.0.0-67",
         opensaml:"$opensaml_version",
         dev_pki: '2.0.0-48',
-        saml_lib:"$opensaml_version-274",
+        saml_lib:"$opensaml_version-275",
         glassfish_version:'2.6.1',
         glassfish_jersey_version:'2.34'
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ subprojects {
         redis_test
         awssdk
         s3mock
+        snakeYaml
     }
 
     configurations.all {
@@ -160,7 +161,9 @@ subprojects {
 
         awssdk 'com.amazonaws:aws-java-sdk-s3:1.12.293'
 
-        s3mock 'com.adobe.testing:s3mock-junit5:2.8.0'
+        s3mock ('com.adobe.testing:s3mock-junit5:2.8.0') {  exclude group: 'org.yaml', module: 'snakeyaml' }
+
+        snakeYaml 'org.yaml:snakeyaml:1.33'
     }
 
     tasks.withType(Test) {

--- a/hub/config/build.gradle
+++ b/hub/config/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     testImplementation configurations.test_deps_compile,
             configurations.test_utils,
             configurations.dev_pki,
+            configurations.snakeYaml,
             configurations.s3mock
 
     implementation configurations.ida_utils,


### PR DESCRIPTION
- s3mock was brining in a older version of snakeYaml. We want to bring in the latest version so exclude the snakeYaml as a transitive dependency and explicitly set the version to the latest
- Bump saml libs to latest version