### PR TITLE
BAU update commons-text version

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.2-open

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 
 ext {
     opensaml_version = '3.4.6'
-    dropwizard_version = '2.1.2'
+    dropwizard_version = '2.1.3'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -40,12 +40,12 @@ repositories {
 }
 
 def dependencyVersions = [
-        ida_utils:'412',
+        ida_utils:'414',
         dropwizard:"$dropwizard_version",
         ida_test_utils:"2.0.0-67",
         opensaml:"$opensaml_version",
         dev_pki: '2.0.0-48',
-        saml_lib:"$opensaml_version-275",
+        saml_lib:"$opensaml_version-276",
         glassfish_version:'2.6.1',
         glassfish_jersey_version:'2.34'
 ]
@@ -118,7 +118,7 @@ subprojects {
 
         config 'commons-io:commons-io:2.11.0'
 
-        verify_event_emitter "uk.gov.ida:verify-event-emitter:2.0.0-87"
+        verify_event_emitter "uk.gov.ida:verify-event-emitter:2.0.0-88"
 
         ida_utils "uk.gov.ida:common-utils:2.0.0-$dependencyVersions.ida_utils",
                 "uk.gov.ida:security-utils:2.0.0-$dependencyVersions.ida_utils",

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ subprojects {
         }
     }
 
+    task allDeps(type: DependencyReportTask) {}
+
     configurations {
         common
         dropwizard


### PR DESCRIPTION
Upgrade commons-text dependency to beyond 1.9.
We can see this with:
````
❯ ./gradlew allDeps | grep "commons-text" | sort | uniq
     |         \--- org.apache.commons:commons-text:1.10.0
     |    |    \--- org.apache.commons:commons-text:1.10.0
     |    |    |    \--- org.apache.commons:commons-text:1.10.0
|         \--- org.apache.commons:commons-text:1.10.0
|    |         \--- org.apache.commons:commons-text:1.10.0
|    |         |    \--- org.apache.commons:commons-text:1.10.0
|    |    \--- org.apache.commons:commons-text:1.10.0
|    |    |    |    \--- org.apache.commons:commons-text:1.10.0
````